### PR TITLE
Reset the GUI backend before each RSpec example.

### DIFF
--- a/lib/shoes/configuration.rb
+++ b/lib/shoes/configuration.rb
@@ -21,11 +21,25 @@ module Shoes
       # @example
       #   Shoes::Configuration.backend = :swt # => Shoes::Swt
       def backend=(backend)
-        require "shoes/#{backend.to_s.downcase}"
-        @backend ||= Shoes.const_get(backend.to_s.capitalize)
-        @backend_name ||= backend
+        if @backend
+          STDERR << "Shoes backend can be set only once. #{@backend} => #{backend}\n"
+        else
+          require "shoes/#{backend.to_s.downcase}"
+          @backend = Shoes.const_get(backend.to_s.capitalize)
+          @backend_name = backend
+        end
       rescue LoadError => e
         raise LoadError, "Couldn't load backend '#{backend}'. Error: #{e.message}\n#{e.backtrace.join("\n")}"
+      end
+
+      # Force the backend, this is needed for testing. (see #backend=)
+      #
+      # @param backend [Symbol] The backend's name
+      # @return [Module] The backend's root module
+      def backend!(backend)
+        @backend = nil
+        @backend_name = nil
+        self.backend = backend
       end
 
       # Finds the appropriate backend class for the given Shoes object

--- a/spec/shoes/configuration_spec.rb
+++ b/spec/shoes/configuration_spec.rb
@@ -27,7 +27,7 @@ describe Shoes::Configuration do
     let(:dsl_object) { Shoes::Shape.new app, args }
 
     it "raises ArgumentError on bad input" do
-      lambda { Shoes.configuration.backend = :bogus }.should raise_error(LoadError)
+      lambda { Shoes.configuration.backend! :bogus }.should raise_error(LoadError)
     end
 
     describe "#backend_with_app_for" do

--- a/spec/shoes/spec_helper.rb
+++ b/spec/shoes/spec_helper.rb
@@ -1,10 +1,4 @@
 require 'spec_helper'
 
-Shoes.configuration.backend = :mock
-
-RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
-end
-
 shared_examples = File.expand_path('../shared_examples/**/*.rb', __FILE__)
 Dir[shared_examples].each { |f| require f }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,3 +96,18 @@ include Guard
 
 Dir["#{SHOESSPEC_ROOT}/support/**/*.rb"].each {|f| require f}
 
+module MockBackendSpec
+  def self.included(spec_group)
+    spec_group.class_eval do
+
+      let(:backend_name) { :mock }
+      let!(:backend) {  Shoes.configuration.backend! backend_name }
+
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.treat_symbols_as_metadata_keys_with_true_values = true
+  config.include MockBackendSpec
+end

--- a/spec/swt_shoes/animation_spec.rb
+++ b/spec/swt_shoes/animation_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::Animation do
+describe Shoes::Swt::Animation, :swt do
   let(:dsl) { double('dsl', :stopped? => false, :removed? => false)}
   let(:app) { double 'app', :real => app_real }
   let(:block) { double 'block' }

--- a/spec/swt_shoes/app_spec.rb
+++ b/spec/swt_shoes/app_spec.rb
@@ -1,6 +1,6 @@
 require "swt_shoes/spec_helper"
 
