### PR TITLE
Update rspec to 2.99.0.rc1 to get rspec3 deprecations

### DIFF
--- a/shoes.gemspec
+++ b/shoes.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "guard-rspec"
   s.add_development_dependency "pry"
 
-  s.add_development_dependency "rspec", "~>2.10"
+  s.add_development_dependency "rspec", "~>2.99.0.rc1"
   s.add_development_dependency "rake"
 
   s.add_development_dependency "yard"


### PR DESCRIPTION
Suggesting to already update to rspec 2.99.0.rc1 so we can already get started on eliminating the rspec3 deprecations.
