### PR TITLE
Implement style method for default text block styles

### DIFF
--- a/lib/shoes/app.rb
+++ b/lib/shoes/app.rb
@@ -154,6 +154,7 @@ class Shoes
     def set_initial_attributes
       @app                = self
       @style              = default_styles
+      @element_styles     = {}
       @contents           = []
       @unslotted_elements = []
       @mouse_motion       = []

--- a/lib/shoes/slot.rb
+++ b/lib/shoes/slot.rb
@@ -23,14 +23,15 @@ class Shoes
     end
 
     def init_attributes(app, parent, opts, blk)
-      @app          = app
-      @parent       = parent
-      @contents     = SlotContents.new
-      @style        = {}
-      @blk          = blk
-      @dimensions   = Dimensions.new parent, opts
-      @fixed_height = height || false
-      @prepending   = false
+      @app            = app
+      @parent         = parent
+      @contents       = SlotContents.new
+      @style          = {}
+      @element_styles = {}
+      @blk            = blk
+      @dimensions     = Dimensions.new parent, opts
+      @fixed_height   = height || false
+      @prepending     = false
       set_default_dimension_values
 
       init_values_from_options(opts)

--- a/samples/sample56.rb
+++ b/samples/sample56.rb
@@ -1,0 +1,10 @@
+# sample56.rb
+Para = Shoes::Para
+Shoes.app :width => 200, :height => 160 do
+  style Para, :align => 'center', :stroke => pink, :size => 30
+  stack do
+    para "hello"
+    para "hello", :size => 10, :stroke => red
+    para "hello"
+  end
+end

--- a/spec/shoes/shared_examples/dsl.rb
+++ b/spec/shoes/shared_examples/dsl.rb
@@ -32,6 +32,7 @@ shared_examples "DSL container" do
     shape
     stroke
     strokewidth
+    style
   ].each do |method|
     include_examples "#{method} DSL method"
   end

--- a/spec/shoes/shared_examples/dsl/style.rb
+++ b/spec/shoes/shared_examples/dsl/style.rb
@@ -1,0 +1,32 @@
+shared_examples_for "style DSL method" do
+  describe "setting new defaults for text block" do
+    let(:stroke) { Shoes::COLORS[:chartreuse] }
+    let(:size)   { 42 }
+    let(:fill)   { Shoes::COLORS[:peru] }
+    let(:font )  { "SOME FONT" }
+    let(:style)  { {:stroke => stroke, :size => size, :fill => fill, :font => font} }
+
+    %w(Banner Title Subtitle Tagline Caption Para Inscription).each do |text_block|
+      describe text_block do
+        let(:element) { dsl.public_send text_block.downcase, "Hello!" }
+        let(:klass) { Shoes.const_get(text_block) }
+
+        before :each do
+          dsl.style klass, style
+        end
+
+        it "creates element with appropriate class" do
+          element.class.should eq(klass)
+        end
+
+        it "sets size" do
+          element.font_size.should eq(size)
+        end
+
+        it "sets font" do
+          element.font.should eq(font)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request addresses #303. It sets default styles on text block classes, so that elements of that class use these defaults (though you can override them).

See samples/sample56.rb for a test

In my testing, Shoes 3 does not allow you to use this method to set defaults for shapes or backgrounds. These defaults do not apply, for example:

``` ruby
Shoes.app do
  style Background :margin => 20, :fill => orchid
  background lawngreen
end
```

So, for now, anyway, this method only has effect on TextBlock elements.
