### PR TITLE
Fixing OS X App name to display app title instead of SWT

### DIFF
--- a/lib/shoes/swt/app.rb
+++ b/lib/shoes/swt/app.rb
@@ -11,6 +11,7 @@ module Shoes
 
       def initialize dsl
         @dsl = dsl
+        ::Swt::Widgets::Display.setAppName(@dsl.app_title)
         @real = ::Swt::Widgets::Shell.new(::Swt.display, main_window_style).tap do |shell|
           shell.set_image ::Swt::Graphics::Image.new(::Swt.display, SHOES_ICON)
           shell.setText(@dsl.app_title)


### PR DESCRIPTION
This provides a partial solution to issue #72.You can set the application title on the menubar by calling setAppName before the display is created on the first call to display.getDefault.

Note that the about menu option still doesn't do anything. I'd be happy to look into that if I got some input on what should be displayed there.
