### PR TITLE
Fix for overlapping text

### DIFF
--- a/shoes-swt/lib/shoes/swt/text_block/fitter.rb
+++ b/shoes-swt/lib/shoes/swt/text_block/fitter.rb
@@ -184,6 +184,9 @@ class Shoes
           segment
         end
 
+        # Splits the text into two pieces based on height. Allows one final
+        # line to exceed the requested height, which results in smoother
+        # flowing text between different sized fonts on a line.
         def split_text(layout, height)
           ending_offset = 0
           height_so_far = 0
@@ -191,9 +194,9 @@ class Shoes
           offsets = layout.line_offsets
           offsets[0...-1].each_with_index do |_, i|
             height_so_far += layout.line_bounds(i).height
-            break if height_so_far > height
-
             ending_offset = offsets[i + 1]
+
+            break if height_so_far > height
           end
           [layout.text[0...ending_offset], layout.text[ending_offset..-1]]
         end

--- a/shoes-swt/spec/shoes/swt/text_block/fitter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block/fitter_spec.rb
@@ -74,11 +74,11 @@ describe Shoes::Swt::TextBlock::Fitter do
   end
 
   describe "finding what didn't fit" do
-    it "should tell split text by offsets and heights" do
-      segment = double('segment', line_offsets: [0, 5, 9], text: "Text Split")
-      allow(segment).to receive(:line_bounds) { double('line_bounds', height: 50)}
+    it "splits when one line past requested height" do
+      segment = double('segment', line_offsets: [0, 5, 10], text: "Text Split")
+      allow(segment).to receive(:line_bounds) { double('line_bounds', height: 25)}
 
-      expect(subject.split_text(segment, 55)).to eq(["Text ", "Split"])
+      expect(subject.split_text(segment, 24)).to eq(["Text ", "Split"])
     end
 
     it "should be able to split text when too small" do


### PR DESCRIPTION
Fixes #942 overlapping.

Will be a separate change incoming that will bump text after headings
to a newline, but this gets things so they don't overlap more cleanly.

When flowing text to a second layout, we would stop short of consuming
all the vertical space provided us, but then position the second layout
based on the height of the first layout. Sometimes this resulted in
overlapping text.

Instead, we will now keep putting text into into the first layout until
it completely fills the height--even if it goes over by a little--so
that we get a smoother flow into the second layout.
