### PR TITLE
start being able to be positioned relative to parent extent

### DIFF
--- a/lib/shoes/dimension.rb
+++ b/lib/shoes/dimension.rb
@@ -130,7 +130,9 @@ class Shoes
       # make much sense and are problematic. E.g. through calculations users
       # might end up with values like 5.14 meaning 5 pixel which would get
       # interpreted as 514% of the parent
-      result.is_a?(Float) && result <= 1
+      # Also check for existance of parent because otherwise relative
+      # calculation makes no sense
+      result.is_a?(Float) && result <= 1 && @parent
     end
 
     def calculate_relative(result)

--- a/spec/shoes/dimension_spec.rb
+++ b/spec/shoes/dimension_spec.rb
@@ -168,6 +168,15 @@ describe Shoes::Dimension do
       subject.start = 1.01
       expect(subject.start).to eq 1.01
     end
+
+    context 'without a parent' do
+      let(:parent_dimension) {nil}
+
+      it 'just takes the relative value' do
+        subject.start = 0.8
+        expect(subject.start).to eq 0.8
+      end
+    end
   end
 
   describe 'absolute_start' do


### PR DESCRIPTION
- fixes #690
- I introduced the constraint of the value being smaller than 1
  because it should be rare for elements to be positioned outside
  of their parent container and if so not relative to it. I'm
  scared about cases where people do calculations ending up in
  floats and suddenly 100.3 is interpreted as 100 times the
  width of the parent. Would be weird.
- I'm a bit unhappy with the code have a quick look please @wasnotrice @jasonrclark
