### PR TITLE
Use Right Click for Minesweeper flag placements

### DIFF
--- a/samples/expert-minesweeper-adjusted.rb
+++ b/samples/expert-minesweeper-adjusted.rb
@@ -263,9 +263,9 @@ Shoes.app width: 730, height: 450, title: 'Minesweeper' do
   click do |button, x, y|
     next if @field.game_over? || @field.all_found?
     fx, fy = ((x-@field.offset.first) / @field.cell_size).to_i, ((y-@field.offset.last) / @field.cell_size).to_i
-    @field.click!(fx, fy) if button == Shoes::LEFT_MOUSE_BUTTON
-    @field.flag!(fx, fy) if button == Shoes::RIGHT_MOUSE_BUTTON
-    @field.reveal!(fx, fy) if button == Shoes::MIDDLE_MOUSE_BUTTON
+    @field.click!(fx, fy) if button == 1
+    @field.reveal!(fx, fy) if button == 2
+    @field.flag!(fx, fy) if button == 3
 
     render_field
     alert("Winner!\nTotal time: #{@field.total_time}") if @field.all_found?

--- a/samples/expert-minesweeper.rb
+++ b/samples/expert-minesweeper.rb
@@ -256,9 +256,9 @@ Shoes.app width: 730, height: 450, title: 'Minesweeper' do
   click do |button, x, y|
     next if @field.game_over? || @field.all_found?
     fx, fy = ((x-@field.offset.first) / @field.cell_size).to_i, ((y-@field.offset.last) / @field.cell_size).to_i
-    @field.click!(fx, fy) if button == Shoes::LEFT_MOUSE_BUTTON
-    @field.flag!(fx, fy) if button == Shoes::RIGHT_MOUSE_BUTTON
-    @field.reveal!(fx, fy) if button == Shoes::MIDDLE_MOUSE_BUTTON
+    @field.click!(fx, fy) if button == 1
+    @field.reveal!(fx, fy) if button == 2
+    @field.flag!(fx, fy) if button == 3
 
     render_field
     alert("Winner!\nTotal time: #{@field.total_time}") if @field.all_found?


### PR DESCRIPTION
https://github.com/shoes/shoes4/issues/521

There was a small issue in this sample where the right click and middle click buttons were swapped. This pull request modifies the game so that right click reveals a flag and middle click clears a section of squares. Also, since   I am using the new mouse constants in this game, I decided to switch them in both minesweeper examples.
