### PR TITLE
Click regions for Shoes::Line

### DIFF
--- a/shoes-core/lib/shoes/line.rb
+++ b/shoes-core/lib/shoes/line.rb
@@ -1,3 +1,5 @@
+require 'matrix'
+
 class Shoes
   class Line
     include Common::UIElement
@@ -17,6 +19,26 @@ class Shoes
 
       style[:x2] = point_b.x
       style[:y2] = point_b.y
+    end
+
+    # Check out http://math.stackexchange.com/questions/60070/checking-whether-a-point-lies-on-a-wide-line-segment
+    # for explanations how the algorithm works
+    def in_bounds?(x, y)
+      # c is (x, y)
+      left_most, right_most = point_a.x < point_b.x ? [point_a, point_b] : [point_b, point_a]
+      left_c = Vector.elements (left_most - [x, y]).to_a, false
+      left_right = Vector.elements (left_most - right_most).to_a, false
+
+      boldness = style[:strokewidth].to_i / 2
+      left_c_dot_left_right = left_c.inner_product(left_right)
+      left_right_dot_left_right = left_right.inner_product(left_right)
+
+      if left_c_dot_left_right.between?(0, left_right_dot_left_right)
+        left_c_dot_left_c = left_c.inner_product(left_c)
+        left_right_dot_left_right * left_c_dot_left_c <= boldness ** 2 * left_right_dot_left_right + left_c_dot_left_right ** 2
+      else
+        false
+      end
     end
 
     def update_style(new_styles)

--- a/shoes-core/lib/shoes/point.rb
+++ b/shoes-core/lib/shoes/point.rb
@@ -4,6 +4,7 @@ class Shoes
 
     def initialize(x, y)
       @x, @y = x, y
+      @dimensions = 2
     end
 
     attr_accessor :x, :y
@@ -30,6 +31,18 @@ class Shoes
       Shoes::Point.new(@x + x, @y + y)
     end
 
+    def +(other)
+      other = other.to_a
+      assert_dimensions_match(other.length)
+      Shoes::Point.new(x + other[0], y + other[1])
+    end
+
+    def -(other)
+      other = other.to_a
+      assert_dimensions_match(other.length)
+      Shoes::Point.new(x - other[0], y - other[1])
+    end
+
     def width(other = self)
       (@x - other.x).abs
     end
@@ -47,10 +60,18 @@ class Shoes
       "(#{@x || nothing},#{@y || nothing})"
     end
 
+    def to_a
+      [x, y]
+    end
+
     private
 
     def inspect_details
       " #{self}"
+    end
+
+    def assert_dimensions_match(other_dimension)
+      raise ArgumentError, "Dimensions mismatch: expected #{@dimensions}D point, given #{other_dimension}D point" if @dimensions != other_dimension
     end
   end
 end

--- a/shoes-core/spec/shoes/line_spec.rb
+++ b/shoes-core/spec/shoes/line_spec.rb
@@ -84,4 +84,36 @@ describe Shoes::Line do
       expect(subject.point_b).to eq(Shoes::Point.new(20, 20))
     end
   end
+
+  describe "#in_bounds?" do
+    subject(:line) { Shoes::Line.new(app, app, Shoes::Point.new(100, 100), Shoes::Point.new(50, 50), input_opts) }
+
+    it "returns true if a point is in the end of the line" do
+      expect(subject.in_bounds?(100, 100)).to be true
+    end
+
+    it "returns true if a point is in the end of the line" do
+      expect(subject.in_bounds?(50, 50)).to be true
+    end
+
+    it "returns true if a point is in the middle of the line" do
+      expect(subject.in_bounds?(75, 75)).to be true
+    end
+
+    it "returns false if a point is not in the line" do
+      expect(subject.in_bounds?(201, 200)).to be false
+    end
+
+    it "takes into account :strokewidth style" do
+      line = Shoes::Line.new(app, app, Shoes::Point.new(50, 50), Shoes::Point.new(70, 50), input_opts) 
+      line.style(strokewidth: 20)
+      expect(line.in_bounds?(50, 52)).to be true
+      expect(line.in_bounds?(50, 48)).to be true
+      expect(line.in_bounds?(50, 60)).to be true
+      expect(line.in_bounds?(50, 40)).to be true
+      expect(line.in_bounds?(49, 50)).to be false
+      expect(line.in_bounds?(50, 61)).to be false
+      expect(line.in_bounds?(70, 50)).to be true
+    end
+  end
 end

--- a/shoes-core/spec/shoes/point_spec.rb
+++ b/shoes-core/spec/shoes/point_spec.rb
@@ -29,6 +29,34 @@ describe Shoes::Point do
     end
   end
 
+  describe "#+" do
+    it "performs element-wise addition with other point" do
+      expect(subject + Shoes::Point.new(40, 50)).to eq(Shoes::Point.new(80, 100))
+    end
+
+    it "performs element-wise addition with an array" do
+      expect(subject + [40, 50]).to eq(Shoes::Point.new(80, 100))
+    end
+
+    it "doesn't perform addition when dimensions don't match" do
+      expect { subject + [40, 50, 60] }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#-" do
+    it "performs element-wise subtraction with other point" do
+      expect(subject - Shoes::Point.new(40, 50)).to eq(Shoes::Point.new(0, 0))
+    end
+
+    it "performs element-wise subtraction with an array" do
+      expect(subject - [40, 50]).to eq(Shoes::Point.new(0, 0))
+    end
+
+    it "doesn't perform subtraction when dimensions don't match" do
+      expect { subject - [40, 50, 60] }.to raise_error(ArgumentError)
+    end
+  end
+
   describe "#to" do
     it "positive" do
       expect(subject.to(24, 166)).to eq(Shoes::Point.new(64, 216))


### PR DESCRIPTION
Hello. Here's a fix addressing #778 . Although clicking regions seem to be right, it's hard to hit a line since it requires pixel-level aiming. Shall we add some sloppiness to it?