### PR TITLE
Fix gem name check on uninstall

### DIFF
--- a/shoes-core/lib/rubygems_plugin.rb
+++ b/shoes-core/lib/rubygems_plugin.rb
@@ -4,7 +4,7 @@ require 'fileutils'
 # See ext/install/Rakefile for why this cleanup is our responsibility.
 # Decide if user uninstalled executables based on our actual Ruby script.
 Gem.post_uninstall do |gem|
-  uninstalling_shoes = gem.spec.name == "shoes"
+  uninstalling_shoes = gem.spec.name == "shoes-core"
   missing_executable = !File.exist?(File.join(Gem.bindir, "shoes-picker")) &&
                        !File.exist?(File.join(Gem.bindir, "shoes-picker.bat"))
 


### PR DESCRIPTION
Missed in the Great Gem Shuffle (Part 2) of 2014

Result was that uninstall `shoes-core` potentially left around a stale `shoes` (or `shoes.bat` for the Windows-inclined) and `shoes-backend` executable.

Noticed while taking a peek at #1029. Double goodness from one PR!