### PR TITLE
Require app as a parameter

### DIFF
--- a/lib/shoes/arc.rb
+++ b/lib/shoes/arc.rb
@@ -5,17 +5,19 @@ module Shoes
     include Common::Stroke
     include Common::Style
 
-    def initialize(left, top, width, height, angle1, angle2, opts = {})
+    def initialize(app, left, top, width, height, angle1, angle2, opts = {})
+      @app = app
       @left, @top = left, top
       @angle1, @angle2 = angle1, angle2
       default_style = Common::Fill::DEFAULTS.merge(Common::Stroke::DEFAULTS)
       @style = default_style.merge(opts)
 
       #GUI
-      gui_opts = {:left => left, :top => top, :width => width, :height => height, :app => opts[:app].gui}
-      @gui = Shoes.configuration.backend_for(self, gui_opts)
+      gui_opts = {:left => left, :top => top, :width => width, :height => height}
+      @gui = Shoes.backend_for(self, gui_opts)
     end
 
+    attr_reader :app
     attr_reader :angle1, :angle2
   end
 end

--- a/lib/shoes/configuration.rb
+++ b/lib/shoes/configuration.rb
@@ -48,6 +48,11 @@ module Shoes
         backend_class(shoes_object).new(shoes_object, *args)
       end
 
+      # Experimental replacement for #backend_for
+      def backend_with_app_for(shoes_object, *args)
+        backend_class(shoes_object).new(shoes_object, shoes_object.app.gui, *args)
+      end
+
       def logger=(value)
         @logger = value
         @logger_instance = nil
@@ -66,4 +71,8 @@ end
 
 def Shoes.configuration
   Shoes::Configuration
+end
+
+def Shoes.backend_for(shoes_object, *args)
+  Shoes::Configuration.backend_with_app_for(shoes_object, *args)
 end

--- a/lib/shoes/element_methods.rb
+++ b/lib/shoes/element_methods.rb
@@ -134,8 +134,7 @@ module Shoes
 
     # Draws an arc
     def arc(left, top, width, height, angle1, angle2, opts = {})
-      opts.merge! :app => app
-      Shoes::Arc.new(left, top, width, height, angle1, angle2, opts)
+      Shoes::Arc.new(app, left, top, width, height, angle1, angle2, opts)
     end
 
     # Draws a line from (x1,y1) to (x2,y2)

--- a/lib/shoes/mock/arc.rb
+++ b/lib/shoes/mock/arc.rb
@@ -1,7 +1,7 @@
 module Shoes
   module Mock
     class Arc
-      def initialize(dsl, opts)
+      def initialize(dsl, app, opts)
         @width = opts[:width]
         @height = opts[:height]
       end

--- a/lib/shoes/swt/arc.rb
+++ b/lib/shoes/swt/arc.rb
@@ -4,17 +4,17 @@ module Shoes
       include Common::Fill
       include Common::Stroke
 
-      # @note This class expects opts[:app] to be a Shoes::Swt::App. Other shapes expect a
-      #       Shoes::App. It's preferable to pass a Shoes::Swt::App because it maintains the
-      #       separation between layers. If this attempt is successful, other shapes should
-      #       follow suit (Line, Oval, Shape)
-      def initialize(dsl, opts)
+      # Creates a new Shoes::Swt::Arc
+      #
+      # @param [Shoes::Arc] dsl The DSL object represented by this implementation
+      # @parem [Shoes::Swt::App] app The implementation object of the Shoes app
+      def initialize(dsl, app, opts)
         @dsl = dsl
+        @app = app
         @left = opts[:left]
         @top = opts[:top]
         @width = opts[:width]
         @height = opts[:height]
-        @app = opts[:app]
         @painter = Painter.new(self)
         @app.add_paint_listener @painter
       end

--- a/spec/shoes/arc_spec.rb
+++ b/spec/shoes/arc_spec.rb
@@ -1,10 +1,9 @@
 describe Shoes::Arc do
   context "basic" do
-    let(:gui) { double("gui") }
-    let(:app) { double("app", :gui => gui) }
-    let(:opts) { {:app => app } }
+    let(:app_gui) { double("gui") }
+    let(:app) { double("app", :gui => app_gui) }
 
-    subject { Shoes::Arc.new(13, 44, 200, 300, 0, Shoes::TWO_PI, opts) }
+    subject { Shoes::Arc.new(app, 13, 44, 200, 300, 0, Shoes::TWO_PI) }
 
     it_behaves_like "object with stroke"
     it_behaves_like "object with fill"
@@ -22,7 +21,7 @@ describe Shoes::Arc do
 
     it "passes required values to backend" do
       gui_opts = {:left => 13, :top => 44, :width => 200, :height => 300, :angle1 => 0, :angle2 => Shoes::TWO_PI}
-      Shoes::Mock::Arc.should_receive(:new)#.with(gui_opts)
+      Shoes::Mock::Arc.should_receive(:new).with(subject, app_gui, gui_opts)
       subject
     end
   end

