### PR TITLE
Fix crash computing height with hidden elements

### DIFF
--- a/lib/shoes/slot.rb
+++ b/lib/shoes/slot.rb
@@ -219,7 +219,9 @@ class Shoes
     end
 
     def compute_content_height
-      max_bottom = contents.map(&:absolute_bottom).max
+      max_bottom = contents.reject(&:hidden?).
+                            map(&:absolute_bottom).
+                            max
       if max_bottom
         max_bottom - self.absolute_top + NEXT_ELEMENT_OFFSET
       else

--- a/spec/shoes/shared_examples/slot.rb
+++ b/spec/shoes/shared_examples/slot.rb
@@ -36,6 +36,16 @@ shared_context 'two slot children' do
   end
 end
 
+shared_context 'hidden child' do
+  let(:hidden_element) {Shoes::FakeElement.new nil, height: 200, width: 70}
+
+  before :each do
+    subject.add_child hidden_element
+    hidden_element.gui = double("hidden gui", toggle: nil)
+    hidden_element.hide
+  end
+end
+
 shared_context 'three slot children' do
   include_context 'two slot children'
   let(:element3) {Shoes::FakeElement.new(nil, height: 50, width: 20)}
@@ -226,6 +236,15 @@ shared_examples_for 'growing although relatively positioned elements' do
 
     it 'grows the height even further' do
       expect(subject.height).to eq element.height + 70
+    end
+  end
+
+  describe 'positioning with hidden elements' do
+    include_context 'hidden child'
+
+    it 'grows only to height of first child' do
+      subject.contents_alignment
+      expect(subject.height).to eq element.height
     end
   end
 end


### PR DESCRIPTION
Hidden elements don't receive an absolute_bottom from the slot positioning
logic, but computing the slot height wasn't taking into account that fact when
finding the maximum value to use.

This commit properly ignores elements that are hidden in the calculation. If
other nil's slip into the absolute_bottom list for reasons other than
visibility, those should be dealt with explicitly.

Fixes #796
