### PR TITLE
Fix TextBlock not accepting hex colors

### DIFF
--- a/lib/shoes/swt/text_block_painter.rb
+++ b/lib/shoes/swt/text_block_painter.rb
@@ -192,6 +192,7 @@ class Shoes
       def self.color_from_dsl(dsl_color, default = nil)
         return nil if dsl_color.nil? and default.nil?
         return color_from_dsl default if dsl_color.nil?
+        dsl_color = ::Shoes::Color.create(dsl_color)
         # TODO: mark color for garbage collection
         ::Swt::Color.new(Shoes.display, dsl_color.red, dsl_color.green, dsl_color.blue)
       end


### PR DESCRIPTION
As mentioned in #532, the sample now starts properly without crashing. However, the sample prints an object string and I'm not sure if this is related to my fix (Probably not).

![selection_022](https://f.cloud.github.com/assets/2042399/1958769/ac5ad5ec-821f-11e3-8cb2-bc815bce8c9f.png)

If I change [samples/good-clock.rb#L15](https://github.com/shoes/shoes4/blob/master/samples/good-clock.rb#L15) to use `span` instead of `strong`, it doesn't show an object string.
