### PR TITLE
reference in README to https://github.com/oneclick/rubyinstaller/wiki/Development-Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Hacking (on Windows)
         C:\tmp\shoes4>jruby --1.9 -S gem install json -v '1.6.1'
         C:\tmp\shoes4>jruby --1.9 -S gem install bundler
         C:\tmp\shoes4>jruby --1.9 -S bundle install
+        
+        Refer to https://github.com/oneclick/rubyinstaller/wiki/Development-Kit if you have issues building native gems.
 
 4. You're ready to go!
 


### PR DESCRIPTION
Just a simple change to README, refering to devkit for help with native gems.
