### PR TITLE
Negative dimensions based on parent width/height

### DIFF
--- a/lib/shoes/dimensions.rb
+++ b/lib/shoes/dimensions.rb
@@ -34,19 +34,36 @@ class Shoes
     end
 
     def width
-      if @width.is_a?(Float) && @parent
-        (@width * @parent.width).to_i
-      else
-        @width
-      end
+      calculate_dimension(:width)
     end
 
     def height
-      if @height.is_a?(Float) && @parent
-        (@height * @parent.height).to_i
-      else
-        @height
+      calculate_dimension(:height)
+    end
+
+    def calculate_dimension(name)
+      result = instance_variable_get("@#{name}".to_sym)
+      if @parent
+        result = calculate_relative(name, result) if is_relative?(result)
+        result = calculate_negative(name, result) if is_negative?(result)
       end
+      result
+    end
+
+    def is_relative?(result)
+      result.is_a?(Float)
+    end
+
+    def calculate_relative(name, result)
+      (result * @parent.send(name)).to_i
+    end
+
+    def is_negative?(result)
+      result && result < 0.0
+    end
+
+    def calculate_negative(name, result)
+      @parent.send(name) + result
     end
 
     def absolute_x_position?

--- a/spec/shoes/arc_spec.rb
+++ b/spec/shoes/arc_spec.rb
@@ -42,8 +42,12 @@ describe Shoes::Arc do
 
   context "relative dimensions" do
     subject { Shoes::Arc.new(parent, left, top, relative_width, relative_height, 0, Shoes::TWO_PI) }
-
     it_behaves_like "object with relative dimensions"
+  end
+
+  context "negative dimensions" do
+    subject { Shoes::Arc.new(parent, left, top, -width, -height, 0, Shoes::TWO_PI) }
+    it_behaves_like "object with negative dimensions"
   end
 
   context "wedge" do

--- a/spec/shoes/background_spec.rb
+++ b/spec/shoes/background_spec.rb
@@ -27,9 +27,12 @@ describe Shoes::Background do
   it_behaves_like "object with dimensions"
 
   describe "relative dimensions from parent" do
-    let(:relative_opts) { { left: left, top: top, width: relative_width, height: relative_height } }
     subject { Shoes::Background.new(app, parent, blue, relative_opts) }
-
     it_behaves_like "object with relative dimensions"
+  end
+
+  context "negative dimensions" do
+    subject { Shoes::Background.new(app, parent, blue, negative_opts) }
+    it_behaves_like "object with negative dimensions"
   end
 end

--- a/spec/shoes/border_spec.rb
+++ b/spec/shoes/border_spec.rb
@@ -27,9 +27,12 @@ describe Shoes::Border do
   it_behaves_like "object with dimensions"
 
   describe "relative dimensions from parent" do
-    let(:relative_opts) { { left: left, top: top, width: relative_width, height: relative_height } }
     subject { Shoes::Border.new(app, parent, blue, relative_opts) }
-
     it_behaves_like "object with relative dimensions"
+  end
+
+  describe "negative dimensions" do
+    subject { Shoes::Border.new(app, parent, blue, negative_opts) }
+    it_behaves_like "object with negative dimensions"
   end
 end

--- a/spec/shoes/button_spec.rb
+++ b/spec/shoes/button_spec.rb
@@ -34,11 +34,13 @@ describe Shoes::Button do
     end
   end
 
-  context "relative dimensions" do
-    let(:relative_input_opts) { { :left => left, :top => top, :width => relative_width, :height => relative_height } }
-
-    subject { Shoes::Button.new(app, parent, "text", relative_input_opts, input_block) }
-
+  describe "relative dimensions" do
+    subject { Shoes::Button.new(app, parent, "text", relative_opts, input_block) }
     it_behaves_like "object with relative dimensions"
+  end
+
+  describe "negative dimensions" do
+    subject { Shoes::Button.new(app, parent, "text", negative_opts, input_block) }
+    it_behaves_like "object with negative dimensions"
   end
 end

--- a/spec/shoes/check_button_spec.rb
+++ b/spec/shoes/check_button_spec.rb
@@ -16,10 +16,12 @@ describe Shoes::Check do
   it_behaves_like "object with dimensions"
 
   describe "check takes relative dimensions from parent" do
-    let(:relative_opts) { { left: left, top: top, width: relative_width, height: relative_height } }
-
     subject { Shoes::Check.new(app, parent, relative_opts) }
-
     it_behaves_like "object with relative dimensions"
+  end
+
+  describe "negative dimensions" do
+    subject { Shoes::Check.new(app, parent, negative_opts) }
+    it_behaves_like "object with negative dimensions"
   end
 end

--- a/spec/shoes/dimensions_spec.rb
+++ b/spec/shoes/dimensions_spec.rb
@@ -50,10 +50,10 @@ describe Shoes::Dimensions do
       its(:top) {should eq top}
       its(:width) {should be_within(1).of 0.5 * width}
       its(:height) {should be_within(1).of 0.5 * height}
-      
+
       describe 'width/height change of the parent' do
         let(:parent) {Shoes::Dimensions.new nil, left, top, width, height}
-        
+
         # note that here the first assertion/call is necessary as otherwise
         # the subject will only lazily get initialized after the parent width
         # is already adjusted and therefore wrong impls WILL PASS the tests
@@ -70,6 +70,17 @@ describe Shoes::Dimensions do
           subject.height.should be_within(1).of 400
         end
       end
