### PR TITLE
Fix for background margins

### DIFF
--- a/shoes-core/lib/shoes/dimension.rb
+++ b/shoes-core/lib/shoes/dimension.rb
@@ -218,8 +218,7 @@ class Shoes
   end
 
   class ParentDimension < Dimension
-    SIMPLE_DELEGATE_METHODS = [:extent, :absolute_start, :margin_start,
-                               :margin_end, :start]
+    SIMPLE_DELEGATE_METHODS = [:extent, :absolute_start, :start]
 
     SIMPLE_DELEGATE_METHODS.each do |method|
       define_method method do

--- a/shoes-core/spec/shoes/dimension_spec.rb
+++ b/shoes-core/spec/shoes/dimension_spec.rb
@@ -363,11 +363,12 @@ describe Shoes::Dimension do
       parent.margin_end   = margin
     end
 
-    describe 'it takes its parent values if no values are set' do
-      its(:start) {should eq parent_start}
+    describe 'it takes some parent values if no values are set' do
+      its(:start)  {should eq parent_start}
       its(:extent) {should eq parent_extent}
-      its(:margin_start) {should eq margin}
-      its(:margin_end) {should eq margin}
+
+      its(:margin_start) {should eq 0}
+      its(:margin_end)   {should eq 0}
 
       context 'with parent absolute_start set' do
         before :each do
@@ -375,8 +376,8 @@ describe Shoes::Dimension do
         end
 
         its(:absolute_start) {should eq 11}
-        its(:element_start) {should eq parent.element_start}
-        its(:element_end) {should eq parent.element_end}
+        its(:element_start)  {should eq parent.absolute_start}
+        its(:element_end)    {should eq parent.absolute_end}
       end
     end
 

--- a/shoes-core/spec/shoes/dimensions_spec.rb
+++ b/shoes-core/spec/shoes/dimensions_spec.rb
@@ -719,22 +719,23 @@ describe Shoes::Dimensions do
       end
     end
   end
-  
+
   describe Shoes::ParentDimensions do
-    describe 'takes parent values if not specified' do
+    describe 'takes some parent values if not specified' do
       let(:parent) {Shoes::Dimensions.new nil, parent_left, parent_top,
                                           parent_width, parent_height,
                                           margin: 20}
       subject {Shoes::ParentDimensions.new parent}
 
-      its(:left) {should eq parent.left}
-      its(:top) {should eq parent.top}
-      its(:width) {should eq parent.width}
+      its(:left)   {should eq parent.left}
+      its(:top)    {should eq parent.top}
+      its(:width)  {should eq parent.width}
       its(:height) {should eq parent.height}
-      its(:margin_left) {should eq parent.margin_left}
-      its(:margin_top) {should eq parent.margin_top}
-      its(:margin_right) {should eq parent.margin_right}
-      its(:margin_bottom) {should eq parent.margin_bottom}
+
+      its(:margin_left)   {should eq 0}
+      its(:margin_top)    {should eq 0}
+      its(:margin_right)  {should eq 0}
+      its(:margin_bottom) {should eq 0}
 
       context 'with parent absolute_left/top set' do
         before :each do
@@ -743,9 +744,9 @@ describe Shoes::Dimensions do
         end
 
         its(:absolute_left) {should eq parent.absolute_left}
-        its(:absolute_top) {should eq parent.absolute_top}
-        its(:element_left) {should eq parent.element_left}
-        its(:element_top) {should eq parent.element_top}
+        its(:absolute_top)  {should eq parent.absolute_top}
+        its(:element_left)  {should eq parent.absolute_left}
+        its(:element_top)   {should eq parent.absolute_top}
       end
     end
 


### PR DESCRIPTION
First part of a fix for #874. This PR removes our delegation to the parent
margin for users of ParentDimension (which is only background and border). Both
of these cases already have the margin factored in, so we were doubling up on
it.

~~I also found in the course of this that the check for needing positioning
didn't seem to matter given how the parent dimension lookups override values
for us in the background and border. Less code == more better, so removed.~~
_Nope_

I'm going to run through some samples on this to confirm nothing's too weird.
Note that there's another PR inbound after this that will deal with the
backgrounds running past the end of the containing parent.
