### PR TITLE
Partial fix for TextBlock flowing

### DIFF
--- a/lib/shoes/mock/text_block.rb
+++ b/lib/shoes/mock/text_block.rb
@@ -12,6 +12,9 @@ class Shoes
       def get_size(*opts)
         [WIDTH, HEIGHT]
       end
+      def get_width
+        WIDTH
+      end
       def get_height
         HEIGHT
       end

--- a/lib/shoes/swt/text_block.rb
+++ b/lib/shoes/swt/text_block.rb
@@ -30,10 +30,14 @@ class Shoes
         text_layout.getBounds(0, @dsl.text.length - 1).height.tap{font.dispose}
       end
 
+      def get_width
+        text_layout, font = set_styles
+        text_layout.getBounds(0, @dsl.text.length - 1).width.tap{font.dispose}
+      end
+
       def get_size
         text_layout, font = set_styles
-        bounds = text_layout.getBounds(0, @dsl.text.length - 1)
-        font.dispose
+        bounds = text_layout.getBounds(0, @dsl.text.length - 1).tap{font.dispose}
         return bounds.width, bounds.height
       end
 

--- a/lib/shoes/text_block.rb
+++ b/lib/shoes/text_block.rb
@@ -48,7 +48,7 @@ class Shoes
     end
 
     def set_size left
-      self.width = (left + @parent.width <= app.width) ? @parent.width : app.width - left
+      self.width = @gui.get_width + @margin_left + @margin_right
       self.height = @gui.get_height + @margin_top + @margin_bottom
     end
 


### PR DESCRIPTION
I was doing some investigation on #373 to better understand how flowing
and layout worked in Shoes.

In looking at it, I found that while we were [grabbing the calculated height](https://github.com/shoes/shoes4/blob/master/lib/shoes/swt/text_block.rb#L27-L31) of a
text block from the SWT side, we were not doing the same properly from the width,
and were tromping the value when `Shoes::TextBlock#set_size` was called.
See https://github.com/shoes/shoes4/blob/master/lib/shoes/text_block.rb#L51, and
note how it only deals with the `app` and `@parent`, not the `@gui` width.

This doesn't address flowing multi-line text blocks at all, so we definitely still
have more to do to get #373 right. However, this at least gets smaller blocks of
text flowing more like they did in Shoes 3.

Thoughts? Is this worthwhile in the face of having to revamp the `TextBlock`
flowing entirely before an the alpha release? Not attached to the changes at all, but
thought I'd put them out there since the experiment yielded some fruit.
