### PR TITLE
Add TextBlock#contents

### DIFF
--- a/lib/shoes/text_block.rb
+++ b/lib/shoes/text_block.rb
@@ -6,7 +6,7 @@ class Shoes
     include Common::Clickable
     include DimensionsDelegations
 
-    attr_reader   :gui, :parent, :text, :links, :app, :text_styles, :dimensions, :opts
+    attr_reader   :gui, :parent, :text, :contents, :links, :app, :text_styles, :dimensions, :opts
     attr_accessor :calculated_width, :font, :font_size, :cursor, :textcursor
 
     def initialize(app, parent, text, font_size, opts = {})

--- a/spec/shoes/text_block_spec.rb
+++ b/spec/shoes/text_block_spec.rb
@@ -5,7 +5,7 @@ describe Shoes::TextBlock do
   include_context "dsl app"
 
   let(:text_link) { Shoes::Link.new(app, parent, ['Hello']) }
-  let(:text) { ["#{text_link}, world!"] }
+  let(:text) { [text_link, ", world!"] }
   subject(:text_block) { Shoes::TextBlock.new(app, parent, text, 99, {app: app}) }
 
   describe "initialize" do
@@ -56,6 +56,12 @@ describe Shoes::TextBlock do
     it "allows two arguments" do
       text_block.replace "Goodbye Cruel World, ", text_link
       expect(text_block.text).to eq("Goodbye Cruel World, Hello")
+    end
+  end
+
+  describe "#contents" do
+    it "returns text elements" do
+      expect(text_block.contents).to eql([text_link, ", world!"])
     end
   end
 

--- a/spec/swt_shoes/text_block_spec.rb
+++ b/spec/swt_shoes/text_block_spec.rb
@@ -104,8 +104,8 @@ describe Shoes::Swt::TextBlock do
     end
   end
 
-  it "should test links, contents and clearing" do
-    pending "Waiting on re-enabling links and implementing contents"
+  it "should test links and clearing" do
+    pending "Waiting on link clearing"
   end
 
   def create_layout(width, height, text="layout text")


### PR DESCRIPTION
The proper values for this were already being saved on the `TextBlock` class, so we just needed an accessor.

Resolves #163.
