### PR TITLE
A Ruby script to start shoes4

### DIFF
--- a/bin/ruby-shoes
+++ b/bin/ruby-shoes
@@ -1,0 +1,6 @@
+#!/usr/bin/env jruby
+lib_directory = File.expand_path('../../lib', __FILE__)
+$LOAD_PATH << lib_directory
+
+require 'shoes/cli'
+Shoes::CLI.new.run ARGV


### PR DESCRIPTION
- can be used as the executable of a gem release as mentioned in #231 - but then it should be named shoes imo
- does not depend on the place it is started from, which I need to try to run
  hacketyhack as hackety sadly depends on where you start it from
- I think that this is the simplest possible ruby script to achieve this :-)
