### PR TITLE
TextBlocks have #parent not #parent_text, refers to the same though

### DIFF
--- a/shoes-core/lib/shoes/common/style.rb
+++ b/shoes-core/lib/shoes/common/style.rb
@@ -1,6 +1,11 @@
+# The general Style module handles the many optional styles that may be passed
+# to shoes elements upon creates as well as the fact that they can later on be
+# altered through the #style method.
+#
+# Relies upon:
+#   @app - a reference to the Shoes applications
 class Shoes
   module Common
-    # Style methods.
     module Style
       DEFAULT_STYLES = {
         fill:        Shoes::COLORS[:black],

--- a/shoes-core/lib/shoes/dsl.rb
+++ b/shoes-core/lib/shoes/dsl.rb
@@ -558,7 +558,7 @@ EOS
 
     def link(*texts, &blk)
       opts = normalize_style_for_element(Shoes::Link, texts)
-      create Shoes::Link, texts, opts, blk
+      Shoes::Link.new @__app__, texts, opts, blk
     end
 
     def span(*texts)

--- a/shoes-core/lib/shoes/link.rb
+++ b/shoes-core/lib/shoes/link.rb
@@ -2,13 +2,12 @@ class Shoes
   class Link < Span
     include Common::Style
 
-    attr_reader :app, :parent, :gui, :blk
+    attr_reader :app, :gui, :blk
     style_with :common_styles, :text_block_styles
     STYLES = { underline: true, stroke: ::Shoes::COLORS[:blue], fill: nil }
 
-    def initialize(app, parent, texts, styles = {}, blk = nil)
-      @app = app
-      @parent = parent
+    def initialize(my_app, texts, styles = {}, blk = nil)
+      @app = my_app
       style_init styles
       @gui = Shoes.backend_for self
 

--- a/shoes-core/lib/shoes/span.rb
+++ b/shoes-core/lib/shoes/span.rb
@@ -6,8 +6,8 @@ class Shoes
     end
 
     def style
-      if @parent_text && @parent_text.respond_to?(:style)
-        @parent_text.style.merge(@style)
+      if @parent && @parent.respond_to?(:style)
+        @parent.style.merge(@style)
       else
         @style
       end

--- a/shoes-core/lib/shoes/text.rb
+++ b/shoes-core/lib/shoes/text.rb
@@ -3,18 +3,18 @@ class Shoes
     include Common::Inspect
 
     attr_reader :to_s, :texts, :color
-    attr_accessor :parent_text, :text_block
+    attr_accessor :parent, :text_block
 
     def initialize(texts, color = nil)
-      @texts       = texts
-      @color       = color
-      @to_s        = @texts.map(&:to_s).join
-      @parent_text = nil
-      @text_block  = nil
+      @texts      = texts
+      @color      = color
+      @to_s       = @texts.map(&:to_s).join
+      @parent     = nil
+      @text_block = nil
     end
 
     def app
-      @parent_text.app
+      @parent.app
     end
 
     def inspect

--- a/shoes-core/lib/shoes/text_block.rb
+++ b/shoes-core/lib/shoes/text_block.rb
@@ -84,7 +84,7 @@ class Shoes
       texts.each do |text|
         if text.is_a? Shoes::Text
           text.text_block  = self
-          text.parent_text = parent_text
+          text.parent      = parent_text
           end_point        = start_point + text.to_s.length - 1
 
           # If our endpoint is before our start, it's an empty string. We treat

--- a/shoes-core/spec/shoes/link_spec.rb
+++ b/shoes-core/spec/shoes/link_spec.rb
@@ -6,7 +6,7 @@ describe Shoes::Link do
   let(:internal_app) { double("internal app", app: app, gui: gui, style: {}, element_styles: {}) }
   let(:texts) { ["text", "goes", "first"] }
 
-  subject { Shoes::Link.new(app, app, texts, {color: :blue}) }
+  subject { Shoes::Link.new(app, texts, {color: :blue}) }
 
   context "initialize" do
     it "should set up text" do
@@ -25,7 +25,7 @@ describe Shoes::Link do
     end
 
     context "overriding styles" do
-      subject { Shoes::Link.new(app, app, texts,
+      subject { Shoes::Link.new(app, texts,
                                 underline: false, bg: Shoes::COLORS[:green]) }
 
       it "should include defaults" do
@@ -43,7 +43,7 @@ describe Shoes::Link do
 
     context "with a block" do
       let(:callable) { double("callable") }
-      subject { Shoes::Link.new(internal_app, nil, texts, {}, Proc.new { callable.call }) }
+      subject { Shoes::Link.new(internal_app, texts, {}, Proc.new { callable.call }) }
 
       it "sets up for the click" do
         expect(callable).to receive(:call)
@@ -52,7 +52,7 @@ describe Shoes::Link do
     end
 
     context "with click option as text" do
-      subject { Shoes::Link.new(internal_app, nil, texts, click: "/url") }
+      subject { Shoes::Link.new(internal_app, texts, click: "/url") }
 
       it "should visit the url" do
         expect(app).to receive(:visit).with("/url")
@@ -62,7 +62,7 @@ describe Shoes::Link do
 
     context "with click option as Proc" do
       let(:callable) { double("callable", call: nil) }
-      subject { Shoes::Link.new(internal_app, nil, texts, click: Proc.new { callable.call }) }
+      subject { Shoes::Link.new(internal_app, texts, click: Proc.new { callable.call }) }
 
       it "calls the block" do
         expect(callable).to receive(:call)
@@ -73,7 +73,7 @@ describe Shoes::Link do
     context "calling click explicitly" do
       let(:original_block)    { double("original") }
       let(:replacement_block) { double("replacement") }
-      subject { Shoes::Link.new(internal_app, nil, texts) { original_block.call } }
+      subject { Shoes::Link.new(internal_app, texts) { original_block.call } }
 
       it "replaces original block" do
         expect(original_block).to_not receive(:call)
@@ -100,6 +100,19 @@ describe Shoes::Link do
     it 'forwards hidden? calls' do
       subject.hidden?
       expect(text_block).to have_received :hidden?
+    end
+  end
+
+  # #979
+  describe 'parent' do
+    let(:text_block) {double 'text block'}
+
+    before :each do
+      subject.parent = text_block
+    end
+
+    it 'has the correct parent, namingly he text block' do
+      expect(subject.parent).to eq text_block
     end
   end
 end

--- a/shoes-core/spec/shoes/span_spec.rb
+++ b/shoes-core/spec/shoes/span_spec.rb
@@ -33,13 +33,13 @@ describe Shoes::Span do
     let(:red) {Shoes::COLORS[:red]}
     it 'does not try to merge with parent style when there are none' do
       parent = double 'parent'
-      span.parent_text = parent
+      span.parent = parent
       expect {span.style}.to_not raise_error()
     end
 
     it 'merges with the styles of the parent text' do
       parent = double 'parent', style: {stroke: white}
-      span.parent_text = parent
+      span.parent = parent
       expect(span.style[:stroke]).to eq(white)
     end
 
@@ -47,7 +47,7 @@ describe Shoes::Span do
       let(:style) {{stroke: red}}
       it 'prefers own values over parent text values' do
         parent = double 'parent', style: {stroke: white}
-        span.parent_text = parent
+        span.parent = parent
         expect(span.style[:stroke]).to eq(red)
       end
     end

--- a/shoes-core/spec/shoes/text_block_spec.rb
+++ b/shoes-core/spec/shoes/text_block_spec.rb
@@ -4,7 +4,7 @@ require 'shoes/helpers/sample17_helper'
 describe Shoes::TextBlock do
   include_context "dsl app"
 
-  let(:text_link) { Shoes::Link.new(app, parent, ['Hello']) }
+  let(:text_link) { Shoes::Link.new(app, ['Hello']) }
   let(:text) { [text_link, ", world!"] }
   subject(:text_block) { Shoes::TextBlock.new(app, parent, text, {app: app}) }
 
@@ -256,11 +256,11 @@ describe Shoes::TextBlock do
     end
 
     it 'sets the parent_text of the non nested texts to the para' do
-      expect(helper.strong_breadsticks.parent_text).to eq para
+      expect(helper.strong_breadsticks.parent).to eq para
     end
 
     it 'sets the parent_text of nested fragments correctly' do
-      expect(helper.ins.parent_text).to eq helper.strong
+      expect(helper.ins.parent).to eq helper.strong
     end
 
     it 'lets the nested text fragements know what their text block is' do

--- a/shoes-swt/spec/shoes/swt/link_spec.rb
+++ b/shoes-swt/spec/shoes/swt/link_spec.rb
@@ -3,7 +3,7 @@ require 'shoes/swt/spec_helper'
 describe Shoes::Swt::Link do
   include_context "swt app"
 
-  let(:dsl) { Shoes::Link.new shoes_app, parent, ["linky"] }
+  let(:dsl) { Shoes::Link.new shoes_app, ["linky"] }
 
   subject { Shoes::Swt::Link.new(dsl, swt_app) }
 

--- a/shoes-swt/spec/shoes/swt/text_block/text_segment_collection_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block/text_segment_collection_spec.rb
@@ -243,7 +243,7 @@ describe Shoes::Swt::TextBlock::TextSegmentCollection do
   end
 
   def create_link(text)
-    Shoes::Link.new(shoes_app, parent, [text])
+    Shoes::Link.new(shoes_app, [text])
   end
 
   def style_with(style={})

--- a/shoes-swt/spec/shoes/swt/text_block_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block_spec.rb
@@ -163,7 +163,7 @@ describe Shoes::Swt::TextBlock do
   end
 
   context "links" do
-    let(:link)     { Shoes::Link.new(shoes_app, subject, ["link"])  }
+    let(:link)     { Shoes::Link.new(shoes_app, ["link"])  }
 
     before(:each) do
       allow(dsl).to receive(:links) { [link] }


### PR DESCRIPTION
We introduced `parent_text` for `Text` elements to refer to their parent text_block. Turns out in Shoes3 this is just called `parent`, how we usually referred to the slot around it. :)

This introduced the problem in #979 - where a link did get handed a parent which was a slot and was conflicting.

These elements now don't have a reference to the slot anymore, but they don't need it. Should we need it, we could change it through the text block.
