### PR TITLE
Add breaking changelog category

### DIFF
--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -2,7 +2,8 @@ class Changelog
   CATEGORY_MAPPING = [
     {pattern: 'Changelog: feature', heading: 'New features'},
     {pattern: 'Changelog: improvement', heading: 'Improvements'},
-    {pattern: 'Changelog: bugfix', heading: 'Bug Fixes'}
+    {pattern: 'Changelog: bugfix', heading: 'Bug Fixes'},
+    {pattern: 'Changelog: breaking', heading: 'Breaking Changes'}
   ]
 
   COMMIT_SEPARATOR     = '<--COMMIT-->'


### PR DESCRIPTION
I noticed that it might be nice to have a changelog entry if things break previous behavior or previous shoes3 behavior. So here we are. Btw. I love it when software is build in such a way like here when adding something that is prone to be added at some point is EASY and OBVIOUS to add. Thanks @wasnotrice for that code :heart: 

This fixes #1004 
