### PR TITLE
Cleanup for link click registration weirdness

### DIFF
--- a/lib/shoes/link.rb
+++ b/lib/shoes/link.rb
@@ -11,32 +11,29 @@ class Shoes
       @app = app
       @parent = parent
       style_init(styles)
-      setup_block(blk, @style)
       @gui = Shoes.backend_for(self, @style)
 
+      setup_click(blk, @style)
       super texts, @style
     end
 
-    def setup_block(blk, style)
-      if blk
-        @blk = blk
-      elsif style.include?(:click)
+    # Doesn't use Common::Clickable because of URL flavor option clicks
+    def setup_click(blk, style)
+      if blk.nil? && style.include?(:click)
         if style[:click].respond_to?(:call)
-          @blk = style[:click]
+          blk = style[:click]
         else
           # Slightly awkward, but we need App, not InternalApp, to call visit
-          @blk = Proc.new { app.app.visit(style[:click]) }
+          blk = Proc.new { app.app.visit(style[:click]) }
         end
       end
+
+      click(&blk)
     end
 
     def click(&blk)
+      @gui.click(blk) if blk
       @blk = blk
-      self
-    end
-
-    def execute_link
-      @blk.call
     end
 
     def in_bounds?(x, y)
@@ -46,6 +43,5 @@ class Shoes
     def remove
       @gui.remove
     end
-
   end
 end

--- a/lib/shoes/mock/link.rb
+++ b/lib/shoes/mock/link.rb
@@ -5,6 +5,9 @@ class Shoes
 
       def initialize(dsl, app, opts = {})
       end
+
+      def click(blk)
+      end
     end
   end
 end

--- a/lib/shoes/swt/link.rb
+++ b/lib/shoes/swt/link.rb
@@ -9,12 +9,6 @@ class Shoes
         @app = app
         @link_segments = []
         @dsl = dsl
-
-        # Important to capture a block that executes the DSL's current block,
-        # not just the block the DSL had when initializing, since a `click`
-        # call can change the block but won't update the clickable listener.
-        # See issue #639 for how we'd like to fix this in clickable.
-        clickable self, Proc.new { dsl.execute_link }
       end
 
       def remove

--- a/spec/shoes/link_spec.rb
+++ b/spec/shoes/link_spec.rb
@@ -50,7 +50,7 @@ describe Shoes::Link do
 
       it "sets up for the click" do
         expect(callable).to receive(:call)
-        subject.execute_link
+        subject.blk.call
       end
     end
 
@@ -59,17 +59,17 @@ describe Shoes::Link do
 
       it "should visit the url" do
         expect(app).to receive(:visit).with("/url")
-        subject.execute_link
+        subject.blk.call
       end
     end
 
     context "with click option as Proc" do
-      let(:block) { double("block", call: nil) }
-      subject { Shoes::Link.new(internal_app, nil, texts, click: block) }
+      let(:callable) { double("callable", call: nil) }
+      subject { Shoes::Link.new(internal_app, nil, texts, click: Proc.new { callable.call }) }
 
       it "calls the block" do
-        expect(block).to receive(:call)
-        subject.execute_link
+        expect(callable).to receive(:call)
+        subject.blk.call
       end
     end
 
@@ -83,7 +83,7 @@ describe Shoes::Link do
         expect(replacement_block).to receive(:call)
 
         subject.click { replacement_block.call }
-        subject.execute_link
+        subject.blk.call
       end
     end
   end

--- a/spec/swt_shoes/link_spec.rb
+++ b/spec/swt_shoes/link_spec.rb
@@ -6,13 +6,6 @@ describe Shoes::Swt::Link do
 
   subject { Shoes::Swt::Link.new(dsl, swt_app) }
 
-  it "marks itself clickable" do
-    expect(swt_app).to receive(:add_listener)
-    expect(swt_app).to receive(:add_clickable_element)
-
-    subject
-  end
-
   its(:dsl) {is_expected.to eq dsl}
 
   context "creating link segments" do


### PR DESCRIPTION
_This is what I had in mind when I logged #639. Looks like Links are the only
weird type floating around._

For whatever reason when I last revised the Link class it ended up with this
weird Proc wrapper being added at the SWT layer to make sure links got updated
properly.

It's much simpler to just make sure the DSL passes along changes to the block
we want called on click.

Because of a bit of special link behavior this doesn't actually use the
Shoes::Common::Clickable module, but it does leverage
Shoes::Swt::Common::Clickable on the backend, and is closer to the standard
click implementation.

cc/ @KCErb @PragTob
