### PR TITLE
Only call update_style when styles changed and then redraw

### DIFF
--- a/lib/shoes/common/style.rb
+++ b/lib/shoes/common/style.rb
@@ -8,14 +8,26 @@ class Shoes
       #
       # Returns the updated style
       def style(new_styles = nil)
-        change_style(new_styles) unless new_styles.nil?
+        update_style(new_styles) if need_to_update_style?(new_styles)
         @style
       end
 
       private
-      def change_style(new_styles)
+      def update_style(new_styles)
         normalized_style = StyleNormalizer.new.normalize new_styles
         @style.merge! normalized_style
+      end
+
+      def need_to_update_style?(new_styles)
+        new_styles && style_changed?(new_styles)
+      end
+
+      # check necessary because update_style trigger a redraw in the redrawing
+      # aspect and we want to avoid unnecessary redraws
+      def style_changed?(new_styles)
+        new_styles.each_pair.any? do |key, value|
+          @style[key] != value
+        end
       end
     end
   end

--- a/lib/shoes/swt/redrawing_aspect.rb
+++ b/lib/shoes/swt/redrawing_aspect.rb
@@ -25,7 +25,7 @@ class Shoes
 
       # These need to trigger a redraw
       SAME_POSITION    = {Common::Toggle         => [:toggle],
-                          ::Shoes::Common::Style => [:style],
+                          ::Shoes::Common::Style => [:update_style],
                           ::Shoes::TextBlock     => [:replace]}
 
       CHANGED_POSITION = {::Shoes::CommonMethods => [:_position],

--- a/spec/shoes/common/style_spec.rb
+++ b/spec/shoes/common/style_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe Shoes::Common::Style do
+
+  class StyleTester
+    include Shoes::Common::Style
+
+    def initialize(style = {})
+      @style = style
+    end
+  end
+
+  subject {StyleTester.new}
+
+  its(:style) {should eq Hash.new}
+
+  describe 'changing the style trhough #style(hash)' do
+    let(:changed_style) {{key: 'value'}}
+
+    before :each do
+      subject.style changed_style
+    end
+
+    it 'returns the changed style' do
+      expect(subject.style).to eq changed_style
+    end
+
+    it 'does update values for new values' do
+      subject.style new_key: 'new value'
+      expect(subject.style[:new_key]).to eq 'new value'
+    end
+
+    # these specs are rather extensive as they are performance critical for
+    # redrawing
+    describe 'calling or not calling #update_style' do
+      it 'does not call #update_style if no key value pairs changed' do
+        expect(subject).not_to receive(:update_style)
+        subject.style changed_style
+      end
+
+      it 'does not call #update_style if called without arg' do
+        expect(subject).not_to receive(:update_style)
+        subject.style
+      end
+
+      it 'does call #update_style if the values change' do
+        expect(subject).to receive(:update_style)
+        subject.style key: 'new value'
+      end
+
+      it 'does call #update_style if there is a new key-value' do
+        expect(subject).to receive(:update_style)
+        subject.style new_key: 'value'
+      end
+    end
+  end
+
+end

--- a/spec/shoes/shared_examples/style.rb
+++ b/spec/shoes/shared_examples/style.rb
@@ -8,17 +8,17 @@ shared_examples_for "object with style" do
 
   describe 'changing style' do
     before do
-      subject.stub(:change_style)
+      subject.stub(:update_style)
     end
 
     it 'calls change_style when the style is changed' do
       subject.style :left => 50
-      expect(subject).to have_received(:change_style)
+      expect(subject).to have_received(:update_style)
     end
 
     it 'does not call change_style when style is called without args' do
       subject.style
-      expect(subject).not_to have_received(:change_style)
+      expect(subject).not_to have_received(:update_style)
     end
   end
 end


### PR DESCRIPTION
- PERFORMANCE!
- fixes #654
- renamed change_style --> update_style (seemed like a better fit)
- do not redraw if the value is just queried and do not update if
  the values of the hash don't change
- maybe update the expert-game-of-life-adjusted.rb now?

Would be happy of a quick review of this so it can go in as fast as possible! =)

Happy pre Easter everyone!
Tobi
