### PR TITLE
Clear transform after painting each object

### DIFF
--- a/lib/shoes/swt/common/painter.rb
+++ b/lib/shoes/swt/common/painter.rb
@@ -4,7 +4,12 @@ class Shoes
       class Painter
         include ::Swt::Events::PaintListener
         include Resource
-        LINECAP = {curve: ::Swt::SWT::CAP_ROUND, rect: ::Swt::SWT::CAP_FLAT, project: ::Swt::SWT::CAP_SQUARE}
+
+        LINECAP = {
+          curve:   ::Swt::SWT::CAP_ROUND,
+          rect:    ::Swt::SWT::CAP_FLAT,
+          project: ::Swt::SWT::CAP_SQUARE
+        }
 
         def initialize(obj)
           @obj = obj
@@ -12,7 +17,7 @@ class Shoes
 
         def paint_control(event)
           graphics_context = event.gc
-          gcs_reset graphics_context
+          reset_graphics_context graphics_context
           if @obj.dsl.visible? && @obj.dsl.positioned?
             paint_object graphics_context
           end
@@ -25,9 +30,10 @@ class Shoes
         end
 
         def paint_object(graphics_context)
-          graphics_context.set_antialias ::Swt::SWT::ON
-          graphics_context.set_line_cap(LINECAP[@obj.dsl.style[:cap]] || LINECAP[:rect])
+          cap = LINECAP[@obj.dsl.style[:cap]]
+          graphics_context.set_line_cap(cap) if cap
           graphics_context.set_transform(@obj.transform)
+
           obj = @obj.dsl
           case obj
             when ::Shoes::Oval, ::Shoes::Rect
@@ -41,7 +47,6 @@ class Shoes
               fill graphics_context if fill_setup(graphics_context)
               draw graphics_context if draw_setup(graphics_context)
           end
-          graphics_context.set_transform(nil)
         end
 
         # Override in subclass and return something falsy if not using fill

--- a/lib/shoes/swt/common/resource.rb
+++ b/lib/shoes/swt/common/resource.rb
@@ -2,11 +2,26 @@ class Shoes
   module Swt
     module Common
       module Resource
-        def gcs_reset gc
-          @gcs ||= []
-          @gcs.each{|g| g.dispose if g}
-          @gcs.clear
-          @gcs << gc
+        def reset_graphics_context(graphics_context)
+          dispose_previous_contexts
+          set_defaults_on_context(graphics_context)
+          track_graphics_context(graphics_context)
+        end
+
+        def dispose_previous_contexts
+          @graphic_contexts ||= []
+          @graphic_contexts.each{|g| g.dispose if g}
+          @graphic_contexts.clear
+        end
+
+        def set_defaults_on_context(graphics_context)
+          graphics_context.set_antialias(::Swt::SWT::ON)
+          graphics_context.set_line_cap(::Swt::SWT::CAP_FLAT)
+          graphics_context.set_transform(nil)
+        end
+
+        def track_graphics_context(graphics_context)
+          @graphic_contexts << graphics_context
         end
       end
     end

--- a/lib/shoes/swt/text_block/painter.rb
+++ b/lib/shoes/swt/text_block/painter.rb
@@ -13,7 +13,7 @@ class Shoes
         end
 
         def paintControl(paint_event)
-          gcs_reset(paint_event.gc)
+          reset_graphics_context(paint_event.gc)
           return if @dsl.hidden?
 
           draw_layouts(paint_event.gc)


### PR DESCRIPTION
Resolves #701.

The transform which is set by the `Shoes::Swt::Common::Painter`, if it's provided by the object, was being allowed to persist across to additional painting operations on that graphics context.

Most art objects didn't actually have a transform set, but line does so elements following it would get mixed up by having the line's transform applied to them.

Should this same pattern apply to the other things we're setting in the painter?

```
       graphics_context.set_antialias ::Swt::SWT::ON
       graphics_context.set_line_cap(LINECAP[@obj.dsl.style[:cap]] || LINECAP[:rect])
```

Also note I didn't write up a spec about this since at this point `Shoes::Swt::Common::Painter#paint_object` isn't really tested at all, and I just didn't have the gumption tonight to start writing that spec. :zzz:

If I feel bad enough I might work that spec up before we merge this, otherwise it might be worth a separate issue for some hearty soul to tackle.
