### PR TITLE
Fix app height calculation (was breaking specs on OS X)

### DIFF
--- a/lib/shoes/slot.rb
+++ b/lib/shoes/slot.rb
@@ -18,11 +18,13 @@ module Shoes
         instance_variable_set "@#{v}", opts[v.to_sym]
       end
 
+      @left ||= 0
+      @top ||= 0
       @width ||= 1.0
       @height ||= 0
       @init_height = @height
       @blk = blk
-      
+
       set_margin
 
       @gui = Shoes.configuration.backend_for(self, @parent.gui)

--- a/lib/shoes/swt/app.rb
+++ b/lib/shoes/swt/app.rb
@@ -88,20 +88,15 @@ module Shoes
     class ShellControlListener
       def initialize(app)
         @app = app
-        @times_run = 0
       end
 
       def controlResized(e)
         shell = e.widget
-        w, h = shell.getSize.x - @app.dx, shell.getSize.y - @app.dy
-
-        # will break background element if it's run the first two times
-        if @times_run > 1
-          (@app.dsl.top_slot.width, @app.dsl.top_slot.height = w, h)
-        else
-          @times_run += 1
-        end
+        client_area = shell.getClientArea
+        w, h = client_area.width, client_area.height
+        @app.dsl.top_slot.width, @app.dsl.top_slot.height = w, h
         @app.real.setSize w, h
+        @app.real.layout
       end
 
       def controlMoved(e)

--- a/lib/shoes/swt/layout.rb
+++ b/lib/shoes/swt/layout.rb
@@ -3,11 +3,14 @@ module Shoes::Swt
     attr_accessor :top_slot
 
     def layout *args
+      # Note: This is a Shoes::App
       app = @top_slot.app
       w, h = app.width, app.height
       scrollable_height = contents_alignment @top_slot
+      # Note: This is a Shoes::Swt::App
       app = app.gui
-      app.real.setSize w, [scrollable_height, h].max
+      size = app.real.compute_trim 0, 0, w, [scrollable_height, h].max
+      app.real.set_size(size.width, size.height)
       vb = app.shell.getVerticalBar
       vb.setVisible(scrollable_height > h)
       if scrollable_height > h

--- a/spec/shoes/app_spec.rb
+++ b/spec/shoes/app_spec.rb
@@ -30,10 +30,10 @@ describe Shoes::App do
 
     it "should set accessors from opts", :qt do
       input_blk = Proc.new {}
-      args = {:width => 1, :height => 2, :title => "Shoes::App Spec", :resizable => false}
+      args = {:width => 90, :height => 2, :title => "Shoes::App Spec", :resizable => false}
       Shoes::App.any_instance.stub(:flow)
       app = Shoes::App.new args, &input_blk
-      app.width.should == 1
+      app.width.should == 90
       app.height.should == 2
       app.app_title.should == "Shoes::App Spec"
       app.resizable.should be_false


### PR DESCRIPTION
Two specs were broken by commit
26f4a2588604e201dd5f6a12d7f1d17812dcd3f7, apparently only on OS X.

The spec for App#height using defaults was breaking on OS X because the
app height was including the window decorations (22px).

The spec for setting App#width was breaking on OS X because the spec set
the width to 1, but the window can't be resized smaller than 69px. This
changeset uses a higher width for the spec.

In addition, this fix lets us remove some hacks around background
rendering.

Could you test this on Windows and Linux and see if it works there, too? Thanks!
