### PR TITLE
Clear resources after disposing

### DIFF
--- a/lib/shoes/swt/text_block.rb
+++ b/lib/shoes/swt/text_block.rb
@@ -21,7 +21,7 @@ class Shoes
       end
 
       def dispose
-        @fitted_layouts.map &:dispose
+        dispose_existing_layouts
       end
 
       # has a painter, nothing to do
@@ -118,6 +118,7 @@ class Shoes
 
       def dispose_existing_layouts
         @fitted_layouts.map(&:dispose)
+        @fitted_layouts.clear
       end
     end
 

--- a/lib/shoes/swt/text_font_factory.rb
+++ b/lib/shoes/swt/text_font_factory.rb
@@ -20,6 +20,7 @@ class Shoes
 
       def dispose
         @fonts.each { |font| font.dispose unless font.disposed? }
+        @fonts.clear
       end
     end
   end

--- a/lib/shoes/swt/text_style_factory.rb
+++ b/lib/shoes/swt/text_style_factory.rb
@@ -13,6 +13,7 @@ class Shoes
 
       def dispose
         @colors.each { |color| color.dispose unless color.disposed? }
+        @colors.clear
       end
 
       def create_style(font, foreground, background, opts)


### PR DESCRIPTION
Noticed in testing out samples that we could get crashes from trying to paint text block layouts after we'd already freed the underlying SWT text layout objects. This shouldn't happen so when we dispose of resources we ought to just clear out the underlying objects as well.

Note that this is a blocker for the alpha release since it crashes on one of the known good samples (`samples/expert-definr.rb`)
