### PR TITLE
Fix for cursor problem in samples/simple-editor.rb

### DIFF
--- a/lib/shoes/swt/redrawing_aspect.rb
+++ b/lib/shoes/swt/redrawing_aspect.rb
@@ -13,7 +13,7 @@ class Shoes
       NEED_TO_UPDATE = {Animation                        => [:eval_block],
                         ::Shoes::App                     => [:eval_block],
                         Button                           => [:eval_block],
-                        TextBlockCursorPainter           => [:redraw_textcursor_at],
+                        TextBlockCursorPainter           => [:move_textcursor],
                         Common::Clickable::ClickListener => [:eval_block],
                         KeypressListener                 => [:eval_block],
                         KeyreleaseListener               => [:eval_block],

--- a/lib/shoes/swt/text_block_cursor_painter.rb
+++ b/lib/shoes/swt/text_block_cursor_painter.rb
@@ -18,8 +18,9 @@ class Shoes
         layout = choose_layout
         x, y = new_position(layout)
 
+        # It's important to only move when necessary to avoid constant redraws
         unless textcursor.left == x && textcursor.top == y
-         redraw_textcursor_at(x, y)
+          move_textcursor(x, y)
         end
       end
 
@@ -28,8 +29,7 @@ class Shoes
         [layout.left + position.x, layout.top + position.y]
       end
 
-      # It's important to only move when necessary to avoid constant redraws
-      def redraw_textcursor_at(x, y)
+      def move_textcursor(x, y)
         textcursor.move(x, y)
         textcursor.show
       end

--- a/spec/swt_shoes/text_block_cursor_painter_spec.rb
+++ b/spec/swt_shoes/text_block_cursor_painter_spec.rb
@@ -134,11 +134,11 @@ describe Shoes::Swt::TextBlockCursorPainter do
         position_cursor(1)
         textcursor.stub(:left) { left + position.x }
         textcursor.stub(:top)  { top + position.y }
-        subject.stub(:redraw_textcursor_at)
+        subject.stub(:move_textcursor)
 
         subject.draw
 
-        expect(subject).to_not have_received(:redraw_textcursor_at)
+        expect(subject).to_not have_received(:move_textcursor)
       end
 
       it "should move within second layout" do
@@ -153,11 +153,11 @@ describe Shoes::Swt::TextBlockCursorPainter do
         position_cursor(-1)
         textcursor.stub(:left) { left + position.x }
         textcursor.stub(:top)  { top + 100 + position.y }
-        subject.stub(:redraw_textcursor_at)
+        subject.stub(:move_textcursor)
 
         subject.draw
 
-        expect(subject).to_not have_received(:redraw_textcursor_at)
+        expect(subject).to_not have_received(:move_textcursor)
       end
     end
 


### PR DESCRIPTION
samples/simple-editor.rb seemed to show an off-by-one the cursor.  In fact, the cursor was positioned right, but just lagging on redraws (i.e. cursor moved after drawing for it had already been done)

We update position only as needed and lean on RedrawingAspect for redraws.

cc/ @PragTob to make sure my use of `RedrawingAspect` here is correct, and @wasnotrice since #503 might have a merge conflict if this is landed first (there are a few textcursor painter changes happening that PR).