-describe Shoes::Swt::App do
+describe Shoes::Swt::App, :swt do
   let(:opts) { {:background => Shoes::COLORS[:salmon], :resizable => true} }
   let(:app) { double('app', :opts => opts,
                             :width => 0,

--- a/spec/swt_shoes/arc_spec.rb
+++ b/spec/swt_shoes/arc_spec.rb
@@ -1,4 +1,4 @@
-describe Shoes::Swt::Arc do
+describe Shoes::Swt::Arc, :swt do
   let(:container) { double('container', disposed?: false) }
   let(:app) { double('app', real: container, add_paint_listener: true) }
   let(:left) { 100 }

--- a/spec/swt_shoes/background_spec.rb
+++ b/spec/swt_shoes/background_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::Background do
+describe Shoes::Swt::Background, :swt do
   let(:container) { double('container', :disposed? => false) }
   let(:app) { double('app', :real => container, :add_paint_listener => true) }
   let(:left) { 55 }

--- a/spec/swt_shoes/border_spec.rb
+++ b/spec/swt_shoes/border_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::Border do
+describe Shoes::Swt::Border, :swt do
   let(:container) { double('container', :disposed? => false) }
   let(:app) { double('app', :real => container, :add_paint_listener => true) }
   let(:left) { 55 }

--- a/spec/swt_shoes/button_spec.rb
+++ b/spec/swt_shoes/button_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::Button do
+describe Shoes::Swt::Button, :swt do
   let(:text) { "TEXT" }
   let(:dsl) { double('dsl', :text => text) }
   let(:parent) { double('parent') }

--- a/spec/swt_shoes/check_spec.rb
+++ b/spec/swt_shoes/check_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::Check do
+describe Shoes::Swt::Check, :swt do
   let(:text) { "TEXT" }
   let(:dsl) { double('dsl', :width= => true, :height= => true, contents: []) }
   let(:parent) { double('parent', real: true, dsl: mock(contents: []) ) }

--- a/spec/swt_shoes/color_spec.rb
+++ b/spec/swt_shoes/color_spec.rb
@@ -1,6 +1,7 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::Color do
+describe Shoes::Swt::Color, :swt do
+
   subject { Shoes::Swt::Color.create(Shoes::COLORS[:salmon]) }
 
   it_behaves_like "an swt pattern"
@@ -25,9 +26,8 @@ describe Shoes::Swt::Color do
   end
 end
 
-describe Shoes::Swt::NullColor do
+describe Shoes::Swt::NullColor, :swt do
   subject { Shoes::Swt::Color.create(nil) }
-
   it { should be_instance_of(Shoes::Swt::NullColor) }
   its(:real) { should be_nil }
   its(:dsl) { should be_nil }

--- a/spec/swt_shoes/configuration_spec.rb
+++ b/spec/swt_shoes/configuration_spec.rb
@@ -1,4 +1,4 @@
-describe Shoes::Configuration do
+describe Shoes::Configuration, :swt do
   context ":swt" do
     before :each do
       Shoes.configuration.backend = :swt

--- a/spec/swt_shoes/dialog_spec.rb
+++ b/spec/swt_shoes/dialog_spec.rb
@@ -2,7 +2,7 @@ require 'swt_shoes/spec_helper'
 
 main_object = self
 
-describe Shoes::Swt::Dialog do
+describe Shoes::Swt::Dialog, :swt do
 
   def mock_message_box
     create_mock_message_box mock(:mb, open: true, :message= => true)

--- a/spec/swt_shoes/edit_box_spec.rb
+++ b/spec/swt_shoes/edit_box_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::EditBox do
+describe Shoes::Swt::EditBox, :swt do
   let(:dsl) { double('dsl', opts: {}) }
   let(:parent) { double('parent') }
   let(:block) { double('block') }

--- a/spec/swt_shoes/edit_line_spec.rb
+++ b/spec/swt_shoes/edit_line_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::EditLine do
+describe Shoes::Swt::EditLine, :swt do
   let(:dsl) { double('dsl', opts: {secret: true}) }
   let(:parent) { double('parent') }
   let(:block) { double('block') }

--- a/spec/swt_shoes/element_methods_spec.rb
+++ b/spec/swt_shoes/element_methods_spec.rb
@@ -2,7 +2,7 @@ require 'swt_shoes/spec_helper'
 
 # FIXME: These specs are copied from spec/shoes/element_methods_spec.rb
 #        We should run the same specs instead of duplicating.
-describe "Basic Element Methods" do
+describe "Basic Element Methods", :swt do
   class ElementMethodsShoeLaces
     include Shoes::ElementMethods
 

--- a/spec/swt_shoes/flow_spec.rb
+++ b/spec/swt_shoes/flow_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::Flow do
+describe Shoes::Swt::Flow, :swt do
   let(:dsl) { double('dsl') }
   let(:real) { double('real') }
   let(:parent_real) { double('parent_real', :get_layout => "ok") }

--- a/spec/swt_shoes/gradient_spec.rb
+++ b/spec/swt_shoes/gradient_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::Gradient do
+describe Shoes::Swt::Gradient, :swt do
   let(:color1) { Shoes::Color.create(Shoes::COLORS[:honeydew]) }
   let(:color2) { Shoes::Color.create(Shoes::COLORS[:salmon]) }
   let(:dsl) { Shoes::Gradient.new(color1, color2) }

--- a/spec/swt_shoes/image_pattern_spec.rb
+++ b/spec/swt_shoes/image_pattern_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::ImagePattern do
+describe Shoes::Swt::ImagePattern, :swt do
   let(:path) { File.join Shoes::DIR, 'static/shoes-icon.png'  }
   let(:dsl) { Shoes::ImagePattern.new(path) }
 

--- a/spec/swt_shoes/image_spec.rb
+++ b/spec/swt_shoes/image_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::Image do
+describe Shoes::Swt::Image, :swt do
   class MockSize
     def width; 128 end
     def height; 128 end

--- a/spec/swt_shoes/keypress_spec.rb
+++ b/spec/swt_shoes/keypress_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::Keypress do
+describe Shoes::Swt::Keypress, :swt do
   let(:input_blk) { Proc.new {} }
   let(:opts) { Hash.new }
   let(:app) { Shoes::App.new(opts, &input_blk) }

--- a/spec/swt_shoes/line_spec.rb
+++ b/spec/swt_shoes/line_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::Line do
+describe Shoes::Swt::Line, :swt do
   let(:container) { double('container', :disposed? => false).as_null_object }
   let(:app) { double('app', :real => container, :add_paint_listener => true) }
   let(:dsl) { double('dsl', hidden: false).as_null_object }

--- a/spec/swt_shoes/list_box_spec.rb
+++ b/spec/swt_shoes/list_box_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::ListBox do
+describe Shoes::Swt::ListBox, :swt do
   let(:items) { ["Pie", "Apple", "Sand"] }
   let(:dsl) { double('dsl', items: items, opts: {}) }
   let(:parent) { double('parent') }

--- a/spec/swt_shoes/oval_spec.rb
+++ b/spec/swt_shoes/oval_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::Oval do
+describe Shoes::Swt::Oval, :swt do
   let(:container) { double('container', disposed?: false) }
   let(:app) { double('app', real: container, add_paint_listener: true) }
   let(:left) { 100 }

--- a/spec/swt_shoes/package_app_spec.rb
+++ b/spec/swt_shoes/package_app_spec.rb
@@ -4,7 +4,7 @@ require 'shoes/swt/package/app'
 
 include PackageHelpers
 
-describe Shoes::Swt::Package::App do
+describe Shoes::Swt::Package::App, :swt do
   include_context 'config'
   include_context 'package'
 

--- a/spec/swt_shoes/package_jar_spec.rb
+++ b/spec/swt_shoes/package_jar_spec.rb
@@ -4,7 +4,7 @@ require 'shoes/swt/package/jar'
 
 include PackageHelpers
 
-describe Shoes::Swt::Package::Jar do
+describe Shoes::Swt::Package::Jar, :swt do
   include_context 'config'
   include_context 'package'
 

--- a/spec/swt_shoes/progress_spec.rb
+++ b/spec/swt_shoes/progress_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::Progress do
+describe Shoes::Swt::Progress, :swt do
   let(:text) { "TEXT" }
   let(:dsl) { double('dsl').as_null_object }
   let(:parent) { double('parent') }

--- a/spec/swt_shoes/radio_spec.rb
+++ b/spec/swt_shoes/radio_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::Radio do
+describe Shoes::Swt::Radio, :swt do
   let(:text) { "TEXT" }
   let(:dsl) { double('dsl', :width= => true, :height= => true) }
   let(:parent) { double('parent', real: true, dsl: mock(contents: []) ) }

--- a/spec/swt_shoes/rect_spec.rb
+++ b/spec/swt_shoes/rect_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::Rect do
+describe Shoes::Swt::Rect, :swt do
   let(:container) { double('container', :disposed? => false) }
   let(:app) { double('app', :real => container, :add_paint_listener => true) }
   let(:left) { 55 }

--- a/spec/swt_shoes/shape_spec.rb
+++ b/spec/swt_shoes/shape_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::Shape do
+describe Shoes::Swt::Shape, :swt do
   let(:app) { double("app", add_paint_listener: true) }
   let(:dsl) { double('dsl', hidden: false).as_null_object }
   subject { Shoes::Swt::Shape.new dsl, app }

--- a/spec/swt_shoes/sound.rb
+++ b/spec/swt_shoes/sound.rb
@@ -1,4 +1,4 @@
-describe Shoes::Swt::Sound do
+describe Shoes::Swt::Sound, :swt do
   let(:dsl) { double('dsl') }
   let(:filepath) { double('filepath') }
   subject { Shoes::Swt::Sound.new(dsl, filepath) }

--- a/spec/swt_shoes/spec_helper.rb
+++ b/spec/swt_shoes/spec_helper.rb
@@ -1,7 +1,13 @@
 require "spec_helper"
 require "shoes/swt"
 
-Shoes.configuration.backend = :swt
+module SwtBackendSpec
+  def self.included(example_group)
+    example_group.class_eval do
+      let(:backend_name) { :swt }
+    end
+  end
+end
 
 RSpec.configure do |config|
   config.before(:each) do
@@ -9,7 +15,9 @@ RSpec.configure do |config|
     Swt.stub(:event_loop)
     Swt::Widgets::Shell.any_instance.stub(:open)
   end
-  config.treat_symbols_as_metadata_keys_with_true_values = true
+
+  # Enable the Shoes::Swt backend for specs marked with :swt
+  config.include SwtBackendSpec, :swt
 end
 
 shared_examples = File.join(File.expand_path(File.dirname(__FILE__)), 'shared_examples', '**/*.rb')

--- a/spec/swt_shoes/star_spec.rb
+++ b/spec/swt_shoes/star_spec.rb
@@ -1,6 +1,6 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::Star do
+describe Shoes::Swt::Star, :swt do
   let(:container) { double('container', :disposed? => false) }
   let(:app) { double('app', :real => container, :add_paint_listener => true) }
   let(:left) { 55 }

--- a/spec/swt_shoes/text_block_spec.rb
+++ b/spec/swt_shoes/text_block_spec.rb
@@ -1,10 +1,10 @@
 require 'swt_shoes/spec_helper'
 
-describe Shoes::Swt::TextBlock do
+describe Shoes::Swt::TextBlock, :swt do
   let(:opts) { {justify: true, leading: 10} }
   let(:font) { ::Swt::Graphics::Font.new }
   let(:parent) { Shoes::Flow.new app_real, app: app_real }
-  let(:dsl) { double("dsl", parent: parent, app: parent.app, text: "hello world", opts: opts, left: 0, top: 10, 
+  let(:dsl) { double("dsl", parent: parent, app: parent.app, text: "hello world", opts: opts, left: 0, top: 10,
     width: 200, height: 180, font: "font", font_size: 16, margin_left: 0, margin_top: 0) }
   let(:app) { parent.app.gui.real }
   let(:app_real) { Shoes::App.new }
@@ -33,7 +33,7 @@ describe Shoes::Swt::TextBlock do
 
     before :each do
       ::Swt::TextLayout.stub(:new) { tl }
-      #::Swt::Font.stub(:new) 
+      #::Swt::Font.stub(:new)
     end
 
     it "sets text" do


### PR DESCRIPTION
This allows specs using the Mock backend, and specs for the SWT backend to be
run in the same rspec run. Currently when one simply types 'rspec' at the root
of the project, a number of specs fail because they assume a certain backend has
been set. But because the backend is effectively a global variable, and Shoes
only allows it to be set once, this causes problems.

The current way to solve this is to use a Rake task that invokes a separate
rspec run for each set of specs. This works, but I would argue that it breaks
the principle of least surprise. A newcomer checking out the project and running
`rspec` at the root of the project would get the impression that certain specs
are broken.

The proposed approach here is to have an extra 'destructive' method to set the
backend, Shoes.configuration.backend! (notice the bang), that sets the backend
to nil before trying to set it. This way a backend can be changed within one
process.

Before each example the backend is set with

```
let!(:backend) { Shoes.configure.backend! backend_name }
```

backend_name defaults to :mock, but can be set with let(:backend_name). In the
Swt specs, one can also 'tag' the example group like so:

```
describe Shoes::Swt::Star, :swt do
```
