### PR TITLE
Fix running bin/shoes.bat from source

### DIFF
--- a/bin/shoes.bat
+++ b/bin/shoes.bat
@@ -1,0 +1,8 @@
+@echo off
+
+REM Note that this is NOT the actual bin/shoes.bat that gets installed with
+REM the gem! ext\install\shoes.bat is copied over to bin for gems, but this
+REM is the right thing to use from bin on a source checkout.
+
+set bin_dir=%~dp0
+ext\install\shoes.bat %*

--- a/ext/install/shoes.bat
+++ b/ext/install/shoes.bat
@@ -1,6 +1,9 @@
 @setlocal enableextensions enabledelayedexpansion
 @echo off
-set bin_dir=%~dp0
+
+REM If we're running from source, bin/shoes.bat will have set bin_dir already.
+if not defined bin_dir set bin_dir=%~dp0
+
 set command=jruby --1.9 !bin_dir!/ruby-shoes %*
 call !command!
 endlocal


### PR DESCRIPTION
Fixes #918.

On gem installation, we copy `ext/install/shoes.bat` over to the Ruby bin
directory. The batch file assumed that it would be located next to
`ruby-shoes` to execute.

When running from source, though, we were "linking" `bin/shoes.bat` to just
point to the `ext/install/shoes.bat` location. On *nix systems, the symlink
would behave as if it was in the bin directory, but on Windows the file
is literally just a single line reading `"ext\install\shoes.bat"`, which
executes the ext copy of shoes.bat, but from the wrong location.

The fix here was to make `ext/install/shoes.bat` take a `bin_dir` if already
set, no longer treat `bin/shoes.bat` as a link to that file, and have
`bin/shoes` properly set the `bin_dir` so running `ext/install/shoes.bat` works.

Fun times in trying to not have your Ruby program get started by Ruby :)

cc/ @glenn-murray-bse in case you had bandwidth to test this out on your
Windows machine. Worked fine for me, but since I'm primarily on Mac,
would appreciate a double-check.
