### PR TITLE
Fix text block modifiers with additional parameters

### DIFF
--- a/spec/shoes/shared_examples/dsl/text_elements.rb
+++ b/spec/shoes/shared_examples/dsl/text_elements.rb
@@ -54,4 +54,15 @@ shared_examples_for "text element DSL methods" do
       expect{dsl.span *[link, link]}.not_to raise_error
     end
   end
+
+  describe 'para' do
+    context "with nested text fragments with parameters" do
+      Shoes::DSL::TEXT_STYLES.keys.each do |style|
+        it "handles opts properly for #{style}" do
+          para = dsl.para(dsl.send(style, style, stroke: '#ccc'))
+          expect(para.text).to eq(style.to_s)
+        end
+      end
+    end
+  end
 end

--- a/spec/shoes/text_block_spec.rb
+++ b/spec/shoes/text_block_spec.rb
@@ -207,14 +207,4 @@ describe Shoes::TextBlock do
       expect(helper.ins.parent).to eq helper.strong
     end
   end
-
-  context "with nested text fragments with parameters" do
-    it 'removes the style hash from text' do
-      text_styles = %w(code del em ins sub sup strong)
-      text_styles.each do |m|
-        para = app.app.para(app.app.send(m, m, stroke: '#ccc'))
-        expect(para.text).to eq(m)
-      end
-    end
-  end
 end


### PR DESCRIPTION
The options hash for the text block modifiers was previously not popped from
the modifier text.

Using pop_style to pop the last element if it's a hash, then merging the arrays.

I'll also add a couple more tests for the other text block modifiers.

Ref #582, #588
