### PR TITLE
Fix the edit_box DSL method to optionally take a string of text.

### DIFF
--- a/lib/shoes/edit_box.rb
+++ b/lib/shoes/edit_box.rb
@@ -8,15 +8,16 @@ module Shoes
 
     attr_reader :gui, :blk, :parent, :text, :opts
 
-    def initialize(parent, opts = {}, blk = nil)
+    def initialize(parent, text, opts = {}, blk = nil)
       @parent = parent
       @blk = blk
-      @app = opts[:app]
+      @app = opts.delete(:app)
       @opts = opts
 
       @gui = Shoes.configuration.backend_for(self, @parent.gui)
       @parent.add_child self
 
+      self.text = text
       self.change &blk if blk
     end
 

--- a/lib/shoes/element_methods.rb
+++ b/lib/shoes/element_methods.rb
@@ -83,9 +83,10 @@ module Shoes
       Shoes::EditLine.new @current_slot, opts, blk
     end
 
-    def edit_box(opts = {}, &blk)
-      opts.merge! :app => @app
-      Shoes::EditBox.new @current_slot, opts, blk
+    def edit_box(*args, &blk)
+      opts = extract_opts!(args)
+      text = args.first
+      Shoes::EditBox.new @current_slot, text, opts, blk
     end
 
     def progress(opts = {}, &blk)
@@ -495,6 +496,17 @@ EOS
 
     def clipboard=(str)
       @app.gui.clipboard = str
+    end
+
+    private
+
+    def extract_opts!(args)
+      opts = {}
+      if args.last.is_a?(Hash)
+        opts = args.pop
+      end
+      opts[:app] = @app
+      opts
     end
   end
 end

--- a/lib/shoes/mock/edit_box.rb
+++ b/lib/shoes/mock/edit_box.rb
@@ -1,6 +1,7 @@
 module Shoes
   module Mock
     class EditBox
+      attr_accessor :text
       include Shoes::Mock::CommonMethods
     end
   end

--- a/spec/shoes/edit_box_spec.rb
+++ b/spec/shoes/edit_box_spec.rb
@@ -3,11 +3,11 @@ require "shoes/spec_helper"
 describe Shoes::EditBox do
 
   let(:input_block) { Proc.new {} }
-  let(:input_opts) { {} }
-  let(:app) { Shoes::App.new }
-  let(:parent) { Shoes::Flow.new app, app: app }
-  subject { Shoes::EditBox.new(parent, input_opts, input_block) }
-
+  let(:input_opts)  { {} }
+  let(:app)         { Shoes::App.new }
+  let(:parent)      { Shoes::Flow.new app, app: app }
+  let(:text)        { nil }
+  subject { Shoes::EditBox.new(parent, text, input_opts, input_block) }
 
   it_behaves_like "movable object"
   it_behaves_like "movable object with gui"
@@ -16,4 +16,11 @@ describe Shoes::EditBox do
   it { should respond_to :focus }
   it { should respond_to :text  }
   it { should respond_to :text= }
+
+  context "with text given in its constructor" do
+    let(:text) { "text here, no kidding" }
+    it "should set that as its text property" do
+      subject.text.should == text
+    end
+  end
 end

--- a/spec/shoes/element_methods/edit_box_spec.rb
+++ b/spec/shoes/element_methods/edit_box_spec.rb
@@ -1,0 +1,38 @@
+require "shoes/spec_helper"
+require "shoes/element_methods/shared_contexts"
+
+describe Shoes::ElementMethods, "edit_box" do
+  include_context "with a mock dsl object"
+
+  subject { dsl.edit_box *args }
+
+  describe "edit_box()" do
+    let(:args) { [] }
+    it { should be_instance_of Shoes::EditBox }
+    its(:text)  { should == nil }
+    its(:opts) { should == {}  }
+  end
+
+  describe "edit_box(text)" do
+    let(:args) { ['Hello text here'] }
+
+    it { should be_instance_of Shoes::EditBox }
+    its(:text)  { should == 'Hello text here' }
+    its(:opts) { should == {}  }
+  end
+
+  describe "edit_box(style: options)" do
+    let(:args) { [{width: 100, height: 50}] }
+
+    it { should be_instance_of Shoes::EditBox }
+    its(:text)  { should == nil }
+    its(:opts) { should == {width: 100, height: 50} }
+  end
+
+  describe "edit_box(text, style: options)" do
+    let(:args) { ['Hello text here', {width: 100, height: 50}] }
+    it { should be_instance_of Shoes::EditBox }
+    its(:text)  { should == 'Hello text here' }
+    its(:opts) { should == {width: 100, height: 50} }
+  end
+end

--- a/spec/shoes/element_methods/shared_contexts.rb
+++ b/spec/shoes/element_methods/shared_contexts.rb
@@ -1,0 +1,14 @@
+shared_context "with a mock dsl object" do
+  let(:dsl) do
+    Class.new do
+      include Shoes::ElementMethods
+      include RSpec::Mocks::ExampleMethods
+
+      def initialize
+        @current_slot = double('current_slot').as_null_object
+        @gui = double('current_slot').as_null_object
+      end
+
+    end.new
+  end
+end

