### PR TITLE
Move some stray requires to be with their friends

### DIFF
--- a/shoes-core/lib/shoes/core.rb
+++ b/shoes-core/lib/shoes/core.rb
@@ -1,4 +1,1 @@
-require 'tmpdir'
-require 'fileutils'
-
 require 'shoes/dsl'

--- a/shoes-core/lib/shoes/dsl.rb
+++ b/shoes-core/lib/shoes/dsl.rb
@@ -1,5 +1,8 @@
+require 'delegate'
+require 'fileutils'
 require 'forwardable'
 require 'pathname'
+require 'tmpdir'
 require 'shoes/common/registration'
 
 class Shoes

--- a/shoes-core/lib/shoes/logger/ruby.rb
+++ b/shoes-core/lib/shoes/logger/ruby.rb
@@ -1,5 +1,3 @@
-require 'delegate'
-
 class Shoes
   module Logger
     class Ruby < SimpleDelegator


### PR DESCRIPTION
No reason to have these requires all off by themselves like they're not
as good as all of the rest :D

Making these requires consistent also allows us to only have to modify
one file to load shoes-core for the atom backend.