### PR TITLE
Removed deprecation warnings of respec 2.14.x

### DIFF
--- a/spec/shoes/oval_spec.rb
+++ b/spec/shoes/oval_spec.rb
@@ -4,8 +4,8 @@ describe Shoes::Oval do
   let(:app) { Shoes::App.new }
 
   before :each do
-    Shoes::Mock::Oval.any_instance.stub(:real) { mock( size:
-      mock(x: 100, y: 100) ) }
+    Shoes::Mock::Oval.any_instance.stub(:real) { double( size:
+      double(x: 100, y: 100) ) }
   end
 
   describe "basic" do

--- a/spec/swt_shoes/app_spec.rb
+++ b/spec/swt_shoes/app_spec.rb
@@ -5,14 +5,14 @@ describe Shoes::Swt::App do
   let(:app) { double('app', :opts => opts,
                             :width => 0,
                             :height => 0,
-                            :app_title => 'mock') }
+                            :app_title => 'double') }
 
   let(:opts_unresizable) { {:background => Shoes::COLORS[:salmon],
                             :resizable => false} }
   let(:app_unresizable) { double('app', :opts => opts_unresizable,
                                         :width => 0,
                                         :height => 0,
-                                        :app_title => 'mock') }
+                                        :app_title => 'double') }
 
   subject { Shoes::Swt::App.new(app) }
 
@@ -36,7 +36,7 @@ describe Shoes::Swt::App do
     let(:the_display) { ::Swt::Widgets::Display }
 
     it "should set the menubar title" do
-      the_display.should_receive(:app_name=).with('mock')
+      the_display.should_receive(:app_name=).with('double')
       subject
     end
   end

--- a/spec/swt_shoes/button_spec.rb
+++ b/spec/swt_shoes/button_spec.rb
@@ -11,7 +11,7 @@ describe Shoes::Swt::Button do
 
   before :each do
     parent.stub(:real)
-    parent.stub(:dsl){mock(contents: [])}
+    parent.stub(:dsl){double(contents: [])}
     dsl.stub(:width=)
     dsl.stub(:height=)
     ::Swt::Widgets::Button.stub(:new) { real }

--- a/spec/swt_shoes/check_spec.rb
+++ b/spec/swt_shoes/check_spec.rb
@@ -3,7 +3,7 @@ require 'swt_shoes/spec_helper'
 describe Shoes::Swt::Check do
   let(:text) { "TEXT" }
   let(:dsl) { double('dsl', :width= => true, :height= => true, contents: []) }
-  let(:parent) { double('parent', real: true, dsl: mock(contents: []) ) }
+  let(:parent) { double('parent', real: true, dsl: double(contents: []) ) }
   let(:block) { proc {} }
   let(:real) { double('real').as_null_object }
 

--- a/spec/swt_shoes/dialog_spec.rb
+++ b/spec/swt_shoes/dialog_spec.rb
@@ -4,23 +4,23 @@ main_object = self
 
 describe Shoes::Swt::Dialog do
 
-  def mock_message_box
-    create_mock_message_box mock(:mb, open: true, :message= => true)
+  def double_message_box
+    create_double_message_box double(:mb, open: true, :message= => true)
   end
 
-  def mock_message_box_expecting_message(message)
-    mock_dialog = mock(:mb, open: true)
-    mock_dialog.should_receive(:message=).with(message)
-    create_mock_message_box mock_dialog
+  def double_message_box_expecting_message(message)
+    double_dialog = double(:mb, open: true)
+    double_dialog.should_receive(:message=).with(message)
+    create_double_message_box double_dialog
   end
 
-  def mock_message_box_returning(return_value)
-    create_mock_message_box mock(:mb, :message= => true, open: return_value)
+  def double_message_box_returning(return_value)
+    create_double_message_box double(:mb, :message= => true, open: return_value)
   end
 
-  def create_mock_message_box(mock_dialog)
+  def create_double_message_box(double_dialog)
     ::Swt::Widgets::Shell.stub(:new)
-    ::Swt::Widgets::MessageBox.stub(new: mock_dialog)
+    ::Swt::Widgets::MessageBox.stub(new: double_dialog)
   end
 
   before :each do
