### PR TITLE
First Appveyor Windows build running but failing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,4 +10,4 @@ build: off
 shallow_clone: true
 
 test_script:
-  - rake spec
+  - rake spec:shoes

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+install:
+  - appveyor DownloadFile https://s3.amazonaws.com/jruby.org/downloads/1.7.19/jruby-bin-1.7.19.zip
+  - 7z x jruby-bin-1.7.19.zip -y
+  - SET PATH=C:\projects\shoes4\jruby-1.7.19\bin;%PATH%
+  - gem install bundler
+  - bundle
+
+build: off
+
+shallow_clone: true
+
+test_script:
+  - rake spec


### PR DESCRIPTION
(Getting it into this stage took me a lot of trail and error - Windows and CLI.. though - squashed it though for your convenience)

Builds run on appveyor: http://www.appveyor.com/
Repository url: https://ci.appveyor.com/project/PragTob/shoes4/

The build is running now, in the sense that it installs and the tests run... however the specs fail with: 

```
Failure/Error: Unable to find matching line from backtrace
Java::OrgEclipseSwt::SWTError:
No more handles
```

I don't think it's like that on a real Windows machine, so maybe the server edition the tests are running on has less handles. Or maybe something else.

Solution strategies?

* Find a way to get rid of more handles during test runs
* Find a way to increase the number of handles on the appveyor systems
* Cry and give up on Windows builds :)

At some point this should fix #1040 

Tobi