### PR TITLE
Add method for adding details to inspect string

### DIFF
--- a/shoes-core/lib/shoes/app.rb
+++ b/shoes-core/lib/shoes/app.rb
@@ -86,11 +86,11 @@ class Shoes
     alias_method :fullscreen?, :fullscreen
 
     def to_s
-      inject_title super
+      add_detail_to_inspect super, " \"#{@__app__.app_title}\""
     end
 
     def inspect
-      inject_title super
+      add_detail_to_inspect super, " \"#{@__app__.app_title}\""
     end
 
     def eval_with_additional_context(context, &blk)
@@ -125,12 +125,6 @@ class Shoes
     def self.new_dsl_method(name, &blk)
       define_method name, blk
       @method_subscribers.each { |klazz| klazz.def_delegator :app, name }
-    end
-
-    protected
-
-    def inject_title(string)
-      "#{string.chop} \"#{@__app__.app_title}\"#{string[-1]}"
     end
   end
 end

--- a/shoes-core/lib/shoes/app.rb
+++ b/shoes-core/lib/shoes/app.rb
@@ -85,14 +85,6 @@ class Shoes
 
     alias_method :fullscreen?, :fullscreen
 
-    def to_s
-      add_detail_to_inspect super, " \"#{@__app__.app_title}\""
-    end
-
-    def inspect
-      add_detail_to_inspect super, " \"#{@__app__.app_title}\""
-    end
-
     def eval_with_additional_context(context, &blk)
       @__additional_context__ = context
       instance_eval(&blk) if blk
@@ -107,6 +99,18 @@ class Shoes
         super
       end
     end
+
+    private
+
+    def inspect_details
+      " \"#{@__app__.app_title}\""
+    end
+
+    def to_s_details
+      inspect_details
+    end
+
+    public
 
     DELEGATE_BLACKLIST = [:parent, :app]
 

--- a/shoes-core/lib/shoes/color.rb
+++ b/shoes-core/lib/shoes/color.rb
@@ -79,11 +79,11 @@ EOS
       "rgb(#{red}, #{green}, #{blue})"
     end
 
-    def inspect
-      add_detail_to_inspect super, " #{self} alpha:#{@alpha}"
-    end
-
     private
+
+    def inspect_details
+      " #{self} alpha:#{@alpha}"
+    end
 
     def normalize_rgb(value)
       rgb = value.is_a?(Fixnum) ? value : (255 * value).round

--- a/shoes-core/lib/shoes/color.rb
+++ b/shoes-core/lib/shoes/color.rb
@@ -80,7 +80,7 @@ EOS
     end
 
     def inspect
-      super.insert(-2, " #{self} alpha:#{@alpha}")
+      add_detail_to_inspect super, " #{self} alpha:#{@alpha}"
     end
 
     private

--- a/shoes-core/lib/shoes/common/inspect.rb
+++ b/shoes-core/lib/shoes/common/inspect.rb
@@ -19,8 +19,8 @@ class Shoes
       #
       # add_detail_to_inspect("(Shoes::Object)", 'o="eyelet"')
       #     #=> (Shoes::Object o="eyelet")
-      def add_detail_to_inspect(string, details)
-        "#{string.chop}#{details}#{string[-1]}"
+      def add_detail_to_inspect(string, detail)
+        "#{string.chop}#{detail}#{string[-1]}"
       end
     end
   end

--- a/shoes-core/lib/shoes/common/inspect.rb
+++ b/shoes-core/lib/shoes/common/inspect.rb
@@ -9,6 +9,19 @@ class Shoes
       def inspect
         "(#{self.class.name}:#{'0x%08x' % (object_id * 2)})"
       end
+
+      protected
+
+      # Creates a new string with details placed before last character
+      # of string.
+      #
+      # Example:
+      #
+      # add_detail_to_inspect("(Shoes::Object)", 'o="eyelet"')
+      #     #=> (Shoes::Object o="eyelet")
+      def add_detail_to_inspect(string, details)
+        "#{string.chop}#{details}#{string[-1]}"
+      end
     end
   end
 end

--- a/shoes-core/lib/shoes/common/inspect.rb
+++ b/shoes-core/lib/shoes/common/inspect.rb
@@ -2,25 +2,26 @@ class Shoes
   module Common
     module Inspect
       def to_s
