### PR TITLE
Text passed into InputBoxes is automatically converted to string

### DIFF
--- a/lib/shoes/input_box.rb
+++ b/lib/shoes/input_box.rb
@@ -9,7 +9,7 @@ class Shoes
     def initialize(app, parent, text, styles = {}, blk = nil)
       @app = app
       @parent = parent
-      style_init styles, text: text
+      style_init styles, text: text.to_s
       @dimensions = Dimensions.new parent, @style
       @parent.add_child self
       @gui = Shoes.configuration.backend_for self, @parent.gui

--- a/spec/shoes/input_box_spec.rb
+++ b/spec/shoes/input_box_spec.rb
@@ -38,6 +38,14 @@ describe Shoes::InputBox do
     subject.caret_to 42
   end
 
+  describe 'non string text' do
+    let(:text) {42}
+
+    it 'is converted to a string (convenience + error in backend)' do
+      expect(subject.text).to eq '42'
+    end
+  end
+
   describe "relative dimensions from parent" do
     subject { Shoes::EditBox.new(app, parent, text, relative_opts) }
     it_behaves_like "object with relative dimensions"


### PR DESCRIPTION
- Also vintage shoes behavior :-)
- causes a crash on the backend otherwise (expects string)

Noticed that while running some of my shoes applications and they started crashing (I often have options saved as numbers and then pass them in there)
