### PR TITLE
Fix for unbounded height crash on centering

### DIFF
--- a/lib/shoes/swt/text_block/fitter.rb
+++ b/lib/shoes/swt/text_block/fitter.rb
@@ -203,7 +203,7 @@ class Shoes
         # the current font. Take our pre-existing allowed height instead.
         def first_height(first_layout, first_text, height)
           first_height = first_layout.bounds.height - first_layout.spacing
-          first_height = height if first_text.empty?
+          first_height = height if first_text.empty? && height != :unbounded
           first_height
         end
       end

--- a/spec/swt_shoes/text_block/fitter_spec.rb
+++ b/spec/swt_shoes/text_block/fitter_spec.rb
@@ -176,6 +176,12 @@ describe Shoes::Swt::TextBlock::Fitter do
         segments = when_fit_at(x: 20, y: 75, next_line_start: 95)
         expect_segments(segments, [20, 76], [1, 96])
       end
+
+      it "if unbounded height, still bumps down properly" do
+        allow(dsl).to receive_messages(absolute_top: 95, element_left: 20, left: 20, margin_left: 1)
+        segments = when_fit_at(x: 20, y: 75, next_line_start: 95)
+        expect_segments(segments, [20, 76], [1, 96])
+      end
     end
   end
 


### PR DESCRIPTION
With certain values, a centered text segment is coerced into thinking it has
unbounded height (which is set as a symbol, not a number) and was later
incorrectly used in some position math.

Calculating the first_height now gates for the :unbounded symbol so we don't
crash on it.

Fixes #824

cc/ @miller0929
