### PR TITLE
Implement the #change method on ListBox, EditLine and EditBox.

### DIFF
--- a/lib/shoes/common/changeable.rb
+++ b/lib/shoes/common/changeable.rb
@@ -1,0 +1,34 @@
+module Shoes
+  module Common
+    # Changeable elements are elements that receive `change' events.
+    # These are ListBox, EditBox and EditLine. To have your code respond
+    # to these events, either pass a block in when creating the element,
+    # or call #change on the element with a block.
+    module Changeable
+      # Add an extra change event listener block
+      #
+      # @dsl
+      def change(&blk)
+        add_change_listener(blk)
+      end
+
+      # The GUI backend needs to call this when an actual change happens in
+      # the backend.
+      def call_change_listeners
+        change_listeners.each do |listener|
+          listener.call(self)
+        end
+      end
+
+      private
+
+      def change_listeners
+        @change_listeners ||= []
+      end
+
+      def add_change_listener(callable)
+        change_listeners << callable
+      end
+    end
+  end
+end

--- a/lib/shoes/edit_box.rb
+++ b/lib/shoes/edit_box.rb
@@ -1,8 +1,10 @@
 require 'shoes/common_methods'
+require 'shoes/common/changeable'
 
 module Shoes
   class EditBox
     include Shoes::CommonMethods
+    include Shoes::Common::Changeable
 
     attr_reader :gui, :blk, :parent, :text, :opts
 
@@ -12,14 +14,16 @@ module Shoes
       @app = opts[:app]
       @opts = opts
 
-      @gui = Shoes.configuration.backend_for(self, @parent.gui, blk)
+      @gui = Shoes.configuration.backend_for(self, @parent.gui)
       @parent.add_child self
+
+      self.change &blk if blk
     end
 
     def focus
       @gui.focus
     end
-    
+
     def text
       @gui.text
     end

--- a/lib/shoes/edit_line.rb
+++ b/lib/shoes/edit_line.rb
@@ -1,8 +1,10 @@
 require 'shoes/common_methods'
+require 'shoes/common/changeable'
 
 module Shoes
   class EditLine
     include Shoes::CommonMethods
+    include Shoes::Common::Changeable
 
     attr_reader :gui, :blk, :parent, :text, :opts
 
@@ -12,14 +14,15 @@ module Shoes
       @app = opts[:app]
       @opts = opts
 
-      @gui = Shoes.configuration.backend_for(self, @parent.gui, blk)
+      @gui = Shoes.configuration.backend_for(self, @parent.gui)
       @parent.add_child self
+      self.change &blk if blk
     end
 
     def focus
       @gui.focus
     end
-    
+
     def text
       @gui.text
     end

--- a/lib/shoes/list_box.rb
+++ b/lib/shoes/list_box.rb
@@ -1,8 +1,11 @@
 require 'shoes/common_methods'
+require 'shoes/common/changeable'
 
 module Shoes
   class ListBox
     include Shoes::CommonMethods
+    include Shoes::Common::Changeable
+
     attr_reader :items, :gui, :blk, :parent, :opts
 
     def initialize(parent, opts = {}, blk = nil)
@@ -11,9 +14,11 @@ module Shoes
       @app = opts[:app]
       @opts = opts
 
-      @gui = Shoes.configuration.backend_for(self, @parent.gui, blk)
+      @gui = Shoes.configuration.backend_for(self, @parent.gui)
       self.items = opts.has_key?(:items) ? opts[:items] : [""]
       @parent.add_child self
+
+      self.change &blk if blk
     end
 
     def items=(values)

--- a/lib/shoes/swt/edit_box.rb
+++ b/lib/shoes/swt/edit_box.rb
@@ -4,18 +4,16 @@ module Shoes
   module Swt
     class EditBox < InputBox
 
-      def initialize(dsl, parent, blk)
+      def initialize(dsl, parent)
         dsl.opts[:width] ||= 200
         dsl.opts[:height] ||= 100
