### PR TITLE
Fixes for one-pixel off problems with text blocks

### DIFF
--- a/shoes-swt/lib/shoes/swt/text_block.rb
+++ b/shoes-swt/lib/shoes/swt/text_block.rb
@@ -44,10 +44,11 @@ class Shoes
       end
 
       def adjust_current_position(current_position)
-        current_position.y = @dsl.absolute_bottom
+        current_position.y = @dsl.absolute_bottom + 1
 
         last_segment = segments.last
         if last_segment && !@bumped_to_next_line
+          current_position.x -= 1
           current_position.y -= last_segment.last_line_height
         end
       end
@@ -70,10 +71,10 @@ class Shoes
         last_segment = segments.last
 
         @dsl.absolute_right  = starting_left + last_segment.last_line_width +
-          margin_right
+          margin_right - 1
 
         @dsl.absolute_bottom = starting_top + last_segment.height +
-          margin_top + margin_bottom
+          margin_top + margin_bottom - 1
       end
 
       def bump_absolutes_to_next_line

--- a/shoes-swt/lib/shoes/swt/text_block.rb
+++ b/shoes-swt/lib/shoes/swt/text_block.rb
@@ -7,6 +7,7 @@ class Shoes
       include ::Shoes::BackendDimensionsDelegations
 
       DEFAULT_SPACING = 4
+      NEXT_ELEMENT_OFFSET = 1
 
       attr_reader :dsl, :app
       attr_accessor :segments
@@ -44,11 +45,15 @@ class Shoes
       end
 
       def adjust_current_position(current_position)
-        current_position.y = @dsl.absolute_bottom + 1
+        current_position.y = @dsl.absolute_bottom + NEXT_ELEMENT_OFFSET
 
         last_segment = segments.last
         if last_segment && !@bumped_to_next_line
+          # Not quite sure why this is necessary. Could be a problem in some
+          # other part of positioning, or something about how text layouts
+          # actually draw themselves.
           current_position.x -= 1
+
           current_position.y -= last_segment.last_line_height
         end
       end
@@ -71,10 +76,10 @@ class Shoes
         last_segment = segments.last
 
         @dsl.absolute_right  = starting_left + last_segment.last_line_width +
-          margin_right - 1
+          margin_right - NEXT_ELEMENT_OFFSET
 
         @dsl.absolute_bottom = starting_top + last_segment.height +
-          margin_top + margin_bottom - 1
+          margin_top + margin_bottom - NEXT_ELEMENT_OFFSET
       end
 
       def bump_absolutes_to_next_line

--- a/shoes-swt/lib/shoes/swt/text_block/fitter.rb
+++ b/shoes-swt/lib/shoes/swt/text_block/fitter.rb
@@ -197,7 +197,7 @@ class Shoes
 
           offsets = layout.line_offsets
           offsets[0...-1].each_with_index do |_, i|
-            height_so_far += layout.line_bounds(i).height + 1
+            height_so_far += layout.line_bounds(i).height + TextBlock::NEXT_ELEMENT_OFFSET
             ending_offset = offsets[i + 1]
 
             break if height_so_far >= height

--- a/shoes-swt/lib/shoes/swt/text_block/fitter.rb
+++ b/shoes-swt/lib/shoes/swt/text_block/fitter.rb
@@ -136,7 +136,7 @@ class Shoes
             first_layout.position_at(@dsl.element_left,
                                      @dsl.element_top),
             second_layout.position_at(parent.absolute_left + @dsl.margin_left,
-                                      @dsl.element_top + first_height + 1)
+                                      @dsl.element_top + first_height)
           ]
         end
 
@@ -197,10 +197,10 @@ class Shoes
 
           offsets = layout.line_offsets
           offsets[0...-1].each_with_index do |_, i|
-            height_so_far += layout.line_bounds(i).height
+            height_so_far += layout.line_bounds(i).height + 1
             ending_offset = offsets[i + 1]
 
-            break if height_so_far > height
+            break if height_so_far >= height
           end
           [layout.text[0...ending_offset], layout.text[ending_offset..-1]]
         end

--- a/shoes-swt/spec/shoes/swt/text_block/fitter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block/fitter_spec.rb
@@ -149,13 +149,13 @@ describe Shoes::Swt::TextBlock::Fitter do
       it "rolls to second segment when 0 remaining width" do
         allow(dsl).to receive_messages(desired_width: 0)
         segments = when_fit_at(x: 0, y: 75, next_line_start: 95)
-        expect_segments(segments, [26, 76], [1, 97])
+        expect_segments(segments, [26, 76], [1, 96])
       end
 
       it "rolls to second segment when negative remaining width" do
         allow(dsl).to receive_messages(desired_width: -1)
         segments = when_fit_at(x: 0, y: 75, next_line_start: 95)
-        expect_segments(segments, [26, 76], [1, 97])
+        expect_segments(segments, [26, 76], [1, 96])
       end
     end
 
