### PR TITLE
Do not count scroll bar into app width

### DIFF
--- a/lib/shoes/swt/app.rb
+++ b/lib/shoes/swt/app.rb
@@ -58,11 +58,11 @@ class Shoes
       end
 
       def width
-        @shell.client_area.width
+        shell.client_area.width
       end
 
       def height
-        @shell.client_area.height
+        shell.client_area.height
       end
 
       def disposed?

--- a/spec/swt_shoes/app_spec.rb
+++ b/spec/swt_shoes/app_spec.rb
@@ -81,4 +81,36 @@ describe Shoes::Swt::App do
   # which at the time is overkill imo
   it {is_expected.to respond_to :started?}
 
+  describe 'App dimensions' do
+    let(:client_area) {double 'client_area', width: width, height: height}
+    let(:vertical_bar) {double 'scroll bar', visible?: bar_visible}
+    let(:shell) {double('shell', client_area: client_area,
+                                 vertical_bar: vertical_bar)}
+    let(:width) {50}
+    let(:height) {80}
+    let(:bar_visible) {false}
+
+    before :each do
+      allow(subject).to receive(:shell).and_return(shell)
+    end
+
+    shared_examples_for 'reports client area dimensions' do
+      it 'always returns the client area width' do
+        expect(subject.width).to eq width
+      end
+
+      it 'returns the client area height' do
+        expect(subject.height).to eq height
+      end
+    end
+
+    it_behaves_like 'reports client area dimensions'
+
+    context 'with a scroll bar' do
+      let(:bar_visible) {true}
+
+      it_behaves_like 'reports client area dimensions'
+    end
+  end
+
 end


### PR DESCRIPTION
This change is for #580 - finally.

It is rather simple. Before would take non-overlay scrollbars into account when calculating the app width (as theoretically they could disappear and wohooaaa - new space). However, we can't draw on the space where scroll bars are so we'd run into problems. class-book-adjusted.rb creates one flow with width 180 and then figures out the width of the next stack through `width - 180`, which would fail if there are scroll bars present as it'd say that there is more space than there really is.

There is also one commit simply converting java style method calls to ruby style method calls. We decided on that once :)

Last but not least, you'll notice that there is no test yet (and sadly no test broke changing this). I'd like to write a spec, however it seems extraordinarily difficult. Because for all the scroll bar methods we need the `@shell` which means we'd have to stub it out on creation and then stub all methods.
Only thing I can think of is modify the code to use accessors and then stub the accessor before the test. I'll probably give this a shot, otherwise ideas are always welcome.

Off to Brunch!
Tobi
