### PR TITLE
Support clearing on links

### DIFF
--- a/lib/shoes/link.rb
+++ b/lib/shoes/link.rb
@@ -41,5 +41,9 @@ class Shoes
       @gui.in_bounds?(x, y)
     end
 
+    def clear
+      @gui.clear
+    end
+
   end
 end

--- a/lib/shoes/swt/common/clickable.rb
+++ b/lib/shoes/swt/common/clickable.rb
@@ -30,6 +30,12 @@ class Shoes
           app.add_listener event, listener
         end
 
+        def remove_listener_for(swt_object = self, event)
+          dsl_object = swt_object.dsl
+          app.clickable_elements.delete(dsl_object)
+          app.remove_listener ::Swt::SWT::MouseDown, swt_object.click_listener
+          app.remove_listener ::Swt::SWT::MouseUp, swt_object.click_listener
+        end
 
         class ClickListener
           include ::Swt::Widgets::Listener

--- a/lib/shoes/swt/link.rb
+++ b/lib/shoes/swt/link.rb
@@ -17,6 +17,11 @@ class Shoes
         clickable self, Proc.new { dsl.execute_link }
       end
 
+      def clear
+        @link_segments.clear
+        remove_listener_for(self)
+      end
+
       def create_links_in(layout_ranges)
         @link_segments.clear
         layout_ranges.each do |layout, range|

--- a/lib/shoes/swt/text_block.rb
+++ b/lib/shoes/swt/text_block.rb
@@ -106,27 +106,18 @@ class Shoes
 
       def clear
         super
-        clear_links
+        clear_contents
       end
 
       def replace(*values)
-        clear_links
+        clear_contents
         @dsl.update_text_styles(values)
-      end
-
-      def contents
       end
 
       private
 
-      def clear_links
-        @dsl.links.each do |link|
-          app.clickable_elements.delete link
-          ln = link.click_listener
-          app.remove_listener ::Swt::SWT::MouseDown, ln if ln
-          app.remove_listener ::Swt::SWT::MouseUp, ln if ln
-        end
-        @dsl.links.clear
+      def clear_contents
+        @dsl.links.each(&:clear)
       end
     end
 

--- a/lib/shoes/text_block.rb
+++ b/lib/shoes/text_block.rb
@@ -6,7 +6,7 @@ class Shoes
     include Common::Clickable
     include DimensionsDelegations
 
-    attr_reader   :gui, :parent, :text, :contents, :links, :app, :text_styles, :dimensions, :opts
+    attr_reader   :gui, :parent, :text, :contents, :app, :text_styles, :dimensions, :opts
     attr_accessor :calculated_width, :font, :font_size, :cursor, :textcursor
 
     def initialize(app, parent, text, font_size, opts = {})
@@ -16,7 +16,6 @@ class Shoes
       @opts               = opts
       @font               = @app.font || DEFAULT_TEXTBLOCK_FONT
       @font_size          = @opts[:size] || font_size
-      @links              = []
       @contents           = texts
       @text               = texts.map(&:to_s).join
       @text_styles        = gather_text_styles(self, texts)
@@ -103,6 +102,12 @@ class Shoes
 
     def has_textcursor?
       @textcursor
+    end
+
+    def links
+      @contents.select do |element|
+        element.is_a?(Shoes::Link)
+      end
     end
 
     private

--- a/spec/swt_shoes/link_spec.rb
+++ b/spec/swt_shoes/link_spec.rb
@@ -28,6 +28,8 @@ describe Shoes::Swt::Link do
     before(:each) do
       shoes_app.stub(:add_listener)
       shoes_app.stub(:add_clickable_element)
+
+      swt_app.stub(:clickable_elements) { [] }
     end
 
     it "clears existing" do
@@ -42,6 +44,16 @@ describe Shoes::Swt::Link do
                                 [layout, [0..5]]
                               ])
       expect(subject.link_segments.count).to eql(2)
+    end
+
+    it "clears links" do
+      # One remove call each for mouse down, mouse up
+      expect(swt_app).to receive(:remove_listener).twice
+
+      subject.create_links_in([[layout, 0..10]])
+      subject.clear
+
+      expect(subject.link_segments).to be_empty
     end
   end
 end

--- a/spec/swt_shoes/text_block_spec.rb
+++ b/spec/swt_shoes/text_block_spec.rb
@@ -104,8 +104,23 @@ describe Shoes::Swt::TextBlock do
     end
   end
 
-  it "should test links and clearing" do
-    pending "Waiting on link clearing"
+  context "links" do
+    let(:link)     { Shoes::Link.new(shoes_app, subject, ["link"])  }
+
+    before(:each) do
+      dsl.stub(:links) { [link] }
+      swt_app.stub(:remove_listener)
+    end
+
+    it "clears links" do
+      expect(link).to receive(:clear)
+      subject.clear
+    end
+
+    it "clears links on replace" do
+      expect(link).to receive(:clear)
+      subject.replace("text")
+    end
   end
 
   def create_layout(width, height, text="layout text")


### PR DESCRIPTION
Because links register themselves into the app's click listeners, it's important that we clean them up when a link element is removed.

Support was already there for passing on a `clear` message to the DSL's `@gui` instance variable--we just didn't have it implemented right in `Shoes::Swt::Link`.

`replace` was also calling into the same clearing routines which weren't working, so this change also got that up to snuff.

This fixes #631 and #645, and gets rid of one of our few remaining pending specs.
