### PR TITLE
Allow click option on link to take a proc

### DIFF
--- a/lib/shoes/link.rb
+++ b/lib/shoes/link.rb
@@ -19,8 +19,12 @@ class Shoes
       if blk
         @blk = blk
       elsif opts.include?(:click)
-        # Slightly awkward, but we need App, not InternalApp, to call visit
-        @blk = Proc.new { app.app.visit(opts[:click]) }
+        if opts[:click].respond_to?(:call)
+          @blk = opts[:click]
+        else
+          # Slightly awkward, but we need App, not InternalApp, to call visit
+          @blk = Proc.new { app.app.visit(opts[:click]) }
+        end
       end
     end
 

--- a/spec/shoes/link_spec.rb
+++ b/spec/shoes/link_spec.rb
@@ -53,11 +53,21 @@ describe Shoes::Link do
       end
     end
 
-    context "with click option" do
+    context "with click option as text" do
       subject { Shoes::Link.new(internal_app, nil, texts, click: "/url") }
 
       it "should visit the url" do
         expect(app).to receive(:visit).with("/url")
+        subject.execute_link
+      end
+    end
+
+    context "with click option as Proc" do
+      let(:block) { double("block", call: nil) }
+      subject { Shoes::Link.new(internal_app, nil, texts, click: block) }
+
+      it "calls the block" do
+        expect(block).to receive(:call)
         subject.execute_link
       end
     end


### PR DESCRIPTION
Notice in the course of another fix that I was only allowing visit strings in the link's options hash, while Shoes 3 allows for passing a proc through instead.

Fixed! :link: 