-        "(#{self.class.name})"
+        "(#{self.class.name}#{to_s_details})"
       end
 
       # Object hex representation from https://github.com/michaeldv/awesome_print
+      # Example:
+      #   (Shoes::App:0x01234abc "Hello")
       def inspect
-        "(#{self.class.name}:#{'0x%08x' % (object_id * 2)})"
+        "(#{self.class.name}:#{'0x%08x' % (object_id * 2)}#{inspect_details})"
       end
 
-      protected
+      private
 
-      # Creates a new string with details placed before last character
-      # of string.
-      #
-      # Example:
-      #
-      # add_detail_to_inspect("(Shoes::Object)", 'o="eyelet"')
-      #     #=> (Shoes::Object o="eyelet")
-      def add_detail_to_inspect(string, detail)
-        "#{string.chop}#{detail}#{string[-1]}"
+      # Additional details to include in the inspect representation.
+      def inspect_details
+        ''
+      end
+
+      # Additional details to include in the to_s representation.
+      def to_s_details
+        ''
       end
     end
   end

--- a/shoes-core/lib/shoes/dimensions.rb
+++ b/shoes-core/lib/shoes/dimensions.rb
@@ -97,10 +97,10 @@ class Shoes
 
     def inspect
       nothing = '_'
-      details = " relative:#{Point.new left, top}->#{Point.new right, bottom}" \
+      detail = " relative:#{Point.new left, top}->#{Point.new right, bottom}" \
                 " absolute:#{Point.new absolute_left, absolute_top}->#{Point.new absolute_right, absolute_bottom}" \
                 " #{width || nothing}x#{height || nothing}"
-      add_detail_to_inspect super, details
+      add_detail_to_inspect super, detail
     end
 
     def self.setup_delegations

--- a/shoes-core/lib/shoes/dimensions.rb
+++ b/shoes-core/lib/shoes/dimensions.rb
@@ -97,10 +97,10 @@ class Shoes
 
     def inspect
       nothing = '_'
-      super.insert(-2,
-                   " relative:#{Point.new left, top}->#{Point.new right, bottom}" \
-                   " absolute:#{Point.new absolute_left, absolute_top}->#{Point.new absolute_right, absolute_bottom}" \
-                   " #{width || nothing}x#{height || nothing}")
+      details = " relative:#{Point.new left, top}->#{Point.new right, bottom}" \
+                " absolute:#{Point.new absolute_left, absolute_top}->#{Point.new absolute_right, absolute_bottom}" \
+                " #{width || nothing}x#{height || nothing}"
+      add_detail_to_inspect super, details
     end
 
     def self.setup_delegations

--- a/shoes-core/lib/shoes/dimensions.rb
+++ b/shoes-core/lib/shoes/dimensions.rb
@@ -95,14 +95,6 @@ class Shoes
       true
     end
 
-    def inspect
-      nothing = '_'
-      detail = " relative:#{Point.new left, top}->#{Point.new right, bottom}" \
-                " absolute:#{Point.new absolute_left, absolute_top}->#{Point.new absolute_right, absolute_bottom}" \
-                " #{width || nothing}x#{height || nothing}"
-      add_detail_to_inspect super, detail
-    end
-
     def self.setup_delegations
       methods_to_rename = Dimension.public_instance_methods false
       renamed_delegate_to :x_dimension, methods_to_rename, 'start'  => 'left',
@@ -116,6 +108,13 @@ class Shoes
     setup_delegations
 
     private
+
+    def inspect_details
+      nothing = '_'
+      " relative:#{Point.new left, top}->#{Point.new right, bottom}" \
+        " absolute:#{Point.new absolute_left, absolute_top}->#{Point.new absolute_right, absolute_bottom}" \
+        " #{width || nothing}x#{height || nothing}"
+    end
 
     def hash_as_argument?(left)
       left.respond_to? :fetch

--- a/shoes-core/lib/shoes/gradient.rb
+++ b/shoes-core/lib/shoes/gradient.rb
@@ -11,7 +11,7 @@ class Shoes
     attr_reader :alpha, :color1, :color2
 
     def inspect
-      super.insert(-2, " #{color1}->#{color2}")
+      add_detail_to_inspect super, " #{color1}->#{color2}"
     end
 
     def <=>(other) # arbitrarily compare 1st non-equal color

--- a/shoes-core/lib/shoes/gradient.rb
+++ b/shoes-core/lib/shoes/gradient.rb
@@ -10,10 +10,6 @@ class Shoes
 
     attr_reader :alpha, :color1, :color2
 
