### PR TITLE
Add scroll* methods to slots

### DIFF
--- a/lib/shoes/mock/text_block.rb
+++ b/lib/shoes/mock/text_block.rb
@@ -15,7 +15,11 @@ class Shoes
 
       def remove;end
 
-      def contents_alignment(*args);end
+      # A very imperfect implementation, but at least it takes up about a line.
+      # Needed to spec scrolling behavior
+      def contents_alignment(current_position)
+        @dsl.absolute_top = current_position.y + (@dsl.size || 12)
+      end
 
       def adjust_current_position(*args);end
     end

--- a/lib/shoes/slot.rb
+++ b/lib/shoes/slot.rb
@@ -10,7 +10,7 @@ class Shoes
     NEXT_ELEMENT_OFFSET = 1
 
     attr_reader :parent, :gui, :contents, :blk, :dimensions, :hover_proc,
-                :leave_proc
+                :leave_proc, :scroll
     style_with :art_styles, :attach, :dimensions, :stroke
 
     def initialize(app, parent, styles = {}, blk = nil)
@@ -31,6 +31,8 @@ class Shoes
 
       @dimensions     = Dimensions.new parent, @style
       @fixed_height   = height || false
+      @scroll         = styles.fetch(:scroll, false)
+      @scroll_top     = 0
       set_default_dimension_values
 
       @pass_coordinates = true
@@ -98,6 +100,22 @@ class Shoes
 
     def mouse_left
       @hovered = false
+    end
+
+    def scroll_height
+      position_contents.y
+    end
+
+    def scroll_max
+      scroll_height - height
+    end
+
+    def scroll_top
+      @scroll_top
+    end
+
+    def scroll_top=(position)
+      @scroll_top = position
     end
 
     def app

--- a/spec/shoes/flow_spec.rb
+++ b/spec/shoes/flow_spec.rb
@@ -104,4 +104,30 @@ describe Shoes::Flow do
       it_behaves_like 'taking care of margin'
     end
   end
+
+  describe 'scrolling' do
+    include_context "scroll"
+    subject(:flow) { Shoes::Flow.new(app, parent, opts) }
+
+    context 'when scrollable' do
+      let(:scroll) { true }
+
+      it_behaves_like "scrollable slot"
+
+      context 'when content overflows' do
+        include_context "overflowing content"
+        it_behaves_like "scrollable slot with overflowing content"
+      end
+    end
+
+    context 'when slot is not scrollable' do
+      let(:scroll) { false }
+
+      its(:scroll) { should be_falsey }
+
+      it "initializes scroll_top to 0" do
+        expect(flow.scroll_top).to eq(0)
+      end
+    end
+  end
 end

--- a/spec/shoes/shared_examples/scroll.rb
+++ b/spec/shoes/shared_examples/scroll.rb
@@ -1,0 +1,41 @@
+shared_examples_for "scrollable slot" do
+  its(:scroll) { should be_truthy }
+  it "initializes scroll_top to 0" do
+    expect(subject.scroll_top).to eq(0)
+  end
+end
+
+shared_examples_for "scrollable slot with overflowing content" do
+  it "retains the same height" do
+    expect(subject.height).to eq(height)
+  end
+
+  it "has scroll_height larger than height" do
+    expect(subject.scroll_height).to be > height
+  end
+
+  it "has scroll_max = (scroll_height - height)" do
+    expect(subject.scroll_max).to eq(subject.scroll_height - subject.height)
+  end
+
+  it 'adjusts scroll_top' do
+    expect(subject.scroll_top).to eq(new_position)
+  end
+end
+
+shared_context "scroll" do
+  let(:height) { 200 }
+  let(:input_opts) { {left: 40, top: 20, width: 400, height: height} }
+  let(:opts) { input_opts.merge(scroll: scroll) }
+end
+
+shared_context "overflowing content" do
+  let(:new_position) { 300 }
+
+  before :each do
+    200.times do
+      Shoes::TextBlock.new(app, subject, "Fourteen fat chimichangas", size: 18)
+    end
+    subject.scroll_top = new_position
+  end
+end

--- a/spec/shoes/slot_spec.rb
+++ b/spec/shoes/slot_spec.rb
@@ -8,7 +8,8 @@ describe Shoes::Slot do
   let(:top) { 66 }
   let(:width) { 111 }
   let(:height) { 333 }
-  subject(:slot) { Shoes::Slot.new(app, parent, left: left, top: top, width: width, height: height) }
+  let(:input_opts) { {left: left, top: top, width: width, height: height} }
+  subject(:slot) { Shoes::Slot.new(app, parent, input_opts) }
 
   it_behaves_like "object with dimensions"
 

--- a/spec/shoes/stack_spec.rb
+++ b/spec/shoes/stack_spec.rb
@@ -50,4 +50,30 @@ describe Shoes::Stack do
       it_behaves_like 'taking care of margin'
     end
   end
+
+  describe 'scrolling' do
+    include_context "scroll"
+    subject { Shoes::Stack.new(app, parent, opts) }
+
+    context 'when scrollable' do
+      let(:scroll) { true }
+
+      it_behaves_like "scrollable slot"
+
+      context 'when content overflows' do
+        include_context "overflowing content"
+        it_behaves_like "scrollable slot with overflowing content"
+      end
+    end
+
+    context 'when slot is not scrollable' do
+      let(:scroll) { false }
+
+      its(:scroll) { should be_falsey }
+
+      it "initializes scroll_top to 0" do
+        expect(subject.scroll_top).to eq(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This basically ports the changes from #575 onto the current codebase. The scrolling methods are implemented on the DSL layer. The Swt implementation of Slots currently has no backing Swt class. We'll need to add that so we have a container to display as scrollable. Closes #575.
