### PR TITLE
Fix to allow save file/folder dialogs

### DIFF
--- a/shoes-core/lib/shoes/builtin_methods.rb
+++ b/shoes-core/lib/shoes/builtin_methods.rb
@@ -44,7 +44,7 @@ class Shoes
     end
 
     def ask_save_file
-      Shoes::Dialog.new.dialog_chooser 'Save File...'
+      Shoes::Dialog.new.dialog_chooser 'Save File...', false, :save
     end
 
     def ask_open_folder
@@ -52,7 +52,7 @@ class Shoes
     end
 
     def ask_save_folder
-      Shoes::Dialog.new.dialog_chooser 'Save Folder...', :folder
+      Shoes::Dialog.new.dialog_chooser 'Save Folder...', :folder, :save
     end
 
     def ask(msg, args = {})

--- a/shoes-core/lib/shoes/dialog.rb
+++ b/shoes-core/lib/shoes/dialog.rb
@@ -12,8 +12,8 @@ class Shoes
       @gui.confirm msg
     end
 
-    def dialog_chooser(title, folder = false)
-      @gui.dialog_chooser title, folder
+    def dialog_chooser(title, folder = false, style = :open)
+      @gui.dialog_chooser title, folder, style
     end
 
     def ask(msg, args)

--- a/shoes-swt/lib/shoes/swt/dialog.rb
+++ b/shoes-swt/lib/shoes/swt/dialog.rb
@@ -15,8 +15,8 @@ class Shoes
         confirmed? answer_id
       end
 
-      def dialog_chooser(title, folder = false)
-        style = ::Swt::SWT::OPEN
+      def dialog_chooser(title, folder = false, style = :open)
+        style = (style == :save ? ::Swt::SWT::SAVE : ::Swt::SWT::OPEN)
         shell = ::Swt::Widgets::Shell.new Shoes.display
         fd = folder ? ::Swt::Widgets::DirectoryDialog.new(shell, style) : ::Swt::Widgets::FileDialog.new(shell, style)
         fd.setText title


### PR DESCRIPTION
Adds use of the ::Swt::SWT::SAVE constant for save file and folder dialogs to dialog_chooser method. Thus ask_save_file and ask_save_folder will work as intended.