### PR TITLE
Fix for fully empty text segment range

### DIFF
--- a/shoes-swt/lib/shoes/swt/text_block/text_segment_collection.rb
+++ b/shoes-swt/lib/shoes/swt/text_block/text_segment_collection.rb
@@ -83,6 +83,8 @@ class Shoes
         # segments apply, and what the relative ranges within each segment to use.
         def segment_ranges(text_range)
           return [] unless @segments.first # TODO WTF #636
+          return [] unless text_range.any?
+
           first_text = @segments.first.text
           slice = first_text[text_range]
 

--- a/shoes-swt/spec/shoes/swt/text_block/text_segment_collection_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block/text_segment_collection_spec.rb
@@ -85,6 +85,11 @@ describe Shoes::Swt::TextBlock::TextSegmentCollection do
         result = subject.segment_ranges(0..first_segment.text.length + 10)
         expect(result).to eql([[first_segment, 0..first_segment.text.length]])
       end
+
+      it "picks properly with empty range" do
+        result = subject.segment_ranges(0...0)
+        expect(result).to be_empty
+      end
     end
 
     describe "relative text positions" do


### PR DESCRIPTION
When we pass a text range of `(0...0)` non-inclusive and thus fully empty, the
code that was picking out the text to use was wrong and ended up with negative
values.

Fixes #1014.

Thanks for the find @PragTob. On to pre3 once this is merged!