### PR TITLE
Handle simple string values for dimensions.

### DIFF
--- a/lib/shoes/dimensions.rb
+++ b/lib/shoes/dimensions.rb
@@ -184,10 +184,11 @@ class Shoes
     end
 
     def init_with_arguments(left, top, width, height, opts)
-      self.left   = left
-      self.top    = top
+      self.left   = parse_input_value left
+      self.top    = parse_input_value top
       self.width  = width
       self.height = height
+
       general_options opts
     end
 
@@ -235,9 +236,28 @@ class Shoes
       if match
         match[1].to_f / 100.0
       else
-        # Shoes eats invalid values, so this protects against non-% strings
+        if valid_integer_string?(result)
+          result.to_i
+        else
+          nil
+        end
+      end
+    end
+
+    def parse_input_value(input)
+      if input.is_a?(Integer) || input.is_a?(Float)
+        input
+      elsif input.is_a? String
+        input.to_i
+
+        # valid_integer_string?(input) ? input.to_i : nil
+      else
         nil
       end
+    end
+
+    def valid_integer_string?(result)
+      result.to_i != 0 || result.include?("0")
     end
 
     def is_negative?(result)

--- a/spec/shoes/dimensions_spec.rb
+++ b/spec/shoes/dimensions_spec.rb
@@ -121,16 +121,39 @@ describe Shoes::Dimensions do
         its(:height) {should be_within(1).of 0.9 * parent.height}
       end
 
-      describe 'with invalid strings' do
-        subject {Shoes::Dimensions.new parent, left, top, "boo", "hoo"}
-        its(:width) {should be_nil}
-        its(:height) {should be_nil}
-      end
-
       describe 'with padded strings' do
         subject {Shoes::Dimensions.new parent, left, top, "  50 %  ", "\t- 50 %\n"}
         its(:width) {should be_within(1).of 0.5 * parent.width}
         its(:height) {should be_within(1).of 0.5 * parent.height}
+      end
+    end
+
+    describe 'with strings' do
+      describe 'with integer strings' do
+        subject {Shoes::Dimensions.new parent, "22", "20", "10", "10"}
+
+        its(:left) {should eq 22}
+        its(:top) {should eq 20}
+        its(:width) {should eq 10}
+        its(:height) {should eq 10}
+      end
+
+      describe 'with strings px' do
+        subject {Shoes::Dimensions.new parent, "10px", "10px", "0px", "100px"}
+
+        its(:left) {should eq 10}
+        its(:top) {should eq 10}
+        its(:width) {should eq 0}
+        its(:height) {should eq 100}
+      end
+
+      describe 'with invalid integer strings' do
+        subject {Shoes::Dimensions.new parent, "p100px", "xpo", "blob", "glob"}
+
+        its(:left) {should eq 0}
+        its(:top) {should eq 0}
+        its(:width) {should be_nil}
+        its(:height) {should be_nil}
       end
     end
 


### PR DESCRIPTION
Convert strings with integers to integers for dimensions width, height, left and
top params. For example, if the width param is "20px", convert it to 20 with
String#to_i.

Fixes #564.

This currently just handles `init_with_arguments` params. Should I expand it to cover `init_with_hash` and the `opts` param?

Thanks!
