### PR TITLE
Replace Hpricot with Nokogiri, since Hpricot is officially dead. shoes/s...

### DIFF
--- a/samples/expert-funnies.rb
+++ b/samples/expert-funnies.rb
@@ -1,10 +1,10 @@
-require 'hpricot'
+require 'nokogiri'
 
 class Comic
   attr_reader :rss, :title
 
   def initialize(body)
-    @rss = Hpricot.XML(body)
+    @rss = Nokogiri::XML(body)
     @title = @rss.at("//channel/title").inner_text
   end
 

--- a/shoes.gemspec
+++ b/shoes.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "plist"
   s.add_dependency "warbler"
 
-  s.add_dependency "hpricot" # For manual
+  s.add_dependency "nokogiri" # For converting the manual to HTML
 
   s.add_development_dependency "guard"
   s.add_development_dependency "guard-rspec"

--- a/static/manual-ja.txt
+++ b/static/manual-ja.txt
@@ -773,14 +773,14 @@ download
 
      download "http://www.stevex.net/dump.php",
               :method => "POST", :body => "v=1.0&q=shoes" do |dump|
-       require 'hpricot'
-       @status.text = Hpricot(dump.response.body).inner_text
+       require 'nokogiri'
+       @status.text = Nokogiri::HTML(dump.response.body).inner_text
      end
    end
  end
 }}}
 
-上記の例から、ShoesはHTMLを解析するHpricotなライブラリを含んでいることが分かります。
+上記の例から、ShoesはHTMLを解析するNokogiriなライブラリを含んでいることが分かります。
 
 === location() » a string ===
 


### PR DESCRIPTION
Replace Hpricot with Nokogiri, since Hpricot is officially dead. shoes/shoes4#176

Besides lib/shoes/help.rb I also updated samples/expert-funnies and the Japanese
manual since they both referred to using Hpricot, however they both depend on 'download'
which seems to be (currently) unimplemented.
