### PR TITLE
Implement Shoes.setup to print a warning message

### DIFF
--- a/lib/shoes.rb
+++ b/lib/shoes.rb
@@ -17,6 +17,28 @@ module Shoes
       Shoes.configuration.logger_instance
     end
 
+    # To ease the upgrade path from Shoes 3 we warn users they need to install
+    # and require gems themselves.
+    #
+    # @example
+    #   Shoes.setup do
+    #     gem 'bluecloth =2.0.6'
+    #     gem 'metaid'
+    #   end
+    #
+    # @param block [Proc] The block that describes the gems that are needed
+    # @deprecated
+    def setup(&block)
+      $stderr.puts "WARN: The Shoes.setup method is no longer used, you need to install gems yourself."
+      Class.new do
+        def gem(name)
+          name, version = name.split()
+          install_cmd = ["gem install", name, version ? "--version \"#{version}\"" : ''].join(' ')
+          $stderr.puts "WARN: To use the '#{name}' gem, install it with '#{install_cmd}', and put 'require \"#{name}\"' at the top of your Shoes program."
+        end
+      end.new.instance_eval(&block)
+    end
+
     # Load the backend in memory. This does not set any configuration.
     #
     # @param name [String|Symbol] The name, such as :swt or :mock


### PR DESCRIPTION
Shoes 3 Had a way of specifying gems a Shoes app depends on, like so

```
Shoes.setup do
  gem 'nokogiri ~>1.6.0'
end
```

This was relevant then because Shoes embedded its own Ruby, in this case Shoes
would take care of installing the gem in the right place and loading it in
the app.

In Shoes 4 we will no longer do this, the user can use the standard tools
(gem install, or bundler on top of that) and require the needed files in
the Shoes app.

To ease the upgrade path for people coming from Shoes 3 (or relying on outdated
documentation) we print a warning telling them what to do. This is what it looks
like.

```
WARN: The Shoes.setup method is no longer used, you need to install gems yourself.
WARN: To use the 'bluecloth' gem, install it with 'gem install bluecloth --version "=2.0.6"', and put 'require "bluecloth"' at the top of your Shoes program.
WARN: To use the 'metaid' gem, install it with 'gem install metaid ', and put 'require "metaid"' at the top of your Shoes program.
```

I wouldn't normally send this in without tests, but @PragTob twisted my arm.

I considered using flashy red ANSI colors, but I'm not sure how to detect if a terminal is capable of ANSI colors, and I would hate to show funny escape characters to some users.