-        super(dsl, parent, blk,
+        super(dsl, parent,
           ::Swt::SWT::MULTI  |
           ::Swt::SWT::BORDER |
           ::Swt::SWT::WRAP
-          )
+        )
       end
 
     end
   end
 end
-
-

--- a/lib/shoes/swt/edit_line.rb
+++ b/lib/shoes/swt/edit_line.rb
@@ -3,14 +3,12 @@ require 'shoes/swt/input_box'
 module Shoes
   module Swt
     class EditLine < InputBox
-      def initialize(dsl, parent, blk)
+      def initialize(dsl, parent)
         dsl.opts[:width] ||= 200
         dsl.opts[:height] ||= 20
         styles = dsl.opts[:secret] ? ::Swt::SWT::SINGLE | ::Swt::SWT::BORDER | ::Swt::SWT::PASSWORD : ::Swt::SWT::SINGLE | ::Swt::SWT::BORDER
-        super(dsl, parent, blk, styles)
+        super(dsl, parent, styles)
       end
     end
   end
 end
-
-

--- a/lib/shoes/swt/input_box.rb
+++ b/lib/shoes/swt/input_box.rb
@@ -9,22 +9,23 @@ module Shoes
 
       attr_reader :real
 
-      def initialize(dsl, parent, blk, text_options)
-        @dsl = dsl
-        @parent = parent
-        @blk = blk
+      def initialize(dsl, parent, text_options)
+        @dsl          = dsl
+        @parent       = parent
         @text_options = text_options
 
         @real = ::Swt::Widgets::Text.new(@parent.real, text_options)
-        @real.setSize dsl.opts[:width], dsl.opts[:height]
-        @real.setText dsl.opts[:text].to_s
-        @real.addModifyListener{|e| blk[@dsl]} if blk
+        @real.set_size dsl.opts[:width], dsl.opts[:height]
+        @real.set_text dsl.opts[:text].to_s
+        @real.add_modify_listener do |event|
+          @dsl.call_change_listeners
+        end
       end
 
       def text
-        @real.text  
+        @real.text
       end
-      
+
       def text=(value)
         @real.text = value
       end

--- a/lib/shoes/swt/list_box.rb
+++ b/lib/shoes/swt/list_box.rb
@@ -6,19 +6,21 @@ module Shoes
 
       # Create a list box
       #
-      # @param [Shoes::List_obx] dsl The Shoes DSL list box this represents
-      # @param [::Swt::Widgets::Composite] parent The parent element of this button
-      # @param [Proc] blk The block of code to call when this button is activated
-      def initialize(dsl, parent, blk)
+      # @param dsl    [Shoes::List_obx] The Shoes DSL list box this represents
+      # @param parent [::Swt::Widgets::Composite] The parent element of this button
+      def initialize(dsl, parent)
         dsl.opts[:width] ||= 200
         dsl.opts[:height] ||= 20
         @dsl = dsl
         @parent = parent
-        @blk = blk
-        @real = ::Swt::Widgets::Combo.new(@parent.real,
-          ::Swt::SWT::DROP_DOWN | ::Swt::SWT::READ_ONLY)
-        @real.setSize dsl.opts[:width], dsl.opts[:height]
-        @real.addSelectionListener{|e| blk[@dsl]} if blk
+        @real = ::Swt::Widgets::Combo.new(
+          @parent.real,
+          ::Swt::SWT::DROP_DOWN | ::Swt::SWT::READ_ONLY
+        )
+        @real.set_size dsl.opts[:width], dsl.opts[:height]
+        @real.add_selection_listener do |event|
+          @dsl.call_change_listeners
+        end
       end
 
       def update_items(values)

--- a/spec/shoes/edit_box_spec.rb
+++ b/spec/shoes/edit_box_spec.rb
@@ -8,8 +8,10 @@ describe Shoes::EditBox do
   let(:parent) { Shoes::Flow.new app, app: app }
   subject { Shoes::EditBox.new(parent, input_opts, input_block) }
 