@@ -31,34 +31,34 @@ describe Shoes::Swt::Dialog do
 
   describe 'alert' do
     it 'pops up a window containing a short message.' do
-      mock_message_box_expecting_message TEXT
+      double_message_box_expecting_message TEXT
       @dialog.alert TEXT
     end
 
     it 'returns nil' do
-      mock_message_box
+      double_message_box
       @dialog.alert('Nothing').should be_nil
     end
   end
 
   describe 'confirm' do
     it 'pops up a window containing a short message.' do
-      mock_message_box_expecting_message TEXT
+      double_message_box_expecting_message TEXT
       @dialog.confirm TEXT
     end
 
     it 'is true when YES was pressed' do
-      mock_message_box_returning ::Swt::SWT::YES
+      double_message_box_returning ::Swt::SWT::YES
       subject.confirm.should be_true
     end
 
     it 'is false when NO was pressed' do
-      mock_message_box_returning ::Swt::SWT::NO
+      double_message_box_returning ::Swt::SWT::NO
       subject.confirm.should be_false
     end
 
     it 'is false when an arbitary number is returned' do
-      mock_message_box_returning 42
+      double_message_box_returning 42
       subject.confirm.should be_false
     end
   end
@@ -85,19 +85,19 @@ describe Shoes::Swt::Dialog do
     describe '#alert' do
 
       it 'returns nil' do
-        mock_message_box
+        double_message_box
         main_object.alert('Something').should be_nil
       end
     end
 
     describe '#confirm' do
       it 'returns true when YES was clicked' do
-        mock_message_box_returning ::Swt::SWT::YES
+        double_message_box_returning ::Swt::SWT::YES
         main_object.confirm('1 + 1 = 2').should be_true
       end
 
       it 'returns false when NO was clicked' do
-        mock_message_box_returning ::Swt::SWT::NO
+        double_message_box_returning ::Swt::SWT::NO
         main_object.confirm('1 + 1 = 3').should be_false
       end
     end

--- a/spec/swt_shoes/flow_spec.rb
+++ b/spec/swt_shoes/flow_spec.rb
@@ -10,7 +10,7 @@ describe Shoes::Swt::Flow do
 
   describe "#initialize" do
     before do
-      parent_real.stub(:get_layout){mock(top_slot: true)}
+      parent_real.stub(:get_layout){double(top_slot: true)}
     end
 
     it "sets readers" do

--- a/spec/swt_shoes/image_spec.rb
+++ b/spec/swt_shoes/image_spec.rb
@@ -14,7 +14,7 @@ describe Shoes::Swt::Image do
   let(:dsl) { double("dsl object", left: left, top: top, app: app, hidden: false, opts: {})}
   let(:left) { 100 }
   let(:top) { 200 }
-  let(:mock_image) { mock(:swt_image, getImageData: MockSize.new, addListener: true, add_paint_listener: true) }
+  let(:mock_image) { double(:swt_image, getImageData: MockSize.new, addListener: true, add_paint_listener: true) }
   let(:real) { mock_image }
   let(:gui) { double("gui", real: real, clickable_elements: [], add_clickable_element: nil) }
   let(:app) { double("app", gui: gui) }

--- a/spec/swt_shoes/keypress_spec.rb
+++ b/spec/swt_shoes/keypress_spec.rb
@@ -5,7 +5,7 @@ require 'swt_shoes/spec_helper'
 describe Shoes::Swt::Keypress do
   let(:input_blk) { Proc.new {} }
   let(:opts) { Hash.new }
-  let(:app) { stub shell: stub() }
+  let(:app) { double shell: double() }
   let(:dsl) { double('dsl') }
   let(:block) { proc{ |key| key} }
   subject { Shoes::Swt::Keypress.new dsl, app, &block}
@@ -26,7 +26,7 @@ describe Shoes::Swt::KeyListener do
 
   def test_character_press(character, state_modifier = 0, result_char = character)
     block.should_receive(:call).with(result_char)
-    event = stub  character: character.ord,
+    event = double  character: character.ord,
                   stateMask: 0 | state_modifier,
                   keyCode: character.downcase.ord
     subject.key_pressed(event)
