### PR TITLE
Fix a typo in the adjusted minesweeper sample

### DIFF
--- a/samples/expert-minesweeper-adjusted.rb
+++ b/samples/expert-minesweeper-adjusted.rb
@@ -248,9 +248,6 @@ Shoes.app width: 730, height: 450, title: 'Minesweeper' do
 
   def new_game level
     @field = Field.new self, level
-    #translate -@old_offset.first, -@old_offset.last unless @old_offset.nil?
-    #translate @field.offset.first, @field.offset.last
-    #@old_offset = @field.offset
     $x, $y = @field.offset.first, @field.offset.last
     render_field
   end
@@ -267,6 +264,6 @@ Shoes.app width: 730, height: 450, title: 'Minesweeper' do
 
     render_field
     alert("Winner!\nTotal time: #{@field.total_time}") if @field.all_found?
-    alert("Bang!\nYou loose.") if @field.game_over?
+    alert("Bang!\nYou lose.") if @field.game_over?
   end
 end


### PR DESCRIPTION
I found that the pop up that came up after losing a game said, "Bang! You loose."
Wanted my first commit to the shoes4 project so here is the typo fix to make
the pop up state that, "Bang! You lose."
I also removed some code that had been commented out.
