### PR TITLE
Account for margin in TextBlock absolutes

### DIFF
--- a/lib/shoes/swt/text_block.rb
+++ b/lib/shoes/swt/text_block.rb
@@ -86,15 +86,17 @@ class Shoes
       end
 
       def set_absolutes_for_one_layout
-        @dsl.absolute_right = @dsl.absolute_left + last_bounds.width
-        @dsl.absolute_bottom = @dsl.absolute_top + layout_height(first_layout)
+        @dsl.absolute_right = @dsl.absolute_left + last_bounds.width + margin_right
+        @dsl.absolute_bottom = @dsl.absolute_top + layout_height(first_layout) +
+                                margin_top + margin_bottom
         @dsl.absolute_top = @dsl.absolute_bottom - line_height(first_layout)
         @dsl.calculated_width = first_layout.bounds.width
       end
 
       def set_absolutes_for_two_layouts(next_line_start)
-        @dsl.absolute_right =  @dsl.parent.absolute_left + last_bounds.width
-        @dsl.absolute_bottom = next_line_start + layout_height(last_layout)
+        @dsl.absolute_right =  @dsl.parent.absolute_left + last_bounds.width + margin_right
+        @dsl.absolute_bottom = next_line_start + layout_height(last_layout) +
+                                margin_top + margin_bottom
         @dsl.absolute_top = @dsl.absolute_bottom - line_height(last_layout)
         @dsl.calculated_width = last_layout.bounds.width
       end

--- a/lib/shoes/text_block.rb
+++ b/lib/shoes/text_block.rb
@@ -85,7 +85,7 @@ class Shoes
 
     # If an explicit width's set, it's used. If not, we look to the parent.
     def containing_width
-      @dimensions.width || parent.width
+      (@dimensions.width || parent.width) - (margin_left + margin_right)
     end
 
     # This is the width the text block initially wants to try and fit into.

--- a/spec/swt_shoes/text_block_spec.rb
+++ b/spec/swt_shoes/text_block_spec.rb
@@ -5,7 +5,10 @@ describe Shoes::Swt::TextBlock do
 
   let(:height) { 100 }
   let(:width)  { 200 }
-  let(:dsl) { double("dsl", app: shoes_app).as_null_object }
+  let(:margin) { 10 }
+  let(:dsl) { double("dsl", app: shoes_app,
+                     margin_left: 0, margin_right: 0,
+                     margin_top: 0, margin_bottom: 0).as_null_object }
 
   subject { Shoes::Swt::TextBlock.new(dsl) }
 
@@ -24,18 +27,18 @@ describe Shoes::Swt::TextBlock do
       stub_layout(layout)
     end
 
-    it "should not strink when enough containing width" do
+    it "should not shrink when enough containing width" do
       expect(layout).to receive(:setWidth).never
       subject.generate_layout(width + 10, "text text")
     end
 
-    it "should shrink when too long for containing width" do
+    it "shrinks when too long for containing width" do
       containing_width = width - 10
       expect(layout).to receive(:setWidth).with(containing_width)
       subject.generate_layout(containing_width, "text text")
     end
 
-    it "should pass text along to layout" do
+    it "passes text along to layout" do
       expect(layout).to receive(:setText).with("text text")
       subject.generate_layout(0, "text text")
     end
@@ -63,7 +66,7 @@ describe Shoes::Swt::TextBlock do
         layout.stub(:line_count)   { 1 }
       end
 
-      it "should position for single line of text" do
+      it "positions single line of text" do
         expect(dsl).to receive(:absolute_right=).with(layout_width + 50)
         expect(dsl).to receive(:absolute_bottom=).with(layout_height)
         expect(dsl).to receive(:absolute_top=).with(layout_height - line_height)
@@ -71,7 +74,18 @@ describe Shoes::Swt::TextBlock do
         subject.contents_alignment(current_position)
       end
 
-      it "should push to next line if ends in newline" do
+      it "positions single line with margin" do
+        dsl.stub(margin_left: margin, margin_right: margin,
+                 margin_top: margin, margin_bottom: margin)
+
+        expect(dsl).to receive(:absolute_right=).with(layout_width + 50 + margin)
+        expect(dsl).to receive(:absolute_bottom=).with(layout_height + 2 * margin)
+        expect(dsl).to receive(:absolute_top=).with(layout_height - line_height)
+
+        subject.contents_alignment(current_position)
+      end
+
+      it "pushes to next line if ends in newline" do
         layout.stub(:text) { "text\n" }
 
         expect(dsl).to receive(:absolute_right=).with(50)
@@ -86,17 +100,28 @@ describe Shoes::Swt::TextBlock do
       before(:each) do
         dsl.stub(:parent) { double("dsl parent", absolute_left: 0) }
         dsl.stub(:absolute_bottom) { layout_height }
-      end
 
-      it "should set position for fitting two layouts" do
         current_position.next_line_start = 0
 
         fitter.stub(:fit_it_in) {
           [:unused_layout, double("fitted_layout", layout: layout)]
         }
+      end
 
+      it "positions in two layouts" do
         expect(dsl).to receive(:absolute_right=).with(layout_width)
         expect(dsl).to receive(:absolute_bottom=).with(layout_height)
+        expect(dsl).to receive(:absolute_top=).with(layout_height - line_height)
+
+        subject.contents_alignment(current_position)
+      end
+
+      it "positions in two layouts with margins" do
+        dsl.stub(margin_left: margin, margin_right: margin,
+                 margin_top: margin, margin_bottom: margin)
+
+        expect(dsl).to receive(:absolute_right=).with(layout_width + margin)
+        expect(dsl).to receive(:absolute_bottom=).with(layout_height + 2 * margin)
         expect(dsl).to receive(:absolute_top=).with(layout_height - line_height)
 
         subject.contents_alignment(current_position)


### PR DESCRIPTION
The absolute dimension elements should take into account their element margins. Because `TextBlock` fitting was manually overriding the absolutes to get flowing right, they also needed to explicitly take margins into account and weren't doing so.

Resolves #653 in which @PragTob was spot on about this being an absolute vs element problem. Good eye!
