### PR TITLE
stop animate the same way as on shoes3

### DIFF
--- a/lib/shoes/swt/animation.rb
+++ b/lib/shoes/swt/animation.rb
@@ -16,8 +16,10 @@ class Shoes
         @task = Proc.new do
           unless @app.real.disposed?
             eval_block
-            @dsl.increment_frame unless @dsl.stopped?
-            ::Swt.display.timer_exec(1000 / @dsl.framerate, @task) unless @dsl.removed?
+            unless @dsl.stopped?
+              @dsl.increment_frame 
+              ::Swt.display.timer_exec(1000 / @dsl.framerate, @task) unless @dsl.removed?
+            end
           end
         end
         ::Swt.display.timer_exec(1000 / @dsl.framerate, @task)


### PR DESCRIPTION
now it should be the same behavior in shoes3 and shoes4

``` ruby
Shoes.app do
  @animation = animate(20) {para "test"}
  button 'abort' do 
    @animation.stop
    @animation = nil
    @animation = animate(20) {para "test2"} 
  end
end
```

related #567 
