### PR TITLE
Fix app.width on OSX 10.7+

### DIFF
--- a/lib/shoes/swt/app.rb
+++ b/lib/shoes/swt/app.rb
@@ -22,7 +22,6 @@ class Shoes
         attach_event_listeners
         initialize_scroll_bar
         @redrawing_aspect = RedrawingAspect.new self, Shoes.display
-        @overlay_scrollbar = @shell.getScrollbarsMode() == 2
       end
 
       def open
@@ -44,9 +43,13 @@ class Shoes
       def app
         self
       end
+      
+      def overlay_scrollbars?
+        @shell.getScrollbarsMode() == ::Swt::SWT::SCROLLBAR_OVERLAY
+      end
 
       def width
-        if @overlay_scrollbar
+        if overlay_scrollbars?
           @shell.client_area.width
         else
           @shell.getVerticalBar.getVisible ? (@shell.client_area.width + @shell.getVerticalBar.getSize.x) : @shell.client_area.width


### PR DESCRIPTION
Addresses #625

After a bit of research it looks like this should be a pretty quick fix. After OSX 10.7, the scroll bars are included in the client area since they disappear when not scrolling. That means the current app#width gives an app width that is too wide by 16 pixels (scroll bar width) on OSX 10.7+.

I chose to have the os name and release number initialized because after experimentation, I learned that `uname` is a pretty slow command so we don't want to call it more times than necessary. 

I'm definitely not an expert on this, and I could only test it on my own machine: OSX 10.9., so please check this out if you're on a different OSX!
