### PR TITLE
No left= redraws

### DIFF
--- a/lib/shoes/swt/redrawing_aspect.rb
+++ b/lib/shoes/swt/redrawing_aspect.rb
@@ -10,16 +10,17 @@ class Shoes
   module Swt
     class RedrawingAspect
 
-      NEED_TO_UPDATE = {Animation                        => [:eval_block],
-                        Button                           => [:eval_block],
-                        Common::Clickable::ClickListener => [:eval_block],
-                        ::Shoes::InternalApp             => [:execute_block],
-                        Keypress                         => [:eval_block],
-                        Keyrelease                       => [:eval_block],
-                        MouseMoveListener                => [:eval_move_block],
-                        TextBlock::CursorPainter         => [:move_textcursor],
-                        Timer                            => [:eval_block],
-                        ::Shoes::Common::Changeable      => [:call_change_listeners]}
+      NEED_TO_UPDATE =
+          {Animation                        => [:eval_block],
+           Button                           => [:eval_block],
+           Common::Clickable::ClickListener => [:eval_block],
+           ::Shoes::InternalApp             => [:execute_block],
+           Keypress                         => [:eval_block],
+           Keyrelease                       => [:eval_block],
+           MouseMoveListener                => [:eval_move_block],
+           TextBlock::CursorPainter         => [:move_textcursor],
+           Timer                            => [:eval_block],
+           ::Shoes::Common::Changeable      => [:call_change_listeners]}
       # only the main thread may draw
       NEED_TO_ASYNC_UPDATE_GUI = {::Shoes::Download => [:eval_block]}
 
@@ -28,7 +29,8 @@ class Shoes
                           Image                   => [:update_image],
                           ::Shoes::Common::Style  => [:update_style],
                           ::Shoes::Common::Remove => [:remove],
-                          ::Shoes::Slot           => [:mouse_hovered, :mouse_left],
+                          ::Shoes::Slot           => [:mouse_hovered,
+                                                      :mouse_left],
                           ::Shoes::TextBlock      => [:replace]}
 
       CHANGED_POSITION = {::Shoes::Common::Positioning => [:_position]}


### PR DESCRIPTION
- As discussed in #871
- This was originally introduced in 8a35ebb to make sample 14
  work but it seems to work fine without, might have been
  misjudgement on my part or I'm missing something now
- It should work because the REAL repositioning on the GUI only
  happens through #_position which the slot positioning code calls.
  left= etc. just set values that are considered by the positioning
  code they should not have an effect by themselves
- includes styling changes for 80 character width

Adding those was misjudgement on my part, as the original PR states: _"sample14 leaves artifacts of ovals behind --> some area is not marked as damaged"_ but that was later on really solved by redrawing the old area before `_position` is executed and the new area after `_position` is called :-)

Should be good to go!
