### PR TITLE
Try the new travis-ci build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-script: "rake spec:all"
+script: "bundle exec rake spec:all"
 rvm:
   - jruby-19mode
   - jruby-head


### PR DESCRIPTION
See the blog post: http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/

Other projects seem to have decreased build time tremendously. We can't use sudo with this but afaik we don't need to.

There is also bundler caching support now, but I can't see how we can invalidate the cache without a `Gemfile.lock`: http://docs.travis-ci.com/user/caching/
