### PR TITLE
Support the hidden style on all elements

### DIFF
--- a/shoes-core/lib/shoes/common/initialization.rb
+++ b/shoes-core/lib/shoes/common/initialization.rb
@@ -19,6 +19,7 @@ class Shoes
         @gui = Shoes.backend_for self
 
         handle_block(blk)
+        update_visibility
 
         after_initialize(*args)
       end

--- a/shoes-core/lib/shoes/common/style.rb
+++ b/shoes-core/lib/shoes/common/style.rb
@@ -123,6 +123,7 @@ class Shoes
       def update_style(new_styles)
         normalized_style = StyleNormalizer.new.normalize(new_styles)
         set_dimensions(new_styles)
+        set_visibility(new_styles)
         click(&new_styles[:click]) if new_styles.key?(:click)
         @style.merge! normalized_style
       end
@@ -132,6 +133,12 @@ class Shoes
         new_styles.each do |key, value|
           send("#{key}=", value) if STYLE_GROUPS[:dimensions].include?(key)
         end
+      end
+
+      def set_visibility(new_styles)
+        return unless new_styles.include?(:hidden)
+        @style[:hidden] = new_styles[:hidden]
+        update_visibility
       end
 
       def update_dimensions # so that @style hash matches actual values

--- a/shoes-core/lib/shoes/common/visibility.rb
+++ b/shoes-core/lib/shoes/common/visibility.rb
@@ -3,12 +3,12 @@ class Shoes
     module Visibility
       # Hides the element, so that it can't be seen. See also #show and #toggle.
       def hide
-        @hidden = true
+        style[:hidden] = true
         update_visibility
       end
 
       def hidden?
-        @hidden
+        style[:hidden]
       end
 
       alias_method :hidden, :hidden?
@@ -19,21 +19,21 @@ class Shoes
 
       # Reveals the element, if it is hidden. See also #hide and #toggle.
       def show
-        @hidden = false
+        style[:hidden] = false
         update_visibility
       end
 
       # Hides an element if it is shown. Or shows the element, if it is hidden.
       # See also #hide and #show.
       def toggle
-        @hidden = !@hidden
+        style[:hidden] = !style[:hidden]
         update_visibility
       end
 
       private
 
       def update_visibility
-        gui.update_visibility
+        gui.update_visibility if gui.respond_to?(:update_visibility)
         self
       end
     end

--- a/shoes-core/lib/shoes/common/visibility.rb
+++ b/shoes-core/lib/shoes/common/visibility.rb
@@ -33,7 +33,7 @@ class Shoes
       private
 
       def update_visibility
-        gui.update_visibility if gui.respond_to?(:update_visibility)
+        gui.update_visibility
         self
       end
     end

--- a/shoes-core/lib/shoes/input_box.rb
+++ b/shoes-core/lib/shoes/input_box.rb
@@ -10,6 +10,7 @@ class Shoes
 
     def handle_block(blk)
       change(&blk) if blk
+      update_visibility
     end
 
     def state=(value)

--- a/shoes-core/lib/shoes/mock/arc.rb
+++ b/shoes-core/lib/shoes/mock/arc.rb
@@ -1,7 +1,9 @@
 class Shoes
   module Mock
     class Arc
+      include Shoes::Mock::CommonMethods
       include Shoes::Mock::Clickable
+
       def initialize(_dsl, _app, _opts = {})
       end
     end

--- a/shoes-core/lib/shoes/mock/common_methods.rb
+++ b/shoes-core/lib/shoes/mock/common_methods.rb
@@ -7,6 +7,9 @@ class Shoes
 
       def update_position
       end
+
+      def update_visibility
+      end
     end
   end
 end

--- a/shoes-core/lib/shoes/mock/slot.rb
+++ b/shoes-core/lib/shoes/mock/slot.rb
@@ -1,6 +1,7 @@
 class Shoes
   module Mock
     class Slot
+      include Shoes::Mock::CommonMethods
       include Shoes::Mock::Clickable
 
       def initialize(dsl, parent)

--- a/shoes-core/lib/shoes/progress.rb
+++ b/shoes-core/lib/shoes/progress.rb
@@ -8,6 +8,7 @@ class Shoes
 
     def after_initialize(*_)
       @gui.fraction = @style[:fraction]
+      update_visibility
     end
 
     def handle_block(*_)

--- a/shoes-core/spec/shoes/common/style_spec.rb
+++ b/shoes-core/spec/shoes/common/style_spec.rb
@@ -5,9 +5,12 @@ describe Shoes::Common::Style do
   let(:blue) { Shoes::COLORS[:blue] }
 
   class StyleTester
+    include Shoes::Common::Visibility
     include Shoes::Common::Style
+
     attr_accessor :left
     style_with :key, :left, :click, :strokewidth, :fill
+
     STYLES = {fill: Shoes::COLORS[:blue]}
 
     def initialize(app, styles = {})
@@ -23,7 +26,11 @@ describe Shoes::Common::Style do
     def click_blk
       @click
     end
+
+    def update_visibility
+    end
   end
+
   subject {StyleTester.new(app)}
 
   its(:style) { should eq (initial_style) }
@@ -55,6 +62,16 @@ describe Shoes::Common::Style do
     it 'writes new dimensions' do
       subject.style(left: 200)
       expect(subject.left).to eq 200
+    end
+
+    it 'reads visibility' do
+      subject.hide
+      expect(subject.style[:hidden]).to be true
+    end
+
+    it 'writes visibility' do
+      subject.style(hidden: true)
+      expect(subject.hidden?).to be true
     end
 
     it 'sets click' do

--- a/shoes-core/spec/shoes/helpers/fake_element.rb
+++ b/shoes-core/spec/shoes/helpers/fake_element.rb
@@ -12,6 +12,13 @@ class Shoes
     def adjust_current_position(*_)
     end
 
+    # Fake this out instead of using Common::Style to avoid things like touching
+    # app level styles, etc. that we don't need for testing purposes
+    def style
+      @style ||= {}
+      @style
+    end
+
     attr_accessor :parent, :gui
   end
 end

--- a/shoes-swt/lib/shoes/swt/shape.rb
+++ b/shoes-swt/lib/shoes/swt/shape.rb
@@ -2,6 +2,7 @@ class Shoes
   module Swt
     class Shape
       include Common::Clickable
+      include Common::Visibility
       include Common::Remove
       include Common::Fill
       include Common::Stroke


### PR DESCRIPTION
Per #808 and compatibility with Shoes 3.

To accomplish this, instead of using a separate instance variable in the `Shoes::Common::Visibility` module (`@hidden`), we now back onto `style[:hidden]` as the stateful source of all truth about whether to show ourselves or not.

This required a couple of additional changes:

* ~~Several elements needed to have a call to `update_visibility` when they were done. These were primarily anything without a painter (since painters were taking visibility into account properly), because the backends didn't consult the visibility flags directly. I actually like this well enough, since another backend will get the proper calls, and we don't bake things. Note that we can't do this in `style_init` because the backend objects don't actually exist yet at that point in time. We'd need another "done with initializing" hook to try to do it generically.~~ Revised in light of #1030 so only one the `Common::Initialization#initialize` method needed `update_visibility` added. Hurray!
* For testing purposes `Shoes::Common::Visibility#update_visibility` does a `respond_to?` check since now it gets hit against the mocks, which don't all individually have that method. This seemed cleaner than scattering more of this business across the mocks to me at the moment.
* `Shoes::FakeElement` got a little bit of style treatment, since it uses `Visibility` but not `Style` (too much app-level stuff in that module to use from this fake object).