### PR TITLE
Fix for allowing widgets to use widget DSL methods

### DIFF
--- a/lib/shoes/widget.rb
+++ b/lib/shoes/widget.rb
@@ -61,6 +61,10 @@ class Shoes
           widget_instance
         end
       end
+
+      # Now that we've made the widget method on the app, make sure that
+      # widgets know to delegate to the newly defined method.
+      def_delegator :app, dsl_method
     end
 
 

--- a/spec/shoes/widget_spec.rb
+++ b/spec/shoes/widget_spec.rb
@@ -6,6 +6,13 @@ class Smile < Shoes::Widget
   end
 end
 
+class Face < Shoes::Widget
+  def initialize
+    para  "Hair"
+    smile "Toothsome"
+  end
+end
+
 describe Shoes::Widget do
   let(:app) { Shoes::App.new }
 
@@ -30,5 +37,10 @@ describe Shoes::Widget do
       widget = smile 'lalala'
     end
     expect(widget.parent).to eq slot
+  end
+
+  it "allows can use other widgets from widget initialize" do
+    expect(app).to receive(:smile)
+    app.face
   end
 end


### PR DESCRIPTION
When we define a widget it gets a new DSL method added onto the app. But the
widgets themselves couldn't use these.

This commit adds the necessary delegator for widgets after we've added the
method onto the app.

Fixes #787
