### PR TITLE
Replace Bundler.require with Bundler.require(:shoes) in ui picker

### DIFF
--- a/shoes-core/lib/shoes/ui/picker.rb
+++ b/shoes-core/lib/shoes/ui/picker.rb
@@ -12,9 +12,10 @@ class Shoes
       # Only bundle if we find a local Gemfile.  This allows us to work properly
       # running from source without finding gem-nstalled backends.
       def bundle
-        return unless File.exists?("Gemfile")
-        require 'bundler/setup'
-        Bundler.require
+        if File.exist?("Gemfile")
+          require 'bundler/setup'
+          Bundler.require(:shoes)
+        end
       end
 
       def select_generator


### PR DESCRIPTION
This is a fix for https://github.com/shoes/shoes4/issues/1055

I'm not sure if it's the right fix though, so critique away.

In ```shoes-core/lib/shoes/ui/picker.rb``` ```Bundler.require``` doesn't specify a gemset and so the default gemset is used. But because shoes has a .ruby-gemset file the gems get installed to the shoes gemset and so picker.rb should use ```Bundler.require(:shoes)```