### PR TITLE
Fix for hang during content alignment with text

### DIFF
--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -150,6 +150,13 @@ class Shoes
       else
         current_position
       end
+    rescue => e
+      puts "SWALLOWED POSITIONING EXCEPTION ON #{element} - go take care of it: " + e.to_s
+      puts e.backtrace.join("\n\t")
+      puts 'Unfortunately we have to swallow it or risk SWT hanging.'
+      puts "It doesn't like exceptions during layout. :O"
+
+      current_position
     end
 
     def position_element(_element, _current_position)

--- a/shoes-core/spec/shoes/shared_examples/slot.rb
+++ b/shoes-core/spec/shoes/shared_examples/slot.rb
@@ -108,6 +108,12 @@ shared_examples_for 'positioning through :_position' do
     expect(element).not_to receive(:_position)
     subject.contents_alignment
   end
+
+  it 'is resilient to exceptions during positioning' do
+    allow(element).to receive(:contents_alignment).and_raise("O_o")
+    allow(subject).to receive(:puts)  # Quiet, you
+    add_child_and_align
+  end
 end
 
 shared_examples_for 'element one positioned with top and left' do

--- a/shoes-swt/lib/shoes/swt/text_block.rb
+++ b/shoes-swt/lib/shoes/swt/text_block.rb
@@ -44,9 +44,12 @@ class Shoes
       end
 
       def adjust_current_position(current_position)
-        last_segment = segments.last
         current_position.y = @dsl.absolute_bottom
-        current_position.y -= last_segment.last_line_height unless @bumped_to_next_line
+
+        last_segment = segments.last
+        if last_segment && !@bumped_to_next_line
+          current_position.y -= last_segment.last_line_height
+        end
       end
 
       def set_absolutes_on_dsl(current_position)

--- a/shoes-swt/lib/shoes/swt/text_block.rb
+++ b/shoes-swt/lib/shoes/swt/text_block.rb
@@ -37,6 +37,8 @@ class Shoes
         dispose_existing_segments
         @segments = Fitter.new(self, current_position).fit_it_in
 
+        return if @segments.nil? || @segments.empty?
+
         set_absolutes_on_dsl(current_position)
         set_calculated_sizes
       end

--- a/shoes-swt/lib/shoes/swt/text_block/fitter.rb
+++ b/shoes-swt/lib/shoes/swt/text_block/fitter.rb
@@ -95,6 +95,10 @@ class Shoes
         end
 
         def fit_as_empty_first_layout(height)
+          if height == :unbounded || height == 0
+            return []
+          end
+
           height += ::Shoes::Slot::NEXT_ELEMENT_OFFSET
           generate_two_layouts(empty_segment, "", @dsl.text, height)
         end

--- a/shoes-swt/spec/shoes/swt/text_block/fitter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block/fitter_spec.rb
@@ -183,6 +183,20 @@ describe Shoes::Swt::TextBlock::Fitter do
         expect_segments(segments, [20, 76], [1, 96])
       end
     end
+
+    context "doesn't fit" do
+      it "with no width and unbounded height" do
+        allow(dsl).to receive_messages(desired_width: 0)
+        segments = when_fit_at(x: 0, y: 0, next_line_start: 0)
+        expect(segments).to be_empty
+      end
+
+      it "with no width and 0 height" do
+        allow(dsl).to receive_messages(desired_width: 0, containing_width: 0)
+        segments = when_fit_at(x: 0, y: 0, next_line_start: 1)
+        expect(segments).to be_empty
+      end
+    end
   end
 
   def with_text_split(first, second)

--- a/shoes-swt/spec/shoes/swt/text_block_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block_spec.rb
@@ -90,6 +90,11 @@ describe Shoes::Swt::TextBlock do
         expect(current_position.y).to eq(layout_height)
       end
 
+      it "is aligns and positions safely without segments" do
+        allow(fitter).to receive(:fit_it_in).and_return([])
+        when_aligns_and_positions
+      end
+
       it "disposes of prior segments" do
         subject.contents_alignment(current_position)
         expect(segment).to receive(:dispose)

--- a/shoes-swt/spec/shoes/swt/text_block_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block_spec.rb
@@ -124,6 +124,13 @@ describe Shoes::Swt::TextBlock do
           subject.remove
         end
       end
+
+      context "when doesn't fit" do
+        it "bails out early" do
+          allow(fitter).to receive(:fit_it_in).and_return([])
+          subject.contents_alignment(current_position)
+        end
+      end
     end
 
     describe "with two segments" do


### PR DESCRIPTION
This fixes #982 in two ways:

* Calculations which were failing when text blocks got squeezed too small have been individually tightened up to not raise. These are the changes you see in `swt/text_block/fitter.rb` and `swt/text_block.rb` which are being more careful around 0 height/width and empty segments.
* Also, because the behavior is so strange and unhelpful, we also now trap exceptions in the slot positioning code rather **loudly** but carry on so we don't bork SWT.

:boom: => :hushed: 