+
   it_behaves_like "movable object"
   it_behaves_like "movable object with gui"
+  it_behaves_like "an element that can respond to change"
 
   it { should respond_to :focus }
   it { should respond_to :text  }

--- a/spec/shoes/edit_line_spec.rb
+++ b/spec/shoes/edit_line_spec.rb
@@ -10,6 +10,7 @@ describe Shoes::EditLine do
 
   it_behaves_like "movable object"
   it_behaves_like "movable object with gui"
+  it_behaves_like "an element that can respond to change"
 
   it { should respond_to :focus }
   it { should respond_to :text  }

--- a/spec/shoes/list_box_spec.rb
+++ b/spec/shoes/list_box_spec.rb
@@ -1,12 +1,13 @@
 require 'shoes/spec_helper'
 
 describe Shoes::ListBox do
-  subject { Shoes::ListBox.new(parent,
-    input_opts, input_block) }
-  let(:input_block) { Proc.new {} }
-  let(:input_opts) { { :items => ["Wine", "Vodka", "Water"] } }
-  let(:app) { Shoes::App.new }
-  let(:parent) { Shoes::Flow.new app, app: app}
+  subject           { Shoes::ListBox.new(parent, input_opts, input_block) }
+  let(:input_block) { ->(listbox) {} }
+  let(:input_opts)  { { :items => ["Wine", "Vodka", "Water"] } }
+  let(:app)         { Shoes::App.new }
+  let(:parent)      { Shoes::Flow.new app, app: app}
+
+  it_behaves_like "an element that can respond to change"
 
   it "should contain the correct items" do
     subject.items.should eq ["Wine", "Vodka", "Water"]
@@ -26,5 +27,11 @@ describe Shoes::ListBox do
     Shoes.configuration.backend::ListBox.any_instance.
         should_receive(:choose).with "Wine"
     subject.choose "Wine"
+  end
+
+  it "should delegate #text to the backend" do
+    Shoes.configuration.backend::ListBox.any_instance.
+        should_receive(:text).and_return("Sneakers & Sandals")
+    subject.text.should == "Sneakers & Sandals"
   end
 end

--- a/spec/shoes/shared_examples/changeable.rb
+++ b/spec/shoes/shared_examples/changeable.rb
@@ -1,0 +1,26 @@
+shared_examples "an element that can respond to change" do
+  describe "when passing a block to the constructor" do
+    it "should notify the block of change events" do
+      input_block.should_receive(:call).with(subject)
+      subject.call_change_listeners
+    end
+  end
+
+  describe "when setting up a callback with #change" do
+    it "should notify the callback of change events" do
+      called = false
+      subject.change do |element|
+        called = true
+      end
+      subject.call_change_listeners
+      called.should be_true
+    end
+
+    it "should pass the element itself to the callback" do
+      subject.change do |element|
+        element.should == subject
+      end
+      subject.call_change_listeners
+    end
+  end
+end

--- a/spec/swt_shoes/edit_box_spec.rb
+++ b/spec/swt_shoes/edit_box_spec.rb
@@ -1,12 +1,11 @@
 require 'swt_shoes/spec_helper'
 
 describe Shoes::Swt::EditBox do
-  let(:dsl) { double('dsl', opts: {}) }
+  let(:dsl)    { double('dsl', opts: {}) }
   let(:parent) { double('parent') }
-  let(:block) { double('block') }
-  let(:real) { double('real').as_null_object }
+  let(:real)   { double('real').as_null_object }
 
-  subject { Shoes::Swt::EditBox.new dsl, parent, block }
+  subject { Shoes::Swt::EditBox.new dsl, parent }
 
   before :each do
     parent.stub(:real)
@@ -21,6 +20,14 @@ describe Shoes::Swt::EditBox do
     it "sets text on real element" do
       real.should_receive(:text=).with("some text")
       subject.text = "some text"
