### PR TITLE
Throw a video not implementedm error upon calling that method

### DIFF
--- a/lib/shoes/dsl.rb
+++ b/lib/shoes/dsl.rb
@@ -66,6 +66,7 @@ require 'shoes/renamed_delegate'
 require 'shoes/common/inspect'
 require 'shoes/dimension'
 require 'shoes/dimensions'
+require 'shoes/not_implemented_error'
 require 'shoes/text_block_dimensions'
 
 require 'shoes/color'
@@ -583,6 +584,14 @@ EOS
     def gutter
       @__app__.gutter
     end
+
+    def video(*args)
+      raise Shoes::NotImplementedError,
+            'Sorry video support has been cut from shoes 4!' +
+            ' Check out github issue #113 for any changes/updates or if you' +
+            ' want to help :)'
+    end
+
   end
 end
 

--- a/lib/shoes/not_implemented_error.rb
+++ b/lib/shoes/not_implemented_error.rb
@@ -1,0 +1,4 @@
+class Shoes
+  class NotImplementedError < StandardError
+  end
+end

--- a/spec/shoes/shared_examples/dsl.rb
+++ b/spec/shoes/shared_examples/dsl.rb
@@ -35,6 +35,7 @@ shared_examples "DSL container" do
     stroke
     strokewidth
     style
+    video
   ].each do |method|
     include_examples "#{method} DSL method"
   end

--- a/spec/shoes/shared_examples/dsl/video.rb
+++ b/spec/shoes/shared_examples/dsl/video.rb
@@ -1,0 +1,5 @@
+shared_examples_for 'video DSL method' do
+  it 'throws a Shoes::NotImplementedError' do
+    expect{dsl.video}.to raise_error Shoes::NotImplementedError
+  end
+end


### PR DESCRIPTION
For #774 :)

So right now this is straight on the DSL level (impl and specs)... This isn't exactly future proof as what is implemented and what is not is a matter of the backend. So _technically_ the error should be thrown upon instantiation of the appropriate backend object. However that makes it a bit harder to follow.. e.g. when you look at the code starting at DSL it's "Oh right the DSL object is created let's have a look there... oh cool it creates a backend object great... whooops that throws a NotImplementedError''

Open to changing that but looking for feedback :)

Tobi
