### PR TITLE
Rise Text Style

### DIFF
--- a/lib/shoes/swt/text_block.rb
+++ b/lib/shoes/swt/text_block.rb
@@ -126,6 +126,8 @@ class Shoes
           set_underline(style)
           set_undercolor(style)
 
+          set_rise(style)
+
           set_strikethrough(style)
           set_strikecolor(style)
 
@@ -208,6 +210,10 @@ class Shoes
             @text_layout.setStyle style, st[1].first, st[1].last
             @gcs << ft
           end if @opts[:text_styles]
+        end
+
+        def set_rise(style)
+          style.rise = @opts[:rise]
         end
 
         def set_underline(style)

--- a/spec/swt_shoes/text_block_spec.rb
+++ b/spec/swt_shoes/text_block_spec.rb
@@ -75,6 +75,18 @@ describe Shoes::Swt::TextBlock do
       subject.paintControl(event)
     end
 
+    it "sets default rise value to nil" do
+      style.should_receive(:rise=).with(nil)
+      subject.paintControl(event)
+    end
+
+    it "sets correct rise value" do
+      opts[:rise] = 10
+      style.should_receive(:rise=).with(10)
+
+      subject.paintControl(event)
+    end
+
     context "underline option" do
       it "sets default underline style to none" do
         opts.delete(:underline)


### PR DESCRIPTION
Rise raises or lowers the font baseline for some text. 

Implemented in SWT Text Block with RSpec tests, pretty similar to underline and strikethrough.

Not sure, but should I handle potential bad input by assigning anything that's not an integer as nil for the rise value?