@@ -84,7 +84,7 @@ describe Shoes::Swt::KeyListener do
     def test_ctrl_character_press(character, modifier = 0)
       result_char = ('control_' + character).to_sym
       block.should_receive(:call).with(result_char)
-      event = stub  character: 'something weird like \x00',
+      event = double  character: 'something weird like \x00',
                     stateMask: CTRL | modifier,
                     keyCode: character.downcase.ord
       subject.key_pressed(event)
@@ -126,7 +126,7 @@ describe Shoes::Swt::KeyListener do
   describe 'only modifier keys yield nothing' do
     def test_receive_nothing_with_modifier(modifier, last_key_press = modifier)
       block.should_not_receive :call
-      event = stub stateMask: modifier, keyCode: last_key_press, character: 0
+      event = double stateMask: modifier, keyCode: last_key_press, character: 0
       subject.key_pressed(event)
     end
 
@@ -161,7 +161,7 @@ describe Shoes::Swt::KeyListener do
 
     def special_key_test(code, expected, modifier = 0)
       block.should_receive(:call).with(expected)
-      event = stub stateMask: modifier,
+      event = double stateMask: modifier,
                    keyCode: code,
                    character: 0
       subject.key_pressed(event)

--- a/spec/swt_shoes/list_box_spec.rb
+++ b/spec/swt_shoes/list_box_spec.rb
@@ -5,7 +5,7 @@ describe Shoes::Swt::ListBox do
   let(:dsl)    { double('dsl', items: items, opts: {}) }
   let(:parent) { double('parent') }
   let(:block)  { ->(){} }
-  let(:real)   { mock(text: "", set_size: true, add_selection_listener: true) }
+  let(:real)   { double(text: "", set_size: true, add_selection_listener: true) }
 
   subject { Shoes::Swt::ListBox.new dsl, parent, &block }
 

--- a/spec/swt_shoes/oval_spec.rb
+++ b/spec/swt_shoes/oval_spec.rb
@@ -27,9 +27,9 @@ describe Shoes::Swt::Oval do
     it_behaves_like "stroke painter"
 
     it "creates oval clipping area" do
-      mock_path = double("path")
-      ::Swt::Path.stub(:new) { mock_path }
-      mock_path.should_receive(:add_arc).with(left, top, width, height, 0, 360)
+      double_path = double("path")
+      ::Swt::Path.stub(:new) { double_path }
+      double_path.should_receive(:add_arc).with(left, top, width, height, 0, 360)
       subject.clipping
     end
 

--- a/spec/swt_shoes/radio_spec.rb
+++ b/spec/swt_shoes/radio_spec.rb
@@ -3,7 +3,7 @@ require 'swt_shoes/spec_helper'
 describe Shoes::Swt::Radio do
   let(:text) { "TEXT" }
   let(:dsl) { double('dsl', :width= => true, :height= => true) }
-  let(:parent) { double('parent', real: true, dsl: mock(contents: []) ) }
+  let(:parent) { double('parent', real: true, dsl: double(contents: []) ) }
   let(:block) { proc {} }
   let(:real) { double('real').as_null_object }
 

--- a/spec/swt_shoes/shared_examples/clickable.rb
+++ b/spec/swt_shoes/shared_examples/clickable.rb
@@ -11,13 +11,13 @@ shared_examples 'clickable backend' do
   let(:click_real) {double 'real', addListener: true}
 
   it {should respond_to :clickable}
-  let(:clickable_block) {mock 'clickable_block'}
+  let(:clickable_block) {double 'clickable_block'}
   let(:clickable_subject) do
     subject.clickable clickable_block
     subject
   end
 
-  let(:mouse_event) {stub 'mouse_event', button: 1, x: 2, y:3}
+  let(:mouse_event) {double 'mouse_event', button: 1, x: 2, y:3}
 
   it 'its click_handler should not be nil' do
     clickable_subject.click_listener.should_not be_nil


### PR DESCRIPTION
- calls to stub/mock replace with double
- this just affects stub to create a double object, not .stub
  for stubbing methods
- Huge thanks to @mbuettner for helping me figure out the regex
  for this saving a ton of time.. it's like: /(?<![.])stub/ :-)
