### PR TITLE
Don't gather coverage data for spec files

### DIFF
--- a/spec/code_coverage.rb
+++ b/spec/code_coverage.rb
@@ -6,4 +6,6 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
     Coveralls::SimpleCov::Formatter,
     SimpleCov::Formatter::HTMLFormatter
 ]
-SimpleCov.start
+SimpleCov.start do
+  add_filter '/spec/'
+end


### PR DESCRIPTION
- until now simplecov simply gathered coverage data for ALL files
  that were loaded, this includes spec files where of course the
  coverage was 100%
- this, well is not exactly the goal, as we want to gather
  coverage data on our implementation.
- the behavior was nice though to spot shared samples that were
  not used/unexecuted test but it's not the main functionality
- This of course drops our test coverage by a good 7% I belive
  (94% --> 87%) and coveralls will complain about that any second
  but this is more honest and accurate :-)

If no one sees a reason to keep it the old way I'll gladly merge it :-)
