### PR TITLE
Animation should stop on clear of parent

### DIFF
--- a/lib/shoes/animation.rb
+++ b/lib/shoes/animation.rb
@@ -10,7 +10,7 @@ class Shoes
     #     animation frame
     #   @option opts [Integer] :framerate (24) The framerate (frames per second)
     #   @option opts [Shoes::App] :app The current Shoes app
-    def initialize(app, opts, blk)
+    def initialize(app, parent, opts, blk)
       @style = opts
       @framerate = @style[:framerate] || 10
       @app = app
@@ -18,6 +18,9 @@ class Shoes
       @current_frame = 0
       @stopped = false
       @gui = Shoes.configuration.backend_for(self, @app.gui)
+
+      @parent = parent
+      @parent.on_clear { stop }
     end
 
     attr_reader :current_frame, :framerate, :blk

--- a/lib/shoes/dsl.rb
+++ b/lib/shoes/dsl.rb
@@ -279,7 +279,7 @@ class Shoes
     #
     def animate(opts = {}, &blk)
       opts = {:framerate => opts} unless opts.is_a? Hash
-      Shoes::Animation.new @__app__, opts, blk
+      create Shoes::Animation, opts, blk
     end
 
     def every(n=1, &blk)

--- a/lib/shoes/slot.rb
+++ b/lib/shoes/slot.rb
@@ -26,6 +26,7 @@ class Shoes
       @parent         = parent
       @contents       = SlotContents.new
       @blk            = blk
+      @on_clear       = []
       style_init styles
       @dimensions     = Dimensions.new parent, @style
       @fixed_height   = height || false
@@ -43,7 +44,14 @@ class Shoes
 
     def clear(&blk)
       contents.clear
+      @on_clear.each do |on_clear|
+        on_clear.call
+      end
       eval_block blk
+    end
+
+    def on_clear(&blk)
+      @on_clear << blk
     end
 
     def eval_block blk

--- a/spec/shoes/animation_spec.rb
+++ b/spec/shoes/animation_spec.rb
@@ -33,9 +33,10 @@ end
 describe Shoes::Animation do
   let(:app) { double('app') }
   let(:app_gui) { double('app gui') }
+  let(:slot) { double('slot', on_clear: nil) }
   let(:opts) { {} }
   let(:block) { double('block') }
-  subject { Shoes::Animation.new( app, opts, block ) }
+  subject { Shoes::Animation.new( app, slot, opts, block ) }
 
   before :each do
     expect(app).to receive(:gui) { app_gui }
@@ -52,6 +53,11 @@ describe Shoes::Animation do
   end
 
   it { is_expected.not_to be_stopped }
+
+  it "sets up callback with parent" do
+    expect(slot).to receive(:on_clear)
+    subject
+  end
 
   describe "with framerate" do
     let(:opts) { {:framerate => 36, :app => app} }


### PR DESCRIPTION
When an animation is removed, turns out it marks itself to stop. Unfortunately, the animations weren't getting added to the parent slot's collection, so the problem was that they never heard a remove at all!

I went down the path of adding `Shoes::Animation` directly to the slot contents like other elements, but I found myself including tons of junk just to appease the slots, things that didn't make sense on an animation like visibility, dimensioning, etc.

After the third not-really-necessary-but-gotta-add-it thing, I decided to change direction and add a hook in the slot class to listen for `clear` calls without being in a slot's contents. This was much, much simpler and get us solved on #935 handily.
