### PR TITLE
Make the SWT image spec independent of where it is run from

### DIFF
--- a/shoes-swt/spec/shoes/swt/image_spec.rb
+++ b/shoes-swt/spec/shoes/swt/image_spec.rb
@@ -13,7 +13,8 @@ describe Shoes::Swt::Image do
   let(:top) { 200 }
   let(:height) { nil }
   let(:width) {nil}
-  let(:image) { "shoes-swt/spec/shoes/swt/minimal.png" }
+  let(:image_path) { File.dirname(__FILE__) + '/minimal.png' }
+  let(:image) { image_path }
 
   subject {
     allow(dsl).to receive(:file_path) { image }
@@ -41,7 +42,7 @@ describe Shoes::Swt::Image do
   end
 
   describe "painting raw images" do
-    let(:image) { File.read("shoes-swt/spec/shoes/swt/minimal.png", :mode => "rb") }
+    let(:image) { File.read(image_path, :mode => "rb") }
 
     specify "loads image from raw data" do
       subject.real.image_data.width = 3


### PR DESCRIPTION
It failed when running from the shoes-swt directory, due to the  hard coded path:

```
tobi@speedy ~/github/shoes4/shoes-swt $ rspec spec/shoes/swt/image_spec.rb 
/home/tobi/.rvm/gems/jruby-1.7.18@shoes/gems/simplecov-0.9.1/lib/simplecov.rb:31 warning: tracing (e.g. set_trace_func) will not capture all events without --debug flag
I, [2014-12-26T19:42:23.941000 #6978]  INFO -- : Not reporting to Code Climate because ENV['CODECLIMATE_REPO_TOKEN'] is not set.
FFFFFFFFFFFFFFFFFF

Failures:

  1) Shoes::Swt::Image behaves like paintable registers for painting
     Failure/Error: Unable to find matching line from backtrace
     Java::OrgEclipseSwt::SWTException:
       i/o error (java.io.FileNotFoundException: shoes-swt/spec/shoes/swt/minimal.png (No such file or directory))
```

This makes it work :) So you can now also do just `rspec` in that directory!