-    def inspect
-      add_detail_to_inspect super, " #{color1}->#{color2}"
-    end
-
     def <=>(other) # arbitrarily compare 1st non-equal color
       raise_class_mismatch_error(other) unless other.is_a?(self.class)
       if @color1 == other.color1
@@ -26,6 +22,12 @@ class Shoes
     def raise_class_mismatch_error(other)
       fail ArgumentError,
            "can't compare #{self.class.name} with #{other.class.name}"
+    end
+
+    private
+
+    def inspect_details
+      " #{color1}->#{color2}"
     end
   end
 end

--- a/shoes-core/lib/shoes/internal_app.rb
+++ b/shoes-core/lib/shoes/internal_app.rb
@@ -149,7 +149,7 @@ class Shoes
     end
 
     def inspect
-      super.insert(-2, " \"#{@app_title}\" #{@dimensions.inspect})")
+      add_detail_to_inspect super, " \"#{@app_title}\" #{@dimensions.inspect}"
     end
 
     def self.global_keypresses

--- a/shoes-core/lib/shoes/point.rb
+++ b/shoes-core/lib/shoes/point.rb
@@ -48,7 +48,7 @@ class Shoes
     end
 
     def inspect
-      super.insert(-2, " #{self}")
+      add_detail_to_inspect super, " #{self}"
     end
   end
 end

--- a/shoes-core/lib/shoes/point.rb
+++ b/shoes-core/lib/shoes/point.rb
@@ -47,8 +47,10 @@ class Shoes
       "(#{@x || nothing},#{@y || nothing})"
     end
 
-    def inspect
-      add_detail_to_inspect super, " #{self}"
+    private
+
+    def inspect_details
+      " #{self}"
     end
   end
 end

--- a/shoes-core/lib/shoes/slot_contents.rb
+++ b/shoes-core/lib/shoes/slot_contents.rb
@@ -33,12 +33,11 @@ class Shoes
       @contents.clear
     end
 
-    def inspect
-      detail = " @size=#{size} @prepending=#{@prepending} @prepending_index=#{@prepending_index}"
-      add_detail_to_inspect super, detail
-    end
-
     private
+
+    def inspect_details
+      " @size=#{size} @prepending=#{@prepending} @prepending_index=#{@prepending_index}"
+    end
 
     def append_element(element)
       @contents << element

--- a/shoes-core/lib/shoes/slot_contents.rb
+++ b/shoes-core/lib/shoes/slot_contents.rb
@@ -34,8 +34,8 @@ class Shoes
     end
 
     def inspect
-      details = " @size=#{size} @prepending=#{@prepending} @prepending_index=#{@prepending_index}"
-      add_detail_to_inspect super, details
+      detail = " @size=#{size} @prepending=#{@prepending} @prepending_index=#{@prepending_index}"
+      add_detail_to_inspect super, detail
     end
 
     private

--- a/shoes-core/lib/shoes/slot_contents.rb
+++ b/shoes-core/lib/shoes/slot_contents.rb
@@ -34,7 +34,8 @@ class Shoes
     end
 
     def inspect
-      super.insert(-2, " @size=#{size} @prepending=#{@prepending} @prepending_index=#{@prepending_index}")
+      details = " @size=#{size} @prepending=#{@prepending} @prepending_index=#{@prepending_index}"
+      add_detail_to_inspect super, details
     end
 
     private

--- a/shoes-core/lib/shoes/text.rb
+++ b/shoes-core/lib/shoes/text.rb
@@ -18,7 +18,7 @@ class Shoes
     end
 
     def inspect
-      super.insert(-2, %( "#{self}"))
+      add_detail_to_inspect super, " \"#{self}\""
     end
   end
 end

--- a/shoes-core/lib/shoes/text.rb
+++ b/shoes-core/lib/shoes/text.rb
@@ -17,8 +17,10 @@ class Shoes
       @parent.app
     end
 
-    def inspect
-      add_detail_to_inspect super, " \"#{self}\""
+    private
+
+    def inspect_details
+      " \"#{self}\""
     end
   end
 end


### PR DESCRIPTION
For consistency, readability, and compatibility with Opal's unmodifiable strings.

I was never really comfortable with the `insert` copy-pasted all over the code. I think this takes us at least a step in the right direction.