### PR TITLE
Fix for readlink following on Mac OS X

### DIFF
--- a/bin/shoes
+++ b/bin/shoes
@@ -4,14 +4,16 @@ mac_readlink_f () {
   # completely stolen from http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
   TARGET_FILE=$1
 
-  cd `dirname $TARGET_FILE`
+  NEXT_DIR=`dirname $TARGET_FILE`
+  cd ./$NEXT_DIR
   TARGET_FILE=`basename $TARGET_FILE`
 
   # Iterate down a (possible) chain of symlinks
   while [ -L "$TARGET_FILE" ]
   do
     TARGET_FILE=`readlink $TARGET_FILE`
-    cd `dirname $TARGET_FILE`
+    NEXT_DIR=`dirname $TARGET_FILE`
+    cd ./$NEXT_DIR
     TARGET_FILE=`basename $TARGET_FILE`
   done
 
@@ -35,5 +37,5 @@ SCRIPTPATH=$(dirname "$SCRIPT")
 
 RUBYSHOES="$SCRIPTPATH/ruby-shoes"
 
-cmd="jruby --1.9 $RUBYSHOES ${swt_opt:-} ${1}"
+cmd="jruby --1.9 ${swt_opt:-} $RUBYSHOES ${1}"
 exec $cmd


### PR DESCRIPTION
Working on a Mac (10.8.5), and after pulling down master recently, I started getting failures running `bin/shoes`:

```
✔ ♥♥♡♡~/source/shoes4 [jruby] (master)*:bin/shoes samples/simple-form.rb
bin/shoes: line 7: cd: bin: No such file or directory
Error opening script file: /Users/jclark/source/shoes4/ruby-shoes (No such file or directory)
```

After some experimenting, I found the line in `bin/shoes` where it called `cd `dirname $TARGET_FILE`` wasn't behaving properly under my shell. Specifically it was giving the error above, and not passing anything to cd to change the current directory.

I'm not the strongest bash dev and keen for any better solutions/explanation anyone might have. That said, the changes appear to be working for me :smile: 

Last tidbit that might matter for more context:

```
✔ ♥♥♡♡~/source/shoes4 [jruby] (bin_shoes_fix)*:/bin/sh --version
GNU bash, version 3.2.48(1)-release (x86_64-apple-darwin12)
Copyright (C) 2007 Free Software Foundation, Inc.
```