@@ -174,13 +174,13 @@ describe Shoes::Swt::TextBlock::Fitter do
       it "bumps down a line if not at start" do
         allow(dsl).to receive_messages(element_left: 20, left: 20)
         segments = when_fit_at(x: 20, y: 75, next_line_start: 95)
-        expect_segments(segments, [20, 76], [1, 96])
+        expect_segments(segments, [20, 76], [1, 95])
       end
 
       it "if unbounded height, still bumps down properly" do
         allow(dsl).to receive_messages(absolute_top: 95, element_left: 20, left: 20, margin_left: 1)
         segments = when_fit_at(x: 20, y: 75, next_line_start: 95)
-        expect_segments(segments, [20, 76], [1, 96])
+        expect_segments(segments, [20, 76], [1, 95])
       end
     end
 

--- a/shoes-swt/spec/shoes/swt/text_block_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block_spec.rb
@@ -59,35 +59,36 @@ describe Shoes::Swt::TextBlock do
       end
 
       it "positions single line of text" do
-        expect(dsl).to receive(:absolute_right=).with(layout_width + 50)
-        expect(dsl).to receive(:absolute_bottom=).with(layout_height)
+        expect(dsl).to receive(:absolute_right=).with(layout_width + 50 - 1)
+        expect(dsl).to receive(:absolute_bottom=).with(layout_height - 1)
 
         when_aligns_and_positions
 
-        expect(current_position.y).to eq(layout_height - line_height)
+        expect(current_position.y).to eq(layout_height - line_height + 1)
       end
 
       it "positions single line with margin" do
         allow(dsl).to receive_messages(margin_left: margin, margin_right: margin,
                  margin_top: margin, margin_bottom: margin)
 
-        expect(dsl).to receive(:absolute_right=).with(layout_width + 50 + margin)
-        expect(dsl).to receive(:absolute_bottom=).with(layout_height + 2 * margin)
+        expect(dsl).to receive(:absolute_right=).with(layout_width + 50 + margin - 1)
+        expect(dsl).to receive(:absolute_bottom=).with(layout_height + 2 * margin - 1)
 
         when_aligns_and_positions
 
-        expect(current_position.y).to eq(layout_height - line_height)
+        expect(current_position.y).to eq(layout_height - line_height + 1)
       end
 
       it "pushes to next line if ends in newline" do
         allow(dsl).to receive(:text) { "text\n" }
 
         expect(dsl).to receive(:absolute_right=).with(50)
-        expect(dsl).to receive(:absolute_bottom=).with(layout_height)
+        expect(dsl).to receive(:absolute_right=).with(149)
+        expect(dsl).to receive(:absolute_bottom=).with(layout_height - 1)
 
         when_aligns_and_positions
 
-        expect(current_position.y).to eq(layout_height)
+        expect(current_position.y).to eq(layout_height + 1)
       end
 
       it "is aligns and positions safely without segments" do
@@ -152,24 +153,24 @@ describe Shoes::Swt::TextBlock do
       end
 
       it "positions in two segments" do
-        expect(dsl).to receive(:absolute_right=).with(layout_width)
-        expect(dsl).to receive(:absolute_bottom=).with(layout_height)
+        expect(dsl).to receive(:absolute_right=).with(layout_width - 1)
+        expect(dsl).to receive(:absolute_bottom=).with(layout_height - 1)
 
         when_aligns_and_positions
 
-        expect(current_position.y).to eq(layout_height - line_height)
+        expect(current_position.y).to eq(layout_height - line_height + 1)
       end
 
       it "positions in two segments with margins" do
         allow(dsl).to receive_messages(margin_left: margin, margin_right: margin,
                  margin_top: margin, margin_bottom: margin)
 
-        expect(dsl).to receive(:absolute_right=).with(layout_width + margin)
-        expect(dsl).to receive(:absolute_bottom=).with(layout_height + 2 * margin)
+        expect(dsl).to receive(:absolute_right=).with(layout_width + margin - 1)
+        expect(dsl).to receive(:absolute_bottom=).with(layout_height + 2 * margin - 1)
 
         when_aligns_and_positions
 
-        expect(current_position.y).to eq(layout_height - line_height)
+        expect(current_position.y).to eq(layout_height - line_height + 1)
       end
     end
   end


### PR DESCRIPTION
This addresses a variety of different off-by-one issues we had with the
exact layout of text blocks. This shows most prominently when text
blocks are lined up with backgrounds. See #777 for an example.

Note that I'm not in love with how these changes went, but from testing
they are right in appearance, even if I can't precisely explain all the
fiddly bits off the top of my head. It deals with:

* One-pixel between text blocks horizontally
* One pixel between text blocks vertically
* An additional horizontal pixel off when flowing to second section of a text block
* Text blocks of same height bumping down two lines instead of lining up perfectly

There are still some other issues I've uncovered based on #777, so I won't
be closing it on this, but these seemed like a valid step to take.