### PR TITLE
Complete renaming has_textcursor? to textcursor?

### DIFF
--- a/shoes-swt/lib/shoes/swt/text_block/cursor_painter.rb
+++ b/shoes-swt/lib/shoes/swt/text_block/cursor_painter.rb
@@ -42,7 +42,7 @@ class Shoes
         end
 
         def remove_textcursor
-          return unless @text_block_dsl.has_textcursor?
+          return unless @text_block_dsl.textcursor?
 
           @text_block_dsl.textcursor.remove
           @text_block_dsl.textcursor = nil

--- a/shoes-swt/spec/shoes/swt/text_block/cursor_painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block/cursor_painter_spec.rb
@@ -3,7 +3,7 @@ require 'shoes/swt/spec_helper'
 describe Shoes::Swt::TextBlock::CursorPainter do
   include_context "swt app"
 
-  let(:dsl) { double("dsl", app: shoes_app, textcursor: textcursor, has_textcursor?: true) }
+  let(:dsl) { double("dsl", app: shoes_app, textcursor: textcursor, textcursor?: true) }
   let(:textcursor) { double("textcursor", left:0, top: 0, height: 10) }
   let(:segment_collection) { double('segment collection',
                                    cursor_height: 12,
@@ -21,7 +21,7 @@ describe Shoes::Swt::TextBlock::CursorPainter do
     end
 
     it "shouldn't do anything without text cursor" do
-      allow(dsl).to receive(:has_textcursor?) { nil}
+      allow(dsl).to receive(:textcursor?) { nil}
       subject.draw
       expect(dsl).to_not have_received(:textcursor=)
     end


### PR DESCRIPTION
Ooops looks like I've forgotten to complete the renaming in #1059 . Tests were green, but now I've found out that samples/good-clock.rb shows an error. I apologize, guys. 
Btw, it's no good that the test doesn't react to the renaming. Maybe we should force the double to recieve ':textcursor?'