### PR TITLE
Move guard against empty text segments further up in the chain

### DIFF
--- a/shoes-swt/lib/shoes/swt/text_block/painter.rb
+++ b/shoes-swt/lib/shoes/swt/text_block/painter.rb
@@ -15,6 +15,10 @@ class Shoes
         def paintControl(paint_event)
           reset_graphics_context(paint_event.gc)
           return if @dsl.hidden?
+          # See #636 for discussion, contents_alignment may not run or if the
+          # space is very narrow we might squish things down to be very narrow.
+          # If paint is triggered then, code later on will crash.
+          return if @dsl.gui.segments.empty?
 
           draw_layouts(paint_event.gc)
         end

--- a/shoes-swt/lib/shoes/swt/text_block/text_segment_collection.rb
+++ b/shoes-swt/lib/shoes/swt/text_block/text_segment_collection.rb
@@ -82,7 +82,6 @@ class Shoes
         # be in either, or both, of the segments. This method figures out which
         # segments apply, and what the relative ranges within each segment to use.
         def segment_ranges(text_range)
-          return [] unless @segments.first # TODO WTF #636
           return [] unless text_range.any?
 
           first_text = @segments.first.text


### PR DESCRIPTION
It has been shown that adding some elements triggers a redraw
while positioning has not run yet and causes failures later on.
This fixes #636 as we have found the root cause of the problem,
which can be resolved by solving #593 :)

Thanks @jasonrclark ! :)