### PR TITLE
Check disposal during startup

### DIFF
--- a/shoes-swt/lib/shoes/swt/app.rb
+++ b/shoes-swt/lib/shoes/swt/app.rb
@@ -35,6 +35,10 @@ class Shoes
       end
 
       def open
+        # If something called quit during the app block's initial evaluation
+        # we might already be disposed of, in which case get out of here!
+        return if ::Shoes::Swt.main_app.disposed? || @shell.disposed?
+
         @shell.pack
         force_shell_size
         @shell.open


### PR DESCRIPTION
If `quit` was called during startup, our SWT resources might be disposed of
and the initial open will crash.

Fixes #1053. Just happened to glance at it to determine what was actually
crashing and accidentally fixed it :blush: