### PR TITLE
Fix the lookup of constants for JRuby 9k

### DIFF
--- a/shoes-core/lib/shoes/configuration.rb
+++ b/shoes-core/lib/shoes/configuration.rb
@@ -43,8 +43,10 @@ class Shoes
       #   Shoes.configuration.backend_class(shoes_button) # => Shoes::Swt::Button
       def backend_class(shoes_object)
         class_name = shoes_object.class.name.split("::").last
-        fail ArgumentError, "#{shoes_object} does not have a backend class defined for #{backend}" unless backend.const_defined?(class_name)
-        backend.const_get(class_name)
+        # Lookup with false to not consult modules higher in the chain Object
+        # because Shoes::Swt.const_defined? 'Range' => true
+        fail ArgumentError, "#{shoes_object} does not have a backend class defined for #{backend}" unless backend.const_defined?(class_name, false)
+        backend.const_get(class_name, false)
       end
 
       # Creates an appropriate backend object, passing along additional arguments


### PR DESCRIPTION
Behavior seems to have changed but 9k behavior is consistent
with 1.9+ so seems to have been a 1.7 bug.

JRuby 1.7:
```
tobi@airship ~/github/shoes4 $ irb
jruby-1.7.18 :001 > module Bla
jruby-1.7.18 :002?>   end
 => nil 
jruby-1.7.18 :003 > Bla.const_defined? 'Range'
 => false 
jruby-1.7.18 :004 > exit
```


Ruby 1.9.3:
```
tobi@airship ~/github/shoes4 $ irb
1.9.3-p551 :001 > module Bla
1.9.3-p551 :002?>   end
 => nil 
1.9.3-p551 :003 > Bla.const_defined? 'Range'
 => true 
1.9.3-p551 :004 > exit
```

The latter on is also the 2.2/9k behavior :)

With this, locally the jruby-head specs past for.. like the first time :rocket: 