### PR TITLE
Text cursor tidy

### DIFF
--- a/lib/shoes/swt/text_block_cursor_painter.rb
+++ b/lib/shoes/swt/text_block_cursor_painter.rb
@@ -18,9 +18,8 @@ class Shoes
         layout = choose_layout
         position = layout.get_location(relative_cursor)
 
-        cursor = textcursor(layout.line_height)
-        cursor.move(layout.left + position.x, layout.top + position.y)
-        cursor.show
+        textcursor.move(layout.left + position.x, layout.top + position.y)
+        textcursor.show
       end
 
       def first_layout
@@ -80,9 +79,15 @@ class Shoes
         @dsl.cursor - first_layout.text.length
       end
 
-      def textcursor(line_height)
-        @dsl.textcursor ||= @dsl.app.line(0, 0, 0, line_height, hidden: true,
+      def textcursor
+        @dsl.textcursor ||= @dsl.app.line(0, 0, 0, cursor_height, hidden: true,
                                           strokewidth: 1, stroke: @dsl.app.black)
+      end
+
+      # This could be smarter, basing height on the actual line the cursor's
+      # in. For now, just use the first line's height.
+      def cursor_height
+        first_layout.layout.get_line_bounds(0).height
       end
 
       def remove_textcursor

--- a/lib/shoes/swt/text_block_fitter.rb
+++ b/lib/shoes/swt/text_block_fitter.rb
@@ -127,12 +127,6 @@ class Shoes
         @top = top
       end
 
-      # We assume the text layout doesn't have varying line heights, so we can
-      # treat the first line as the typical height for the whole text block.
-      def line_height
-        @layout.get_line_bounds(0).height
-      end
-
       def get_location(cursor)
         @layout.get_location(cursor, false)
       end

--- a/spec/swt_shoes/text_block_cursor_painter_spec.rb
+++ b/spec/swt_shoes/text_block_cursor_painter_spec.rb
@@ -6,6 +6,8 @@ describe Shoes::Swt::TextBlockCursorPainter do
 
   let(:dsl) { double("dsl", app: shoes_app, textcursor: textcursor) }
   let(:textcursor) { double("textcursor") }
+  let(:text_layout) { double("text layout",
+                             get_line_bounds: double("line bounds", height: 10)) }
   let(:fitted_layouts) { [] }
 
   subject { Shoes::Swt::TextBlockCursorPainter.new(dsl, fitted_layouts) }
@@ -35,10 +37,10 @@ describe Shoes::Swt::TextBlockCursorPainter do
     let(:left) { 10 }
     let(:top)  { 20 }
     let(:position) { double(x: 5, y: 5) }
-    let(:line_height) { 10 }
     let(:first_layout) { double("first layout", text: "first",
                                 get_location: position,
-                                left: left, top: top, line_height: line_height) }
+                                get_line_bounds: text_layout, height: 10,
+                                left: left, top: top) }
 
     before(:each) do
       textcursor.stub(:move)
@@ -85,7 +87,7 @@ describe Shoes::Swt::TextBlockCursorPainter do
     context "with two layouts" do
       let(:second_layout) { double("second layout", text: "second",
                                    get_location: position,
-                                   left: left, top: top + 100, line_height: line_height) }
+                                   left: left, top: top + 100) }
       before(:each) do
         dsl.stub(:text).and_return(first_layout.text + second_layout.text)
         fitted_layouts << second_layout
@@ -148,8 +150,11 @@ describe Shoes::Swt::TextBlockCursorPainter do
   end
 
   describe "textcursor management" do
+    let(:first_layout) { double("first layout", layout: text_layout) }
+
     before(:each) do
       dsl.stub(:textcursor=)
+      fitted_layouts << first_layout
     end
 
     it "should create textcursor if missing" do
@@ -157,13 +162,13 @@ describe Shoes::Swt::TextBlockCursorPainter do
       shoes_app.stub(:line).and_return(textcursor)
       shoes_app.stub(:black)
 
-      result = subject.textcursor(0)
+      result = subject.textcursor
       expect(result).to eq(textcursor)
       expect(dsl).to have_received(:textcursor=).with(textcursor)
     end
 
     it "should just return textcursor if already there" do
-      result = subject.textcursor(0)
+      result = subject.textcursor
       expect(result).to eq(textcursor)
       expect(dsl).to_not have_received(:textcursor=)
     end


### PR DESCRIPTION
Revisions in the text cursor painting based on feedback from @PragTob on #493.
- Removing special logic that assumed order of checks for single layouts
- Clearer names in cursor positioning logic
- Moving calculation of cursor height (which was only consumer of an odd method on `FittedTextLayout`) into the cursor painter itself

Still feeling my way out on what to PR and what to just do on master... How would you have gone about this set of changes @PragTob?
