### PR TITLE
The return of simplecov (it works!)

### DIFF
--- a/shoes.gemspec
+++ b/shoes.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "yard"
   s.add_development_dependency "kramdown"
+  s.add_development_dependency 'simplecov'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 SHOESSPEC_ROOT = File.expand_path('..', __FILE__)
 $LOAD_PATH << File.join('../lib', SHOESSPEC_ROOT)
 


### PR DESCRIPTION
The best friend of all jruby users, @headius, has fixed the coverage library for jruby 1.7.0 - and a monkey patch for jruby-1.6 is also on the way on the [simplecov side](https://github.com/colszowka/simplecov/pull/174). So simplecov works again!

We're looking good by the way:

`rake spec:shoes` covers: Coverage report generated for RSpec to /home/tobi/github/shoes4/coverage. 2227 / 2339 LOC (95.21%) covered.

and `rake spec:swt` covers: Coverage report generated for RSpec to /home/tobi/github/shoes4/coverage. 3982 / 4258 LOC (93.52%) covered.

So we're looking good but still got some things to do. 
Also on a minor note it would be cool, imo if we had a rake task that would run all our specs in one run (rake spec starts rspec twice, generating two coverage reports one overwriting the other.). Only if that's possible without too much of a hassle, of course.

Cheers,
Tobi
