### PR TITLE
Parent method

### DIFF
--- a/lib/shoes/slot.rb
+++ b/lib/shoes/slot.rb
@@ -96,14 +96,6 @@ class Shoes
       "#<#{self.class}:0x#{hash.to_s(16)} @contents=#{@contents.inspect} and so much stuff literally breaks the memory limit. Look at it selectively.>"
     end
 
-    def parent
-      if @parent == @app.top_slot
-        "(Shoes)"
-      else
-      "(#{@parent.class})"
-      end
-    end
-
     protected
     CurrentPosition = Struct.new(:x, :y, :next_line_start)
 

--- a/spec/shoes/app_spec.rb
+++ b/spec/shoes/app_spec.rb
@@ -346,6 +346,25 @@ describe Shoes::App do
     end
   end
 
+  describe "#parent" do
+    context "when parent is top slot" do
+      let(:input_block) {Proc.new{flow{@parent = parent}}}
+      let(:internal_app) {subject.instance_variable_get(:@__app__)}
+    
+      it "#parent returns the top_slot" do
+        expect @parent == internal_app.top_slot
+      end
+    end
+
+    context "when parent is not top slot" do
+      let(:input_block) {Proc.new{stack{flow{@parent = parent}}}}
+      it 'returns the current parent' do
+        expect @parent.class == Shoes::Stack
+      end
+    end
+
+  end
+
   describe 'DELEGATE_METHODS' do
     subject {Shoes::App::DELEGATE_METHODS}
 


### PR DESCRIPTION
So here is the parent method. It correctly returns the parent of the current slot. Unfortunately that makes its behavior a little different than the Shoes3 behavior.
### Same
-  They both return the parent object
### Different
- 

``` ruby
Shoes.app do
  para parent
end
```

returns nothing in Shoes3, and returns the InternalApp in Shoes4
- `para parent` in Shoes3 `para Object`  returns a string with the object's class in it: `(Shoes::Flow)`. This isn't how para does objects in Shoes4. But I suspect this difference has little to do with para . . .
