### PR TITLE
Smart spec_helper for root

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --color
 --format progress
 --order random
+--require spec/spec_helper.rb

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,15 @@
+# This is a helper to let `rspec test-file` run directly from the root dir by
+# pulling in the right spec helpers from the subdirectories
+
+dirs = ARGV.select do |path|
+  path.match /^shoes-.*\//
+end
+
+dirs.map! do |path|
+  File.expand_path(path.split("/").first)
+end
+
+dirs.uniq!
+dirs.each do |dir|
+  require File.join(dir, "spec", "spec_helper")
+end


### PR DESCRIPTION
This commit adds a smart spec_helper at the root of the project which
allows us to just do things like `rspec
shoes-swt/spec/shoes/swt/text_block_spec.rb` and have it work properly
(mod the `JRUBY_OPTS=-XstartOnFirstThread` for OS X users).

It works by just taking the first `shoes-.*` segment of any paths that are
passed, and requires their respective `spec/spec_helper`.

Note that there are potential side-effects if running an odd set of
tests across projects, but it does make the easy case easy.