### PR TITLE
Initialize displace from dimensions hash

### DIFF
--- a/lib/shoes/dimensions.rb
+++ b/lib/shoes/dimensions.rb
@@ -196,8 +196,8 @@ class Shoes
     end
 
     def init_with_arguments(left, top, width, height, opts)
-      @displace_left = 0
-      @displace_top  = 0
+      @displace_left = opts.fetch(:displace_left, 0)
+      @displace_top  = opts.fetch(:displace_top, 0)
       general_options opts # order important for redrawing
       self.left   = parse_input_value left
       self.top    = parse_input_value top

--- a/spec/shoes/dimensions_spec.rb
+++ b/spec/shoes/dimensions_spec.rb
@@ -556,8 +556,8 @@ describe Shoes::Dimensions do
 
     before :each do
       # need to have a rough positon
-      subject.absolute_left = left
-      subject.absolute_top  = top
+      subject.absolute_left = 0
+      subject.absolute_top  = 0
     end
 
     describe 'displace_left' do
@@ -573,8 +573,15 @@ describe Shoes::Dimensions do
           subject.displace_left = displace_left
         end.not_to change {subject.absolute_left}
       end
+
+      context 'via opts' do
+        subject { Shoes::Dimensions.new(nil, 0, 0, 0, 0, displace_left: 10)}
+        it 'modifies element_left' do
+          expect(subject.element_left).to eql(10)
+        end
+      end
     end
-    
+
     describe 'displace_top' do
       let(:displace_top) {7}
 
@@ -589,8 +596,14 @@ describe Shoes::Dimensions do
           subject.displace_top = displace_top
         end.not_to change {subject.absolute_top}
       end
-    end
 
+      context 'via opts' do
+        subject { Shoes::Dimensions.new(nil, 0, 0, 0, 0, displace_top: 10)}
+        it 'modifies element_top' do
+          expect(subject.element_top).to eql(10)
+        end
+      end
+    end
 
   end
 


### PR DESCRIPTION
Values were being set onto `displace_left` and `displace_top`, but they weren't
getting picked up from the initial hash. This caused the layout on the game
of life sample to be weird.

Partial fix for one of the remaining issues on #538.
