### PR TITLE
Test multiple JDK versions on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: ruby
 script: "rake spec:all"
 rvm: jruby
+jdk:
+  - openjdk7
+  - oraclejdk7
+  - openjdk6
 notifications:
   irc: "irc.freenode.org#shoes"
   email:


### PR DESCRIPTION
- While browsing the Travis docs I just saw this, with this we
  can test against openjdk6 & 7 and oracle 7. I think that's
  awesome.
- WDYT
