### PR TITLE
Potential fix for relative vs absolute path

### DIFF
--- a/bin/shoes
+++ b/bin/shoes
@@ -1,18 +1,11 @@
 #!/usr/bin/env sh
 
-# This works around a problem that when the script tries to `cd $NEXT_DIR` to a
-# relative directory, it fails if not preceded with ./  `pwd` reports the right
-# location, so I'm baffled why this is necessary.
-#
-# This forces special treatment for absolute paths too. Also don't try to cd
-# on an empty $NEXT_DIR (link in same directory)
+# Don't try to cd on an empty $NEXT_DIR (link in same directory)
 mac_move_to_link_dir () {
-  LINK=$1
-  NEXT_DIR=$(dirname $LINK)
-  if [[ $NEXT_DIR == /* ]]; then
+  # Skip if already in link directory
+  NEXT_DIR=$(dirname $1)
+  if [[ -n "$NEXT_DIR" ]]; then
     cd $NEXT_DIR
-  elif [[ -n "$NEXT_DIR" ]]; then # Skip if already in link directory
-    cd ./$NEXT_DIR
   fi
 }
 
@@ -27,6 +20,9 @@ mac_readlink_f () {
     echo $LINK
     return
   fi
+
+  # http://bosker.wordpress.com/2012/02/12/bash-scripters-beware-of-the-cdpath/
+  unset CDPATH
 
   # Look up links until we find something that is not a symlink
   while [ -L "$LINK" ] ; do


### PR DESCRIPTION
Following instructions on `pirate_game` (https://github.com/davy/pirate_game) against Shoes4 master, found that the
`bin/shoes` script for my installed gem wouldn't run right. Although I did get the bin/shoes shell script, it would fall over on `cd ./$NEXT_DIR` when run against a fully qualified path (i.e. `/Users/jclark/.rbenv/versions/jruby-1.7.8/lib/ruby/gems/shared/gems/shoes-4.0.0.pre1/bin/shoes`).

My modified instructions of interest (your paths may vary):

```
$ git clone http://github.com/shoes/shoes4
$ git checkout master
$ gem build shoes.gemspec
$ gem install shoes-4.0.0.pre1.gem
$ alias shoes4='/Users/jclark/.rbenv/versions/jruby-1.7.8/lib/ruby/gems/shared/gems/shoes-4.0.0.pre1/bin/shoes'
$ shoes4 samples/sample27.rb
```

My bash scripting isn't awesome, so definitely keen for pointers. At the very least, seems like extracting a separate function is called for, but it's late and I wanted to post this before collapsing :sleeping: 

Also curious to confirm this will work right with the post-install option that was discussed over in #231.
