### PR TITLE
KeyPress fix

### DIFF
--- a/lib/shoes/swt/keypress.rb
+++ b/lib/shoes/swt/keypress.rb
@@ -2,10 +2,21 @@ module Shoes
   module Swt
     class Keypress
       KEY_NAMES = {}
-      %w[DEL ESC ALT SHIFT CTRL ARROW_UP ARROW_DOWN ARROW_LEFT ARROW_RIGHT 
-        PAGE_UP PAGE_DOWN HOME END INSERT 
-        F1 F2 F3 F4 F5 F6 F7 F8 F9 F10 F11 F12 F13 F14 F15].each{|k| KEY_NAMES[eval("::Swt::SWT::#{k}")] = k}
+      
+      #Special keys
+      %w[TAB PAGE_UP PAGE_DOWN HOME END F1 F2 F3 F4 F5 F6 F7 F8 F9 F10 F11 F12 F13 F14 F15].each{|k| KEY_NAMES[eval("::Swt::SWT::#{k}")] = k.downcase}
+      %w[UP DOWN LEFT RIGHT].each{|k| KEY_NAMES[eval("::Swt::SWT::ARROW_#{k}")] = k.downcase} 
+      
+      KEY_NAMES[::Swt::SWT::DEL] = "delete"
+      KEY_NAMES[::Swt::SWT::BS] = "backspace"
+      KEY_NAMES[::Swt::SWT::ESC] = "escape"
+      KEY_NAMES[::Swt::SWT::DEL] = "delete"
       KEY_NAMES[::Swt::SWT::CR] = "\n"
+      
+      #Modifier keys
+      %w[CTRL SHIFT ALT CAPS_LOCK].each {|k| KEY_NAMES[eval("::Swt::SWT::#{k}")] = ""}
+      
+
       
       def initialize dsl, app, &blk
         @dsl = dsl
@@ -14,7 +25,32 @@ module Shoes
         @kl = ::Swt::KeyListener.new.tap do |kl|
           class << kl; self end.
           instance_eval do
-            define_method(:keyPressed){|e| blk[KEY_NAMES[e.keyCode] || e.character.chr]}
+            define_method(:keyPressed)do |e|
+              #Shift-only doesn't count as a modifier
+              if(e.stateMask & (::Swt::SWT::MODIFIER_MASK ^ ::Swt::SWT::SHIFT)) != 0
+                key = ""
+                
+                if (e.stateMask & ::Swt::SWT::CTRL) == ::Swt::SWT::CTRL
+                  key += "control_"
+                end
+                
+                if (e.stateMask & ::Swt::SWT::SHIFT) == ::Swt::SWT::SHIFT
+                  key += "shift_"
+                end
+                
+                if (e.stateMask & ::Swt::SWT::ALT) == ::Swt::SWT::ALT
+                  key += "alt_"
+                end
+                
+                key += KEY_NAMES[e.keyCode] || e.character.chr.downcase
+                blk[key.to_sym]
+                
+              else
+                key = KEY_NAMES[e.keyCode].to_sym if KEY_NAMES[e.keyCode]
+                key ||= e.character.chr
+                blk[key]
+              end
+            end
             define_method(:keyReleased){|e|}
             define_method(:clear){shell.removeKeyListener kl}
           end


### PR DESCRIPTION
keypress now:
- Understands key modifiers (alt ctrl shift)
- Uses Shoes v3 naming convention
- yields symbols when key modifiers and/or special keys
