### PR TITLE
Replace Range#rand with rand(range) as per #94, #199

### DIFF
--- a/samples/good-arc.rb
+++ b/samples/good-arc.rb
@@ -8,7 +8,7 @@ Shoes.app :width => 420, :height => 420, :resizable => false do
   nofill
 
   animate 40 do |i|
-    stage = (1...8).rand if i % 40 == 0
+    stage = rand(1...8) if i % 40 == 0
     rotation = -(HALF_PI / wide)
     clear do
       background gray(240)

--- a/samples/sample3.rb
+++ b/samples/sample3.rb
@@ -9,6 +9,6 @@ Shoes.app width: 300, height: 400 do
   stroke rgb(0, 0.6, 0.9, 0.3)
   strokewidth 1
   100.times do
-    oval left: (-30..width).rand, top: (-30..height).rand, diameter: (25..100).rand
+    oval left: rand(-30..width), top: rand(-30..height), diameter: rand(25..100)
   end
 end

--- a/samples/simple-anim-shapes.rb
+++ b/samples/simple-anim-shapes.rb
@@ -5,10 +5,10 @@ Shoes.app do
     rect(0, 0, 50, 50),
     rect(0, 0, 100, 100),
     rect(0, 0, 75, 75)
-  ] 
+  ]
   animate(24) do |i|
     rects.each do |r|
-      r.move((0..400).rand, (0..400).rand)
+      r.move(rand(0..400), rand(0..400))
     end
   end
   button "OK", :top => 0.5, :left => 0.5 do

--- a/samples/simple-mask.rb
+++ b/samples/simple-mask.rb
@@ -8,12 +8,12 @@ Shoes.app do
       title "Shoes", :weight => "bold", :size => 82
     end
   end
-  
+
   animate 10 do
     @stripes.clear do
       20.times do |i|
         strokewidth 4
-        stroke rgb((0.0..0.5).rand, (0.0..1.0).rand, (0.0..0.3).rand)
+        stroke rgb(rand(0.0..0.5), rand(0.0..1.0), rand(0.0..0.3))
         line 0, i * 5, 400, i * 8
       end
     end


### PR DESCRIPTION
In original Shoes a #rand method was added to Range. In Ruby 1.9 Kernel#rand takes a range, and as discussed in #94 this is now the preferred form.

This PR updates the samples that still used the old syntax.
