### PR TITLE
Fix for offsetting of second text segments

### DIFF
--- a/lib/shoes/swt/text_block/fitter.rb
+++ b/lib/shoes/swt/text_block/fitter.rb
@@ -128,11 +128,12 @@ class Shoes
 
         def position_two_segments(first_layout, second_layout, first_text, height)
           first_height = first_height(first_layout, first_text, height)
+
           [
             first_layout.position_at(@dsl.element_left,
                                      @dsl.element_top),
             second_layout.position_at(parent.absolute_left + @dsl.margin_left,
-                                      @dsl.element_top + first_height)
+                                      @dsl.element_top + first_height + 1)
           ]
         end
 
@@ -201,7 +202,7 @@ class Shoes
         # If first text is empty, height may be smaller than an actual line in
         # the current font. Take our pre-existing allowed height instead.
         def first_height(first_layout, first_text, height)
-          first_height = first_layout.bounds.height
+          first_height = first_layout.bounds.height - first_layout.spacing
           first_height = height if first_text.empty?
           first_height
         end

--- a/lib/shoes/swt/text_block/text_segment.rb
+++ b/lib/shoes/swt/text_block/text_segment.rb
@@ -17,7 +17,7 @@ class Shoes
         attr_reader :layout, :element_left, :element_top
 
         extend Forwardable
-        def_delegators :@layout, :text, :text=, :bounds, :width,
+        def_delegators :@layout, :text, :text=, :bounds, :width, :spacing,
                                  :line_bounds, :line_count, :line_offsets
 
         def initialize(dsl, text, width)

--- a/spec/swt_shoes/text_block/fitter_spec.rb
+++ b/spec/swt_shoes/text_block/fitter_spec.rb
@@ -8,7 +8,7 @@ describe Shoes::Swt::TextBlock::Fitter do
                      margin_left:   1,  margin_top:   1) }
 
   let(:parent_dsl) { double('parent_dsl', parent: grandparent_dsl,
-                            absolute_left: 0, absolute_right: 100,
+                            absolute_top: 0, absolute_left: 0, absolute_right: 100,
                             width: parent_width, height: 200) }
 
   let(:grandparent_dsl) { double('grandparent_dsl', parent: app,
@@ -97,7 +97,11 @@ describe Shoes::Swt::TextBlock::Fitter do
                            line_count: 1, line_offsets:[], bounds: bounds) }
 
     before(:each) do
+      layout = double('swt_layout', :spacing => 4, :spacing= => nil)
       allow(segment).to receive(:position_at) { segment }
+      allow(segment).to receive(:spacing) { 4 }
+      allow(segment).to receive(:layout)  { layout }
+
     end
 
     context "to one segment" do
@@ -125,7 +129,7 @@ describe Shoes::Swt::TextBlock::Fitter do
         expect(segment).to receive(:dispose).once
 
         segments = when_fit_at(x: 25, y: 75, next_line_start: 95)
-        expect_segments(segments, [26, 76], [1, 126])
+        expect_segments(segments, [26, 76], [1, 123])
       end
 
       it "should overflow all text to second segment" do
@@ -133,7 +137,7 @@ describe Shoes::Swt::TextBlock::Fitter do
         expect(segment).to receive(:dispose).once
 
         segments = when_fit_at(x: 25, y: 75, next_line_start: 95)
-        expect_segments(segments, [26, 76], [1, 95])
+        expect_segments(segments, [26, 76], [1, 96])
       end
     end
 
@@ -145,13 +149,13 @@ describe Shoes::Swt::TextBlock::Fitter do
       it "rolls to second segment when 0 remaining width" do
         allow(dsl).to receive_messages(desired_width: 0)
         segments = when_fit_at(x: 0, y: 75, next_line_start: 95)
-        expect_segments(segments, [26, 76], [1, 96])
+        expect_segments(segments, [26, 76], [1, 97])
       end
 
       it "rolls to second segment when negative remaining width" do
         allow(dsl).to receive_messages(desired_width: -1)
         segments = when_fit_at(x: 0, y: 75, next_line_start: 95)
-        expect_segments(segments, [26, 76], [1, 96])
+        expect_segments(segments, [26, 76], [1, 97])
       end
     end
 
@@ -170,7 +174,7 @@ describe Shoes::Swt::TextBlock::Fitter do
       it "bumps down a line if not at start" do
         allow(dsl).to receive_messages(element_left: 20, left: 20)
         segments = when_fit_at(x: 20, y: 75, next_line_start: 95)
-        expect_segments(segments, [20, 76], [1, 95])
+        expect_segments(segments, [20, 76], [1, 96])
       end
     end
   end


### PR DESCRIPTION
Was noted on issue #717 that we had a problem with the text blocks on the
later lines not quite lining up when things wrapped.

Turned out this was because when we asked the first layout its height to
determine where the second layout should begin vertically, that value included
the spacing which contributed +4 pixels that we didn't actually want. Removing
that we I found we still needed one of those pixels, hence the additional plus
one.

~~Surprisingly this broke no tests, so I'm going to dig into why that is later,
but for now wanted to capture this working change for any potential comment.~~ :grimacing: 
