### PR TITLE
Text background and wrapping fix

### DIFF
--- a/shoes-swt/lib/shoes/swt/text_block/fitter.rb
+++ b/shoes-swt/lib/shoes/swt/text_block/fitter.rb
@@ -121,6 +121,7 @@ class Shoes
         end
 
         def generate_two_layouts(first_layout, first_text, second_text, height)
+          first_layout.fill_background = true
           second_layout = generate_second_layout(second_text)
           position_two_segments(first_layout, second_layout, first_text, height)
         end

--- a/shoes-swt/lib/shoes/swt/text_block/text_segment.rb
+++ b/shoes-swt/lib/shoes/swt/text_block/text_segment.rb
@@ -14,7 +14,8 @@ class Shoes
       class TextSegment
         DEFAULT_SPACING = 4
 
-        attr_reader :layout, :element_left, :element_top
+        attr_reader   :layout, :element_left, :element_top
+        attr_accessor :fill_background
 
         extend Forwardable
         def_delegators :@layout, :text, :text=, :bounds, :width, :spacing,
@@ -23,8 +24,11 @@ class Shoes
         def initialize(dsl, text, width)
           @dsl = dsl
           @layout = ::Swt::TextLayout.new Shoes.display
+          @fill_background = false
+
           @font_factory = TextFontFactory.new
           @style_factory = TextStyleFactory.new
+          @color_factory = ColorFactory.new
 
           layout.text = text
           layout.width = width
@@ -35,6 +39,7 @@ class Shoes
           @layout.dispose unless @layout.disposed?
           @font_factory.dispose
           @style_factory.dispose
+          @color_factory.dispose
         end
 
         def position_at(element_left, element_top)
@@ -91,6 +96,15 @@ class Shoes
         end
 
         def draw(graphics_context)
+          # Why not use TextLayout's background? Unfortunately it doesn't draw
+          # all the way to the edges--just around the literal text. This leaves
+          # things jagged when we flow, so do it ourselves.
+          if fill_background && @dsl.style[:fill]
+            background_color = @color_factory.create(@dsl.style[:fill])
+            background_color.apply_as_fill(graphics_context)
+            graphics_context.fill_rectangle(element_left, element_top, width, height)
+          end
+
           layout.draw(graphics_context, element_left, element_top)
         end
 

--- a/shoes-swt/lib/shoes/swt/text_block/text_segment.rb
+++ b/shoes-swt/lib/shoes/swt/text_block/text_segment.rb
@@ -27,7 +27,7 @@ class Shoes
           @style_factory = TextStyleFactory.new
 
           layout.text = text
-          layout.width = width unless layout_fits_in?(width)
+          layout.width = width
           style_from(font_styling, @dsl.style)
         end
 
@@ -76,10 +76,6 @@ class Shoes
               styles: [::Swt::SWT::NORMAL]
             }
           }
-        end
-
-        def layout_fits_in?(width)
-          layout.bounds.width <= width
         end
 
         def height

--- a/shoes-swt/spec/shoes/swt/text_block/fitter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block/fitter_spec.rb
@@ -144,6 +144,7 @@ describe Shoes::Swt::TextBlock::Fitter do
     context "to empty first segment" do
       before(:each) do
         allow(dsl).to receive_messages(containing_width: 100)
+        expect(segment).to receive(:fill_background=).with(true)
       end
 
       it "rolls to second segment when 0 remaining width" do

--- a/shoes-swt/spec/shoes/swt/text_block/text_segment_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block/text_segment_spec.rb
@@ -78,12 +78,12 @@ describe Shoes::Swt::TextBlock::TextSegment do
   end
 
   describe "shrinking on initialization" do
-    it "should not shrink when enough containing width" do
-      expect(subject.layout).to_not have_received(:width=)
+    it "happens when too long for container" do
+      bounds.width = segment_width + 10
+      expect(subject.layout).to have_received(:width=).with(segment_width)
     end
 
-    it "shrinks when too long for container" do
-      bounds.width = segment_width + 10
+    it "happens even when enough containing width" do
       expect(subject.layout).to have_received(:width=).with(segment_width)
     end
   end


### PR DESCRIPTION
This fixes #1046 and #1047 (turns out fix for #1047 addressed the other :tada:)

I've looked back at the history, and I don't see why we were bothering to try and restrict the width on the SWT `TextLayout` object if the text already fit inside the width the fitter passed. Taking that away addresses the resizing problem in #1046.

The story on #1047 is sadder and more annoying. Turns out that SWT's `TextLayout` only puts the background around the characters that it draws, even when the layout is explicitly set to a greater width.

When we're filling in the first of multiple text segments, we actually want the full space filled even though the text probably doesn't eat it all up. Given that, we have to perform the fill ourselves more directly.

Don't have 1000 more words, so here's a couple pictures:

![image](https://cloud.githubusercontent.com/assets/130504/6090988/a3eecc68-ae49-11e4-8a28-36f46b51177b.png)

![image](https://cloud.githubusercontent.com/assets/130504/6090991/cf6bc972-ae49-11e4-9d4c-7a4aae750a2d.png)