+    end
+
+    it "should set up a listener that delegates change events" do
+      dsl.should_receive(:call_change_listeners)
+      real.should_receive(:add_modify_listener) do |&blk|
+        blk.call()
+      end
+      subject
     end
   end
 end

--- a/spec/swt_shoes/edit_line_spec.rb
+++ b/spec/swt_shoes/edit_line_spec.rb
@@ -3,10 +3,9 @@ require 'swt_shoes/spec_helper'
 describe Shoes::Swt::EditLine do
   let(:dsl) { double('dsl', opts: {secret: true}) }
   let(:parent) { double('parent') }
-  let(:block) { double('block') }
   let(:real) { double('real').as_null_object }
 
-  subject { Shoes::Swt::EditLine.new dsl, parent, block }
+  subject { Shoes::Swt::EditLine.new dsl, parent }
 
   before :each do
     parent.stub(:real)
@@ -22,6 +21,17 @@ describe Shoes::Swt::EditLine do
       real.should_receive(:text=).with("some text")
       subject.text = "some text"
     end
+
+    it "should set up a listener that delegates change events" do
+      dsl.should_receive(:call_change_listeners)
+      real.should_receive(:add_modify_listener) do |&blk|
+        blk.call()
+      end
+      subject
+    end
+  end
+
+  describe "responding to change" do
   end
 
   describe ":secret option" do

--- a/spec/swt_shoes/list_box_spec.rb
+++ b/spec/swt_shoes/list_box_spec.rb
@@ -1,13 +1,13 @@
 require 'swt_shoes/spec_helper'
 
 describe Shoes::Swt::ListBox do
-  let(:items) { ["Pie", "Apple", "Sand"] }
-  let(:dsl) { double('dsl', items: items, opts: {}) }
+  let(:items)  { ["Pie", "Apple", "Sand"] }
+  let(:dsl)    { double('dsl', items: items, opts: {}) }
   let(:parent) { double('parent') }
-  let(:block) { double('block') }
-  let(:real) { mock(text: "", setSize: true, addSelectionListener: true) }
+  let(:block)  { ->(){} }
+  let(:real)   { mock(text: "", set_size: true, add_selection_listener: true) }
 
-  subject { Shoes::Swt::ListBox.new dsl, parent, block }
+  subject { Shoes::Swt::ListBox.new dsl, parent, &block }
 
   before :each do
     parent.stub(:real)
@@ -30,5 +30,15 @@ describe Shoes::Swt::ListBox do
   it "should call text= when choosing" do
     real.should_receive(:text=).with "Bacon"
     subject.choose "Bacon"
+  end
+
+  describe "when the backend notifies us that the selection has changed" do
+    it "should call the change listeners" do
+      dsl.should_receive(:call_change_listeners)
+      real.should_receive(:add_selection_listener) do |&blk|
+        blk.call()
+      end
+      subject
+    end
   end
 end


### PR DESCRIPTION
As described in the manual, on these three elements extra event handlers can be
set by passing a block to the `change' method. This block will receive the
element instance when a change happens. This can be choosing an item in the
ListBox, or editing the text in EditLine or EditBox.

Most of the functionality is grouped in Shoes::Common::Changeable, with some
work left in the constructors to wire everything up. It is also possible to pass
a block straight to the constructor, and this was already implemented. The way
this worked though has changed.

In the past the block was passed on the GUI backend, which was responsible for
calling it when a change happens. Now the GUI backend no longer receives a block,
instead the DSL layer sets up the block as any other `change' event handler, and
the backend is only responsible for notifying the DSL layer that something has
changed.

All code has been covered by tests, and I tried out some examples. However
EditBox seems to be broken(?). ListBox and EditLine work fine.

This change is signifcant because it fixes 'browser.rb' in shoes-contrib. That
is, though the layout of browser.rb is not the same as in Red Shoes, it is
functioning and can be used to browse the Shoes examples using Shoes4.
