### PR TITLE
Run background and border through positioning

### DIFF
--- a/shoes-core/lib/shoes/background.rb
+++ b/shoes-core/lib/shoes/background.rb
@@ -16,9 +16,5 @@ class Shoes
       @parent.add_child self
       @gui = Shoes.backend_for self
     end
-
-    def needs_to_be_positioned?
-      absolutely_positioned?
-    end
   end
 end

--- a/shoes-core/lib/shoes/border.rb
+++ b/shoes-core/lib/shoes/border.rb
@@ -16,9 +16,5 @@ class Shoes
       @parent.add_child self
       @gui = Shoes.backend_for self
     end
-
-    def needs_to_be_positioned?
-      false
-    end
   end
 end

--- a/shoes-core/lib/shoes/dimensions.rb
+++ b/shoes-core/lib/shoes/dimensions.rb
@@ -91,12 +91,6 @@ class Shoes
       self.margin_right, self.margin_bottom =  margin
     end
 
-    # used by positioning code in slot and there to be overwritten if something
-    # does not need to be positioned like a background or so
-    def needs_to_be_positioned?
-      true
-    end
-
     def takes_up_space?
       true
     end

--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -143,7 +143,6 @@ class Shoes
     end
 
     def positioning(element, current_position)
-      return current_position unless element.needs_to_be_positioned?
       position_element element, current_position
       element.contents_alignment(current_position) if element.respond_to? :contents_alignment
       if element.takes_up_space?
@@ -241,9 +240,12 @@ class Shoes
     end
 
     def compute_content_height
-      max_bottom = contents.reject(&:hidden?)
-                   .map(&:absolute_bottom)
-                   .max
+      max_bottom = contents.
+                    select(&:takes_up_space?).
+                    reject(&:hidden?).
+                    map(&:absolute_bottom).
+                    max
+
       if max_bottom
         max_bottom - self.absolute_top + NEXT_ELEMENT_OFFSET
       else

--- a/shoes-core/spec/shoes/background_spec.rb
+++ b/shoes-core/spec/shoes/background_spec.rb
@@ -38,16 +38,5 @@ describe Shoes::Background do
     it_behaves_like "object with negative dimensions"
   end
 
-  describe '#needs_to_be_positioned?' do
-    context 'without absolute dimensions' do
-      let(:input_opts) {{}}
-      it {is_expected.not_to be_needs_to_be_positioned}
-    end
-
-    context 'with absolute dimensions' do
-      it {is_expected.to be_needs_to_be_positioned}
-    end
-  end
-
   it {is_expected.not_to be_takes_up_space}
 end

--- a/shoes-core/spec/shoes/border_spec.rb
+++ b/shoes-core/spec/shoes/border_spec.rb
@@ -43,5 +43,4 @@ describe Shoes::Border do
   end
 
   it {is_expected.not_to be_takes_up_space}
-  it {is_expected.not_to be_needs_to_be_positioned}
 end

--- a/shoes-core/spec/shoes/dimensions_spec.rb
+++ b/shoes-core/spec/shoes/dimensions_spec.rb
@@ -659,7 +659,6 @@ describe Shoes::Dimensions do
 
   end
 
-  it {is_expected.to be_needs_to_be_positioned}
   it {is_expected.to be_takes_up_space}
 
   describe 'left/top/right/bottom not set so get them relative to parent' do

--- a/shoes-core/spec/shoes/shared_examples/slot.rb
+++ b/shoes-core/spec/shoes/shared_examples/slot.rb
@@ -96,14 +96,6 @@ shared_examples_for 'positioning through :_position' do
     expect(element).not_to receive(:_position)
     subject.contents_alignment
   end
-
-  it 'does not position an element if it does not need positioning' do
-    my_element = element
-    allow(my_element).to receive_messages needs_to_be_positioned?: false
-    expect(my_element).not_to receive :_position
-    subject.add_child my_element
-    subject.contents_alignment
-  end
 end
 
 shared_examples_for 'element one positioned with top and left' do

--- a/shoes-core/spec/shoes/slot_spec.rb
+++ b/shoes-core/spec/shoes/slot_spec.rb
@@ -138,6 +138,49 @@ describe Shoes::Slot do
       bound = subject.create_bound_block(block)
       bound.call
     end
+  end
 
+  describe "compute_content_height" do
+    subject(:slot) { Shoes::Slot.new(app, parent) }
+
+    it "finds 0 without children" do
+      expect(compute_content_height).to eq(0)
+    end
+
+    describe "with children" do
+      let(:child) {
+        child_element = Shoes::FakeElement.new(subject, height: 100)
+        child_element.absolute_top = 0
+        child_element.gui = double('child gui').as_null_object
+        child_element
+      }
+
+      before do
+        subject.add_child(child)
+      end
+
+      it "finds height from child" do
+        expect(compute_content_height).to eq(100)
+      end
+
+      it "ignores unpositioned children" do
+        allow(child).to receive(:absolute_bottom) { nil }
+        expect(compute_content_height).to eq(0)
+      end
+
+      it "ignores hidden child" do
+        child.hide
+        expect(compute_content_height).to eq(0)
+      end
+
+      it "ignores child that doesn't take up space" do
+        allow(child).to receive(:takes_up_space?) { false }
+        expect(compute_content_height).to eq(0)
+      end
+    end
+
+    def compute_content_height
+      subject.send(:compute_content_height)
+    end
   end
 end


### PR DESCRIPTION
Further pursuit of #874. Along with #976, I think this might have us in a
good place for background margins.

I noted after merging #973 that my fix only "worked" when the background
had a position set. Turns out, the parent slot was only getting a shot to give
a margin to backgrounds when the background was positioned, so a
standard `background white` would end up not getting margins.

I'd toyed before with always positioning backgrounds and borders, but hit
a hang where we got into an infinite re-layout. Well, I solved that problem when
I realized we already have the `takes_up_space?` method which computing
the slot height should have been consulting. Once I did that, I could let the
background and borders get positioned, they get their margins done naturally
then, and we drop some unneeded code. Hurray!

Also proceeded to add some specs around the protected method
`compute_content_height` on the slot since it was gathering a huge cluster
of conditionals that we don't really exercise. Chose to just send to the
protected because actually driving this through `contents_alignment` (the
nearest public method), introduces a TON of other dependencies that were
cluttering up the test. So, slight smell of the send vs much simpler tests... I
thought the simplicity here won out. Let me know if you feel strongly otherwise!

Will be doing another sample run-through (potentially on a merge of this with
#976 to make sure those don't have any conflicts when all put together) before

heading for a merge.
