### PR TITLE
Don't Bundler.require during Picker

### DIFF
--- a/shoes-core/lib/shoes/ui/picker.rb
+++ b/shoes-core/lib/shoes/ui/picker.rb
@@ -13,8 +13,11 @@ class Shoes
       # running from source without finding gem-installed backends.
       def bundle
         return unless File.exists?("Gemfile")
+
+        # Only need bundler/setup to get our paths right--we don't need to
+        # actually require the gems, since we find the generate-backend.rb's
+        # and just require them directly.
         require 'bundler/setup'
-        Bundler.require
       end
 
       def select_generator


### PR DESCRIPTION
Fixes #1055

The Shoes::UI::Picker will use Bundler and the local Gemfile when
selecting a backend in local development. Previously this would do a
`Bundler.require` during the Picker's startup, but on newer versions of
JRuby (1.7.19 at least), this will hit the dreaded Thread Access
exception from SWT when those requires touch some font related files.

I haven't gotten to the bottom of why those hit thread access problems
when we didn't on earlier JRuby's, but looking at the code we use there
it doesn't seem unreasonable that it could fail in that way.

Luckily, the Picker shouldn't actually need the gems required--we just
need the paths to search for generators, which will be loaded up
directly to run.