+    end
+
+    describe 'with negative width and height' do
+      let(:width) { -50 }
+      let(:height) { -50 }
+      subject {Shoes::Dimensions.new parent, left, top, width, height}
+
+      its(:left) {should eq left}
+      its(:top) {should eq top}
+      its(:width) {should eq parent.width + width}
+      its(:height) {should eq parent.height + height}
     end
 
     describe 'with a hash' do

--- a/spec/shoes/image_spec.rb
+++ b/spec/shoes/image_spec.rb
@@ -25,10 +25,13 @@ describe Shoes::Image do
     it_behaves_like "object with dimensions"
 
     describe "relative dimensions from parent" do
-      let(:relative_opts) { { left: left, top: top, width: relative_width, height: relative_height } }
       subject { Shoes::Image.new(app, parent, filename, relative_opts) }
-
       it_behaves_like "object with relative dimensions"
+    end
+
+    describe "negative dimensions" do
+      subject { Shoes::Image.new(app, parent, filename, negative_opts) }
+      it_behaves_like "object with negative dimensions"
     end
   end
 

--- a/spec/shoes/input_box_spec.rb
+++ b/spec/shoes/input_box_spec.rb
@@ -15,10 +15,12 @@ describe Shoes::EditBox do
   it_behaves_like "object with dimensions"
 
   describe "relative dimensions from parent" do
-    let(:relative_opts) { { left: left, top: top, width: relative_width, height: relative_height } }
-
     subject { Shoes::EditBox.new(app, parent, text, relative_opts) }
-
     it_behaves_like "object with relative dimensions"
+  end
+
+  describe "negative dimensions" do
+    subject { Shoes::EditBox.new(app, parent, text, negative_opts) }
+    it_behaves_like "object with negative dimensions"
   end
 end

--- a/spec/shoes/list_box_spec.rb
+++ b/spec/shoes/list_box_spec.rb
@@ -18,11 +18,13 @@ describe Shoes::ListBox do
   it_behaves_like "object with dimensions"
 
   describe "relative dimensions from parent" do
-    let(:relative_opts) { { left: left, top: top, width: relative_width, height: relative_height } }
-
     subject { Shoes::ListBox.new(app, parent, relative_opts, input_block) }
-
     it_behaves_like "object with relative dimensions"
+  end
+
+  describe "negative dimensions" do
+    subject { Shoes::ListBox.new(app, parent, negative_opts, input_block) }
+    it_behaves_like "object with negative dimensions"
   end
 
   it "should contain the correct items" do

--- a/spec/shoes/progress_spec.rb
+++ b/spec/shoes/progress_spec.rb
@@ -30,11 +30,13 @@ describe Shoes::Progress do
     end
   end
 
-  context"relative dimensions from parent" do
-    let(:relative_opts) { { left: left, top: top, width: relative_width, height: relative_height } }
-
+  describe "relative dimensions from parent" do
     subject { Shoes::Progress.new(app, parent, relative_opts, input_block) }
-
     it_behaves_like "object with relative dimensions"
+  end
+
+  describe "negative dimensions" do
+    subject { Shoes::Progress.new(app, parent, negative_opts, input_block) }
+    it_behaves_like "object with negative dimensions"
   end
 end

--- a/spec/shoes/shared_examples/dimensions.rb
+++ b/spec/shoes/shared_examples/dimensions.rb
@@ -10,11 +10,23 @@ end
 shared_examples_for "object with relative dimensions" do
   let(:relative_width) { 0.5 }
   let(:relative_height) { 0.5 }
+  let(:relative_opts) { { left: left, top: top, width: relative_width, height: relative_height } }
 
-  it "should initialize" do
+  it "should initialize based on parent dimensions" do
     subject.left.should == left
     subject.top.should == top
     subject.width.should == parent.width / 2
     subject.height.should == parent.height / 2
+  end
+end
+
+shared_examples_for "object with negative dimensions" do
+  let(:negative_opts){ {left: left, top: top, width: -width, height: -height} }
+
+  it "should initialize based on parent dimensions" do
+    subject.left.should == left
+    subject.top.should == top
+    subject.width.should == parent.width - width
+    subject.height.should == parent.height - height
   end
 end

--- a/spec/shoes/slot_spec.rb
+++ b/spec/shoes/slot_spec.rb
@@ -12,10 +12,12 @@ describe Shoes::Rect do
   it_behaves_like "object with dimensions"
 
   describe "relative dimensions from parent" do
-    let(:relative_opts) { { left: left, top: top, width: relative_width, height: relative_height } }
-
     subject { Shoes::Slot.new(app, parent, relative_opts) }
-
     it_behaves_like "object with relative dimensions"
+  end
+
+  describe "negative dimensions" do
+    subject { Shoes::Slot.new(app, parent, negative_opts) }
+    it_behaves_like "object with negative dimensions"
   end
 end


### PR DESCRIPTION
If a `width` or `height` are negative, we'll base the dimensions relative to the parent (if the parent is present).

As the relative + negative calculations got more complicated, I factored it out into smaller methods with a little meta-programming to glue it together. Hopefully the small methods and naming keeps that straight-forward.

I also added shared spec examples for negative dimensions across the DSL types that used the relative dimensions shared example before. The negative functionality is also independently tested against the `Dimensions` class itself, so I don't know whether those shared examples are superfluous or helpful on the whole, but I thought I'd add them anyway.

Should resolve #411.
