### PR TITLE
Fix for button sizing #452

### DIFF
--- a/lib/shoes/swt/swt_button.rb
+++ b/lib/shoes/swt/swt_button.rb
@@ -13,9 +13,10 @@ class Shoes
         @type = type
         @real = ::Swt::Widgets::Button.new(@parent.real, @type)
         @real.addSelectionListener{|e| eval_block} if @dsl.blk
-        set_size
 
         yield(@real) if block_given?
+
+        set_size
       end
 
 


### PR DESCRIPTION
Turns out that the placement of where the dimensioning was in relation to
the yield(@real) was important. This is because the yield sets the button text
and that in turn influences its width. Setting the size before the yield just
gets whatever button size is out of the box with an empty string.
