### PR TITLE
Change the Rakefile to isolate the regular specs from the SWT specs.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,7 @@ namespace :spec do
   "
   task "all", [:module] do |t, args|
     Rake::Task["spec:shoes"].invoke(args[:module])
-    Rake::Task["spec:swt"].invoke(args[:module])
+    Rake::Task["spec:swt:isolation"].invoke(args[:module])
   end
 
   task :swt, [:module] do |t, args|
@@ -96,6 +96,8 @@ namespace :spec do
     Limit the examples to specific :modules : "
     task :all, [:module] do |t, args|
       argh = swt_args(args)
+      # This is essentially broken, the SWT specs change global state,
+      # making the regular specs fail.
       files = (Dir['spec/swt_shoes/*_spec.rb'] + Dir['spec/shoes/*_spec.rb']).join ' '
       jruby_rspec(files, argh)
     end


### PR DESCRIPTION
Original implementation does this

```
- spec
-- spec:all
--- spec:shoes
----> This runs Shoes specs `spec/shoes/**/*_spec.rb`
--- spec:swt
---- spec:swt:all
-----> This runs SWT + Shoes specs `spec/{shoes,swt_shoes}/**/*_spec.rb`
```

There are two problems with this
1. Regular Shoes specs are run twice
2. The second time they are run in the same process as the SWT specs,
   causing issues, because the SWT specs mess with global state, making
   the other examples fail.

We really need to look into what the core issue is, but in the meantime
this is the sensible thing to do.

@bjoska & @arnebrasseur
