### PR TITLE
Remove gutter specs, they are too flaky

### DIFF
--- a/shoes-core/spec/shoes/app_spec.rb
+++ b/shoes-core/spec/shoes/app_spec.rb
@@ -283,25 +283,6 @@ describe Shoes::App do
     end
   end
 
-  describe "#gutter" do
-    context "when app has a scrollbar" do
-      let(:input_opts) { {width: 100, height: 100} }
-      let(:input_block) { Proc.new { para "Round peg, square hole" * 200 } }
-
-      it "has gutter of 16" do
-        expect(app.gutter).to be_within(2).of(16)
-      end
-    end
-
-    context "when app has no scrollbar" do
-      let(:input_block) { Proc.new { para "Round peg, square hole" } }
-
-      it "has gutter of 16" do
-        expect(app.gutter).to be_within(2).of(16)
-      end
-    end
-  end
-
   describe "#parent" do
     context "for a top-level element (not explicitly in a slot)" do
       it "returns the top_slot" do


### PR DESCRIPTION
We had to always gradually adjust them, and now it seems like
Ubuntu/Unity has an entirely different behavior,
see https://github.com/shoes/shoes4/issues/772#issuecomment-73503674

Therefore I think it's best to get rid of those specs

Input on whether or not that's the best route welcome :)