### PR TITLE
Fix issue with underlines not displaying

### DIFF
--- a/lib/shoes/swt/text_block.rb
+++ b/lib/shoes/swt/text_block.rb
@@ -95,6 +95,7 @@ module Shoes
             ::Swt::Color.new(Shoes.display, 0, 0, 0)
           bgc = @opts[:fill] ? ::Swt::Color.new(Shoes.display, @opts[:fill].red, @opts[:fill].green, @opts[:fill].blue) : nil
           style = ::Swt::TextStyle.new font, fgc, bgc
+		  style.underline = @opts[:underline] ? true : false 
           @tl.setStyle style, 0, @dsl.text.length - 1
           @gcs << font << fgc << bgc
 


### PR DESCRIPTION
Fixed an issue with underlines not displaying for text blocks even when
an underline parameter is passed into the constructor.
