### PR TITLE
Make Shoes::DIR the parent of 'static' and 'lib'.

### DIFF
--- a/lib/shoes.rb
+++ b/lib/shoes.rb
@@ -6,7 +6,7 @@ module Shoes
   PI = Math::PI
   TWO_PI = 2 * PI
   HALF_PI = 0.5 * PI
-  DIR = Pathname.new(__FILE__).realpath.dirname.to_s
+  DIR = Pathname.new(__FILE__).join("../..").realpath.to_s
 
   extend ::Shoes::Common::Registration
 

--- a/samples/sample18.rb
+++ b/samples/sample18.rb
@@ -2,7 +2,7 @@ Shoes.app width: 700, height: 600 do
   title "Shoes is a ", link("tiny"){alert "Cool!"}, " graphics toolkit. "
 
   flow width: 0.4 do
-    image File.join(Shoes::DIR, '../static/shoes-icon.png') do
+    image File.join(Shoes::DIR, 'static/shoes-icon.png') do
       alert "You're soooo quick!"
     end
   end

--- a/samples/sample20.rb
+++ b/samples/sample20.rb
@@ -3,7 +3,7 @@ Shoes.app title: 'potacho', width: 175, height: 160 do
 
   @imgs = []
   1.upto 59 do |i|
-    @imgs << image(File.join(Shoes::DIR, "../samples/potato_chopping/1258_s#{"%03d" % i}.gif")).hide
+    @imgs << image(File.join(Shoes::DIR, "samples/potato_chopping/1258_s#{"%03d" % i}.gif")).hide
     @imgs.last.move(10, 10)
   end
 

--- a/samples/sample35.rb
+++ b/samples/sample35.rb
@@ -13,7 +13,7 @@ class PhotoFrame
     background tomato
     inscription 'Shoes 4'
     flow width: 70 # space
-    image File.join(Shoes::DIR, '../samples/loogink.png')
+    image File.join(Shoes::DIR, 'samples/loogink.png')
     para SPACE
     para SPACE, fg(strong('She is Loogink.'), white),
       '->', link(strong('Cy')){visit '/cy'}
@@ -24,7 +24,7 @@ class PhotoFrame
     background paleturquoise
     inscription 'Shoes 4'
     flow width: 70 # space
-    image File.join(Shoes::DIR, '../samples/cy.png')
+    image File.join(Shoes::DIR, 'samples/cy.png')
     para SPACE
     para SPACE, fg(strong('He is Cy.'), gray), '  ->', 
       link(strong('loogink')){visit '/loogink'}

--- a/samples/sample8.rb
+++ b/samples/sample8.rb
@@ -1,7 +1,7 @@
 Shoes.app do
   10.times do |i|
     button "hello#{i}"
-    image File.join(Shoes::DIR, '../static/shoes-icon.png')
+    image File.join(Shoes::DIR, 'static/shoes-icon.png')
     edit_line
   end
 end

--- a/samples/sample9.rb
+++ b/samples/sample9.rb
@@ -5,6 +5,6 @@ Shoes.app do
   flow(width: 0.5){2.times{|i| flow(width: 0.5){2.times{|j| button "Yayyyy#{j}"}}}}
   flow(width: 0.3){button 'go go go go go'}
   stack(width: 0.3){edit_line; 3.times{para 'hello'}}
-  flow(width: 0.3){image File.join(Shoes::DIR, '../static/shoes-icon.png')}
+  flow(width: 0.3){image File.join(Shoes::DIR, 'static/shoes-icon.png')}
   button 'bye bye2'
 end

--- a/samples/simple-bounce.rb
+++ b/samples/simple-bounce.rb
@@ -6,7 +6,7 @@ Shoes.app do
   border black, :strokewidth => 6
 
   nostroke
-  @icon = image "#{DIR}/static/shoes-icon.png", :left => 100, :top => 100 do
+  @icon = image "#{Shoes::DIR}/static/shoes-icon.png", :left => 100, :top => 100 do
     alert "You're soooo quick."
   end
 

--- a/spec/shoes/constants_spec.rb
+++ b/spec/shoes/constants_spec.rb
@@ -1,3 +1,5 @@
+require "pathname"
+
 describe "Shoes constants" do
   specify "PI equals Math::PI" do
     Shoes::PI.should eq(Math::PI)
@@ -11,15 +13,26 @@ describe "Shoes constants" do
     Shoes::HALF_PI.should eq(0.5 * Math::PI)
   end
 
-  let(:shoes_rb_dir) { File.absolute_path File.join(File.dirname(__FILE__), "..", "..", "lib") }
+  describe "DIR" do
+    let(:shoes_home_dir) { Pathname.new(__FILE__).join("../../..").expand_path }
+    subject { Pathname.new Shoes::DIR }
 
-  it "is the directory where shoes.rb lives" do
-    Shoes::DIR.should eq(shoes_rb_dir)
-  end
+    it "is the shoes home directory" do
+      subject.should eq(shoes_home_dir)
+    end
 
-  it "remains constant when current directory changes" do
-    Dir.chdir ".." do
-      Shoes::DIR.should eq(shoes_rb_dir)
+    it "contains lib/shoes.rb" do
+      subject.join("lib/shoes.rb").should exist
+    end
+
+    it "contains static/shoes_icon.png" do
+      subject.join("static/shoes-icon.png").should exist
+    end
+
+    it "remains constant when current directory changes" do
+      Dir.chdir ".." do
+        subject.should eq(shoes_home_dir)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #152.

Currently, Shoes::DIR is 'lib'. To get at assets packaged with Shoes,
we have to use "#{Shoes::DIR}/../static/shoes-icon.png". This commit
lets us use "#{Shoes::DIR}/static/shoes-icon.png". This makes
Shoes::DIR consistent with DIR in Shoes 3.