--- a/spec/shoes/configuration_spec.rb
+++ b/spec/shoes/configuration_spec.rb
@@ -22,6 +22,9 @@ describe Shoes::Configuration do
   end
 
   describe "backend" do
+    let(:dsl_object) { double("dsl object", :class => Shoes::Shape) }
+    let(:args) { double("args") }
+
     it "raises ArgumentError on bad input" do
       lambda { Shoes.configuration.backend = :bogus }.should raise_error(LoadError)
     end
@@ -33,14 +36,22 @@ describe Shoes::Configuration do
         Shoes.configuration.backend.should eq(Shoes::Mock)
       end
     end
-  end
-
-  describe "#backend_for" do
-    let(:dsl_object) { double("dsl object", :class => Shoes::Shape) }
-    let(:args) { double("args") }
-
-    it "returns shape backend object" do
+    specify "#backend_for returns shape backend object" do
       Shoes.configuration.backend_for(dsl_object, args).should be_instance_of(Shoes::Mock::Shape)
+    end
+
+    describe "#backend_with_app_for" do
+      let(:app) { double('app', :gui => app_gui) }
+      let(:app_gui) { double('app_gui') }
+
+      before :each do
+        dsl_object.stub(:app) { app }
+      end
+
+      it "passes app.gui to backend" do
+        Shoes::Mock::Shape.should_receive(:new).with(dsl_object, app_gui, args)
+        Shoes.configuration.backend_with_app_for(dsl_object, args)
+      end
     end
   end
 end

--- a/spec/swt_shoes/arc_spec.rb
+++ b/spec/swt_shoes/arc_spec.rb
@@ -6,13 +6,13 @@ describe Shoes::Swt::Arc do
   let(:height) { 400 }
   let(:angle1) { Shoes::PI }
   let(:angle2) { Shoes::HALF_PI }
-  let(:opts) { { app: app, left: left, top: top, width: width, height: height, angle1: angle1, angle2: angle2} }
+  let(:opts) { {left: left, top: top, width: width, height: height, angle1: angle1, angle2: angle2} }
   let(:dsl) { double("dsl object", angle1: angle1, angle2: angle2) }
   let(:fill_color) { Shoes::Color.new(40, 50, 60, 70) }
   let(:stroke_color) { Shoes::Color.new(80, 90, 100, 110) }
 
   subject {
-    Shoes::Swt::Arc.new(dsl, opts)
+    Shoes::Swt::Arc.new(dsl, app, opts)
   }
 
   describe "basics" do

--- a/spec/swt_shoes/configuration_spec.rb
+++ b/spec/swt_shoes/configuration_spec.rb
@@ -1,11 +1,14 @@
 describe Shoes::Configuration do
-  describe "#backend" do
-    describe ":swt" do
-      before { Shoes.configuration.backend = :swt }
+  context ":swt" do
+    before :each do
+      Shoes.configuration.backend = :swt
+    end
 
+    describe "#backend" do
       it "sets backend" do
         Shoes.configuration.backend.should == Shoes::Swt
       end
     end
+
   end
 end


### PR DESCRIPTION
I have been running into lots of pain lately as I try to add/modify Art objects (Line, Oval, Arc, etc). Lots of this pain stems from the fact that there is too much coupling between objects. In particular, the Swt objects require a reference to the `Shoes::Swt::App` object. But this object is not passed as an explicit parameter. Rather, it is part of the options hash. This makes it difficult to be sure that it is always included. Plus, since it is **necessary**, passing it as part of an options hash seems somehow wrong.

Also, we have calls to `self.app.gui` sprinkled throughout the code. This call is necessary to pull out the `Shoes::Swt::App` and pass it along, but it is everywhere, which makes change difficult and confusing.

This commit shows how we might move to using an explicit `app` parameter. Changes include
- Requiring `app` as a parameter to `Shoes::Arc.new`, where `app` is a `Shoes::App`
- Requiring `app` as a parameter to `Shoes::Swt::Arc.new`, where `app` is a `Shoes::Swt::App`
- Confining the "reaching into" a `Shoes::App` to a single spot, in the backend generator, in `Shoes::Configuration`.
- Removing all "border-crossing" in `Shoes::Arc` and `Shoes::Swt::Arc` with respect to `app`. Now, there is no confusion about which "app" we are using. In `Shoes::Arc` it is always a `Shoes::App`; in `Shoes::Swt::Arc` it is always a `Shoes::Swt::Arc`
- Removing the `:app => app` key/value from the options hash generated in ElementMethods#arc. Note that this is included in **every** element method, so it is ripe for extraction.

I propose making this change on all of the art classes. I feel like, for consistency, we should also make the change on the "native" classes like Button, etc., and on the text classes, too.

Benefits:
- more decoupled code
- simpler tests
- explicit dependencies
- consistent interface
- tricky and highly coupled code is confined in a single location

Drawbacks:
- more complicated constructor signatures
- we pass around app objects **everywhere**

Please comment!
