### PR TITLE
expert-othello.rb : Place GAME constant at top level.

### DIFF
--- a/samples/expert-othello.rb
+++ b/samples/expert-othello.rb
@@ -291,10 +291,9 @@ module Othello
     }
     return false
   end
-
-  GAME = Othello::Game.new
 end
 
+GAME = Othello::Game.new
 
 Shoes.app :width => 520, :height => 600 do
   extend Othello


### PR DESCRIPTION
The Othello sample gave errors as soon as you clicked on the board that the GAME constant wasn't found.

I'm guessing this is broken because constant lookup changed somewhat between 1.8 and 1.9. With this change the game no longer errors out, but it doesn't seem to be working entirely correctly either. Although that might just be me not really understanding the game
