### PR TITLE
Download fixes

### DIFF
--- a/shoes-core/lib/shoes/download.rb
+++ b/shoes-core/lib/shoes/download.rb
@@ -69,17 +69,27 @@ class Shoes
     def start_download
       require 'open-uri'
       @thread = Thread.new do
-        uri_opts = {}
-        uri_opts[:content_length_proc] = content_length_proc
-        uri_opts[:progress_proc] = progress_proc if @progress_blk
+        begin
+          uri_opts = {}
+          uri_opts[:content_length_proc] = content_length_proc
+          uri_opts[:progress_proc] = progress_proc if @progress_blk
 
-        open @url, uri_opts do |download_data|
-          @response.body = download_data.read
-          @response.status = download_data.status
-          @response.headers = download_data.meta
-          save_to_file(@opts[:save]) if @opts[:save]
-          finish_download download_data
+          open @url, uri_opts do |download_data|
+            @response.body = download_data.read
+            @response.status = download_data.status
+            @response.headers = download_data.meta
+            save_to_file(@opts[:save]) if @opts[:save]
+            finish_download download_data
+          end
+        rescue => e
+          eval_block(error_proc, e)
         end
+      end
+    end
+
+    def error_proc
+      lambda do |exception|
+        raise exception
       end
     end
 

--- a/shoes-core/lib/shoes/download.rb
+++ b/shoes-core/lib/shoes/download.rb
@@ -51,6 +51,7 @@ class Shoes
     end
 
     def percent
+      return 0 if @transferred.nil? || @content_length.nil?;
       @transferred * 100 / @content_length
     end
 

--- a/shoes-core/spec/shoes/download_spec.rb
+++ b/shoes-core/spec/shoes/download_spec.rb
@@ -147,4 +147,16 @@ describe Shoes::Download do
     end
 
   end
+
+  describe 'when things go wrong' do
+    it 'reports back to the parent thread' do
+      error = StandardError.new("Nope")
+
+      expect(download.gui).to receive(:eval_block).with(anything, error)
+      allow(download).to receive(:open).and_raise(error)
+
+      download.start
+      download.join_thread
+    end
+  end
 end

--- a/shoes-core/spec/shoes/download_spec.rb
+++ b/shoes-core/spec/shoes/download_spec.rb
@@ -92,6 +92,10 @@ describe Shoes::Download do
           with(bound_block, download).
           twice
       end
+
+      it 'can call percent just fine thanks' do
+        expect(download.percent).to eq(0)
+      end
     end
   end
 


### PR DESCRIPTION
So there were two separate things reported over in #911 that I address here (at least partially).

https://github.com was a problem because the response we receive from them didn't have a `Content-Length` header, so we didn't set the content length instance variable properly and crashed. I fixed this simply by making `percent` more resilient to those values being `nil`--other uses of them generally looked ok to me, although I wasn't too exhaustive about reading up on them.

http://github.com returns a 301 redirect to https://github.com... but unfortunately `open-uri` disallows redirecting from `http` elsewhere for security reasons (see https://github.com/ruby/ruby/blob/trunk/lib/open-uri.rb#L243-L252 for the gory details). So while I can't fix that without changing our use of `open-uri`, what I did was made it so the error actually propagates up. It was happening on a background thread and silently dying, so now when the download thread gets a problem it shuttles it off to the parent thread via the standard `eval_block` used in all the download code to get work done on the main UI thread.

Certainly up for discussion of whether we should use a different HTTP library, but these changes seem valuable on their own regardless where we head with that.