### PR TITLE
Update Slots to have style method

### DIFF
--- a/lib/shoes/dsl.rb
+++ b/lib/shoes/dsl.rb
@@ -237,11 +237,11 @@ class Shoes
     end
 
     def flow(opts = {}, &blk)
-      create Shoes::Flow, opts, &blk
+      create Shoes::Flow, opts, blk
     end
 
     def stack(opts = {}, &blk)
-      create Shoes::Stack, opts, &blk
+      create Shoes::Stack, opts, blk
     end
 
     def button(text = 'Button', opts={}, &blk)

--- a/lib/shoes/slot.rb
+++ b/lib/shoes/slot.rb
@@ -2,6 +2,7 @@ class Shoes
   class Slot
     include Common::UIElement
     include Common::Clickable
+    include Common::Style
 
     # We need that offset because otherwise element overlap e.g. occupy
     # the same pixel - this way they start right next to each other
@@ -10,9 +11,10 @@ class Shoes
 
     attr_reader :parent, :gui, :contents, :blk, :dimensions, :hover_proc,
                 :leave_proc
+    style_with :art_styles, :attach, :dimensions, :stroke
 
-    def initialize(app, parent, opts={}, &blk)
-      init_attributes(app, parent, opts, blk)
+    def initialize(app, parent, styles = {}, blk = nil)
+      init_attributes(app, parent, styles, blk)
       @parent.add_child self
 
       @gui = Shoes.configuration.backend_for(self, @parent.gui)
@@ -20,12 +22,13 @@ class Shoes
       contents_alignment
     end
 
-    def init_attributes(app, parent, opts, blk)
+    def init_attributes(app, parent, styles, blk)
       @app            = app
       @parent         = parent
       @contents       = SlotContents.new
       @blk            = blk
-      @dimensions     = Dimensions.new parent, opts
+      style_init(styles)
+      @dimensions     = Dimensions.new parent, @style
       @fixed_height   = height || false
       set_default_dimension_values
     end

--- a/spec/shoes/flow_spec.rb
+++ b/spec/shoes/flow_spec.rb
@@ -4,7 +4,7 @@ require 'shoes/helpers/fake_element'
 describe Shoes::Flow do
   include_context "dsl app"
 
-  subject(:flow) { Shoes::Flow.new(app, parent, input_opts, &input_block) }
+  subject(:flow) { Shoes::Flow.new(app, parent, input_opts, input_block) }
 
   it_behaves_like "clickable object"
   it_behaves_like "hover and leave events"


### PR DESCRIPTION
This one's easy. I had to make almost no changes. And everything seems to work fine. I played around with hidden and realized that I need to add `hidden` and `displace_left` and `displace_top` to all the elements. Those are already grouped together as `common_styles` so it shouldn't be hard to do, but I wanted to hold off since I'm thinking `hidden` may need a special call to activate it if set to true from the style hash.