--- a/spec/shoes/element_methods_spec.rb
+++ b/spec/shoes/element_methods_spec.rb
@@ -1,0 +1,208 @@
+require "shoes/spec_helper"
+
+# Since testing all ways of calling these methods can get a bit elaborate, you
+# can split of a file for each method. See element_methods/edit_box_spec.rb for
+# an example
+describe Shoes::ElementMethods do
+  describe "color(c)" do
+    it "should conform to the manual"
+  end
+
+  describe "pattern(*args)" do
+    it "should conform to the manual"
+  end
+
+  describe "pop_and_normalize_style(opts)" do
+    it "should conform to the manual"
+  end
+
+  describe "normalize_style(orig_style)" do
+    it "should conform to the manual"
+  end
+
+  describe "image(path, opts={}, &blk)" do
+    it "should conform to the manual"
+  end
+
+  describe "border(color, opts = {}, &blk)" do
+    it "should conform to the manual"
+  end
+
+  describe "background(color, opts = {}, &blk)" do
+    it "should conform to the manual"
+  end
+
+  describe "edit_line(opts = {}, &blk)" do
+    it "should conform to the manual"
+  end
+
+  describe "progress(opts = {}, &blk)" do
+    it "should conform to the manual"
+  end
+
+  describe "check(opts = {}, &blk)" do
+    it "should conform to the manual"
+  end
+
+  describe "radio(opts = {}, &blk)" do
+    it "should conform to the manual"
+  end
+
+  describe "list_box(opts = {}, &blk)" do
+    it "should conform to the manual"
+  end
+
+  describe "flow(opts = {}, &blk)" do
+    it "should conform to the manual"
+  end
+
+  describe "stack(opts = {}, &blk)" do
+    it "should conform to the manual"
+  end
+
+  describe "button(text, opts={}, &blk)" do
+    it "should conform to the manual"
+  end
+
+  describe "animate(opts = {}, &blk)" do
+    it "should conform to the manual"
+  end
+
+  describe "every n=1, &blk" do
+    it "should conform to the manual"
+  end
+
+  describe "timer n=1, &blk" do
+    it "should conform to the manual"
+  end
+
+  describe "sound(soundfile, opts = {}, &blk)" do
+    it "should conform to the manual"
+  end
+
+  describe "arc(left, top, width, height, angle1, angle2, opts = {})" do
+    it "should conform to the manual"
+  end
+
+  describe "line(x1, y1, x2, y2, opts = {})" do
+    it "should conform to the manual"
+  end
+
+  describe "oval(*opts, &blk)" do
+    it "should conform to the manual"
+  end
+
+  describe "rect(*args, &blk)" do
+    it "should conform to the manual"
+  end
+
+  describe "star(*args, &blk)" do
+    it "should conform to the manual"
+  end
+
+  describe "shape(shape_style = {}, &blk)" do
+    it "should conform to the manual"
+  end
+
+  describe "rgb(red, green, blue, alpha = Shoes::Color::OPAQUE)" do
+    it "should conform to the manual"
+  end
+
+  describe "gradient(*args)" do
+    it "should conform to the manual"
+  end
+
+  describe "image_pattern path" do
+    it "should conform to the manual"
+  end
+
+  describe "stroke(color)" do
+    it "should conform to the manual"
+  end
+
+  describe "nostroke" do
+    it "should conform to the manual"
+  end
+
+  describe "strokewidth(width)" do
+    it "should conform to the manual"
+  end
+
+  describe "fill(pattern)" do
+    it "should conform to the manual"
+  end
+
+  describe "nofill" do
+    it "should conform to the manual"
+  end
+
+  describe "cap line_cap" do
+    it "should conform to the manual"
+  end
+
+  describe "style(new_styles = {})" do
+    it "should conform to the manual"
+  end
+
+  %w[banner title subtitle tagline caption para inscription].each do |method|
+    describe method do
+      it "should conform to the manual"
+    end
+  end
+
+  describe "get_styles msg, styles=[], spoint=0" do
+    it "should conform to the manual"
+  end
+
+  %w[code del em ins strong sub sup].each do |method|
+    describe method  do
+      it "should conform to the manual"
+    end
+  end
+
+  %w[bg fg].each do |method|
+    describe method  do
+      it "should conform to the manual"
+    end
+  end
+
+  describe "link *str, &blk" do
+    it "should conform to the manual"
+  end
+
+  describe "mouse" do
+    it "should conform to the manual"
+  end
+
+  describe "motion &blk" do
+    it "should conform to the manual"
+  end
+
+  describe "keypress &blk" do
+    it "should conform to the manual"
+  end
+
+  describe "clear" do
+    it "should conform to the manual"
+  end
+
+  describe "visit url" do
+    it "should conform to the manual"
+  end
+
+  describe "scroll_top" do
+    it "should conform to the manual"
+  end
+
+  describe "scroll_top=(n)" do
+    it "should conform to the manual"
+  end
+
+  describe "clipboard" do
+    it "should conform to the manual"
+  end
+
+  describe "clipboard=(str)" do
+    it "should conform to the manual"
+  end
+end


### PR DESCRIPTION
Finally made time to wrap/clean this up :)

This had some collateral effects. It seems there are quite a few DSL methods that
should take one or more optional arguments, apart from their style/options hash.
I imagine the work of detecting/extracting these arguments would be done in
ElementMethods, so the constructors of the actual elements take a fixed number
of arguments, of which one or more can be nil.

Because of this, some mechanisms will be needed in ElementMethods to
differentiate the various invocations, and so as a first step I added an
extract_options! which does the usual thing.

There were also no specs in place yet for this DSL layer in ElementMethods. I
created pending specs, and implemented the full behaviour of edit_box, which
can be a nice example for the others, and excellent low hanging fruit for
whoever wants to get their feet wet.

There's a pun in there somewhere. Feet, shoes, wet... :shoe: :mans_shoe: :sandal: :boot: :high_heel: :swimmer:
