### PR TITLE
Line drawing wasn't taking parent into account

### DIFF
--- a/shoes-swt/lib/shoes/swt/line.rb
+++ b/shoes-swt/lib/shoes/swt/line.rb
@@ -27,8 +27,8 @@ class Shoes
 
       class Painter < Common::Painter
         def draw(gc)
-          point_a, point_b = @obj.dsl.point_a, @obj.dsl.point_b
-          gc.draw_line(point_a.x, point_a.y, point_b.x, point_b.y)
+          gc.draw_line(@obj.element_left, @obj.element_top,
+                       @obj.element_right + 1, @obj.element_bottom + 1)
         end
 
         # Don't do fill setup

--- a/shoes-swt/spec/shoes/swt/line_spec.rb
+++ b/shoes-swt/spec/shoes/swt/line_spec.rb
@@ -30,6 +30,8 @@ describe Shoes::Swt::Line do
     subject { Shoes::Swt::Line::Painter.new(shape) }
 
     before(:each) do
+      dsl.absolute_left = point_a.x
+      dsl.absolute_top  = point_a.y
       allow(dsl).to receive_messages(positioned?: true)
     end
 


### PR DESCRIPTION
Wasn't right to use the absolute positions, should have been using the
element variety instead.

We don't, however, want the slight pixel counting adjustment, so give
the end back a +1 that the calculated elements don't have. (Running
`expert-minesweeper-adjusted.rb` shows clearly how current code depends on
the exact placement of the lines.)

Fixes #978.

Tested against samples `simple-face.rb`, `expert-tankspank.rb`,
`expert-minesweeper-adjusted.rb` and `good-clock.rb` (all of which involve
some meaningful line drawing).
