### PR TITLE
Fix for crash on empty link text

### DIFF
--- a/lib/shoes/swt/link_segment.rb
+++ b/lib/shoes/swt/link_segment.rb
@@ -6,8 +6,8 @@ class Shoes
         @range = range
         @text_segment = text_segment
 
-        # Empty link will have no range, so don't create regions for it!
-        return unless @range.count > 1
+        # Don't create regions for empty links!
+        return unless @range.count > 0
 
         add_regions_for_lines(lines_for_link)
         offset_regions(text_segment.element_left, text_segment.element_top)

--- a/lib/shoes/swt/text_block/text_segment.rb
+++ b/lib/shoes/swt/text_block/text_segment.rb
@@ -60,8 +60,8 @@ class Shoes
         end
 
         def set_style(styles, range=(0...text.length))
-          # If we've been given an empty/nonesense range, just ignore it
-          return unless range.count > 1
+          # If we've been given an empty/nonsense range, just ignore it
+          return unless range.count > 0
 
           font = @font_factory.create_font(styles[:font_detail])
           style = @style_factory.create_style(font, styles[:fg], styles[:bg], styles)

--- a/lib/shoes/text_block.rb
+++ b/lib/shoes/text_block.rb
@@ -85,10 +85,15 @@ class Shoes
         if text.is_a? Shoes::Text
           text.text_block  = self
           text.parent_text = parent_text
-
           end_point        = start_point + text.to_s.length - 1
-          end_point        = start_point if end_point < start_point
-          range            = start_point..end_point
+
+          # If our endpoint is before our start, it's an empty string. We treat
+          # those specially with the (0...0) range that has an empty count.
+          if end_point < start_point
+            range = (0...0)
+          else
+            range = start_point..end_point
+          end
 
           styles[range]    ||= []
           styles[range] << text

--- a/spec/shoes/text_block_spec.rb
+++ b/spec/shoes/text_block_spec.rb
@@ -219,7 +219,7 @@ describe Shoes::TextBlock do
     let(:actual_app) { app.app }
 
     it "properly ignores empty element lengths in text_styles" do
-      text_styles = { 0..0 => [link, span] }
+      text_styles = { 0...0 => [link, span] }
 
       expect(para.text_styles).to eq(text_styles)
     end

--- a/spec/swt_shoes/link_segment_spec.rb
+++ b/spec/swt_shoes/link_segment_spec.rb
@@ -17,7 +17,7 @@ describe Shoes::Swt::LinkSegment do
 
   # ....................
   context "empty link" do
-    let(:range) { (0..0) }
+    let(:range) { (0...0) }
 
     it "fails all bounds checks" do
       stub_start_and_end_locations([0, 0], [10, 0])

--- a/spec/swt_shoes/text_block/text_segment_spec.rb
+++ b/spec/swt_shoes/text_block/text_segment_spec.rb
@@ -72,8 +72,8 @@ describe Shoes::Swt::TextBlock::TextSegment do
     end
 
     it "ignores empty ranges" do
-      subject.set_style(style_hash, 1..1)
-      expect(layout).to_not have_received(:set_style).with(style, 1, 1)
+      subject.set_style(style_hash, 0...0)
+      expect(layout).to_not have_received(:set_style).with(style, 0, 0)
     end
   end
 


### PR DESCRIPTION
If you passed an empty string to the link text, the app would crash on you.
This is because the ranges that the `Shoes::TextBlock` class build up for
styling different segments (which the links rely on for building their click
regions), would end up with `(0..-1)`, or nonsense ranges where the end was
before the start, and downstream code would be very unhappy with those.

We now properly will set the start and end equal in the styling range if the
string is empty, but that left another problem where the styling was always
assumed to apply to at least one character. I've updated those spots as well,
because even with this applied, an empty link or span would unduly influence
the styling of the next character after where it should have been.

Fixes #909.
