### PR TITLE
Support click on shape

### DIFF
--- a/shoes-core/lib/shoes/shape.rb
+++ b/shoes-core/lib/shoes/shape.rb
@@ -100,6 +100,14 @@ class Shoes
       self
     end
 
+    # Determines if a given point is in the boundary of the shape. Given the
+    # many possibilities of what a shape could contain, this just checks the
+    # outer bounding box of the shape, nothing more sophisticated.
+    def in_bounds?(x, y)
+      (@left_bound..@right_bound).include?(x) &&
+      (@top_bound..@bottom_bound).include?(y)
+    end
+
     private
 
     # Updates the bounds of this shape to include the rectangle described by

--- a/shoes-core/spec/shoes/shape_spec.rb
+++ b/shoes-core/spec/shoes/shape_spec.rb
@@ -44,7 +44,7 @@ describe Shoes::Shape do
     describe "when created without left and top values" do
       let(:left) { nil }
       let(:top) { nil }
-      
+
       its(:left) { should eq(nil) }
       its(:top) { should eq(nil) }
     end
@@ -90,6 +90,18 @@ describe Shoes::Shape do
     }
 
     it_behaves_like "movable object"
+  end
+
+  describe "in_bounds?" do
+    let(:draw) { Proc.new { line_to 100, 100 } }
+
+    it "is in bounds" do
+      expect(subject.in_bounds?(10, 10)).to be true
+    end
+
+    it "is out of bounds" do
+      expect(subject.in_bounds?(101, 101)).to be false
+    end
   end
 
   describe "accesses app" do

--- a/shoes-core/spec/shoes/shape_spec.rb
+++ b/shoes-core/spec/shoes/shape_spec.rb
@@ -16,6 +16,7 @@ describe Shoes::Shape do
   end
 
   it_behaves_like "movable object"
+  it_behaves_like "clickable object"
 
   describe "octagon" do
     let(:draw) {

--- a/shoes-swt/lib/shoes/swt/shape.rb
+++ b/shoes-swt/lib/shoes/swt/shape.rb
@@ -1,6 +1,7 @@
 class Shoes
   module Swt
     class Shape
+      include Common::Clickable
       include Common::Remove
       include Common::Fill
       include Common::Stroke

--- a/shoes-swt/spec/shoes/swt/shape_spec.rb
+++ b/shoes-swt/spec/shoes/swt/shape_spec.rb
@@ -20,6 +20,7 @@ describe Shoes::Swt::Shape do
   it_behaves_like "Swt::Shape"
   it_behaves_like "paintable"
   it_behaves_like "removable"
+  it_behaves_like 'clickable backend'
 
   it "properly disposes" do
     expect(subject.transform).to receive(:dispose)


### PR DESCRIPTION
Just what it says on the tin :wink: 

The first problem was that the backend was lacking the support for click, which was easily remedied by adding the `Shoes::Swt::Common::Clickable` module.

That unearthed that the standard `Dimensions` provided `in_bounds?` check wasn't quite right, because `Shape` doesn't participate in normal positioning (being an art element), and has its own bounds instance variables kept up to date throughout drawing. Given that, a custom `in_bounds?` didn't seem, ahem, out of bounds to me so I went with it.