### PR TITLE
Fix a couple of fatal exceptions caused by bad input

### DIFF
--- a/samples/simple-calc.rb
+++ b/samples/simple-calc.rb
@@ -30,7 +30,7 @@ class Calc
   end
 
   def press_equals
-    @number = @previous.send(@op, @number.to_i)
+    @number = @previous.send(@op, @number.to_i) unless (@previous.nil? or @op.nil? or @number.nil?)
     @op = nil
   end
 


### PR DESCRIPTION
I pulled the project down and found that a couple of bad behaviors like just pressing the equals button caused the program to exit with a type conversion exception.  I put a simple validation in to ensure that the program continued to run in these cases.  I didn't see how/where to write tests for this sample otherwise I would have.
