### PR TITLE
added image file check for background images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
-gem 'pry'
 
 gemspec


### PR DESCRIPTION
Whenever I tried to add a background picture with an invalid file, I was getting a bad hex color error. This was annoying me, so I added a simple check if it has a file pic file extension and raised and error un the image_pattern method instead of the new color method.

I added some tests to to check both errors and updated some specs along the way.

Any suggestions would be great.
