### PR TITLE
Fix some rubocop warnings

### DIFF
--- a/samples/expert-othello.rb
+++ b/samples/expert-othello.rb
@@ -88,7 +88,6 @@ module Othello
     end
 
     def skip_turn?
-      possibles = []
       @board.each_with_index { |col,col_index|
         col.each_with_index { |cell,row_index|
           return false if possible_move?([col_index,row_index])
@@ -99,7 +98,6 @@ module Othello
 
     def possible_move?(c=[0,0])
       return nil if board_at(c) != 0
-      possible_moves = []
       piece = current_player.piece
       opp_piece = current_player.opp_piece
       pieces_to_change = []
@@ -315,4 +313,3 @@ Shoes.app width: 520, height: 600 do
     end
   }
 end
-

--- a/shoes-core/spec/shoes/app_spec.rb
+++ b/shoes-core/spec/shoes/app_spec.rb
@@ -300,7 +300,7 @@ describe Shoes::App do
       it "returns the enclosing slot" do
         my_parent = nil
         my_stack  = nil
-        app = Shoes.app do
+        Shoes.app do
           my_stack = stack do
             flow do
               my_parent = parent

--- a/shoes-package/spec/configuration_spec.rb
+++ b/shoes-package/spec/configuration_spec.rb
@@ -185,7 +185,7 @@ describe Shoes::Package::Configuration do
     context "with additional gems" do
       let(:path) { @config_filename }
       let(:additional_config) { { gems: gems } }
-      let(:config) { config = Shoes::Package::Configuration.load(path, additional_config) }
+      let(:config) { Shoes::Package::Configuration.load(path, additional_config) }
 
       context "one gem" do
         let(:gems) { 'shoes-swt' }

--- a/shoes-package/spec/spec_helper.rb
+++ b/shoes-package/spec/spec_helper.rb
@@ -38,7 +38,7 @@ module Guard
   #   end
   # end
   def platform_is(platform)
-    yield if self.send "platform_is_#{platform.to_s}"
+    yield if self.send "platform_is_#{platform}"
   end
 
   # Runs specs only if platform does not match
@@ -50,7 +50,7 @@ module Guard
   #   end
   # end
   def platform_is_not(platform)
-    yield unless self.send "platform_is_#{platform.to_s}"
+    yield unless self.send "platform_is_#{platform}"
   end
 
   def platform_is_windows

--- a/shoes-swt/spec/shoes/swt/mouse_move_listener_spec.rb
+++ b/shoes-swt/spec/shoes/swt/mouse_move_listener_spec.rb
@@ -12,7 +12,7 @@ describe Shoes::Swt::MouseMoveListener do
   let(:x) {10}
   let(:y) {42}
   let(:block) {double 'Block', call: nil}
-  let(:mouse_event) {double'mouse event', x: x, y: y}
+  let(:mouse_event) {double 'mouse event', x: x, y: y}
 
   subject {Shoes::Swt::MouseMoveListener.new(app)}
   before :each do

--- a/shoes-swt/spec/shoes/swt/shell_control_listener_spec.rb
+++ b/shoes-swt/spec/shoes/swt/shell_control_listener_spec.rb
@@ -6,18 +6,18 @@ describe Shoes::Swt::ShellControlListener do
   let(:resize_callbacks) {[]}
   let(:dsl_app) {double('DSL App', resize_callbacks: resize_callbacks).as_null_object}
   let(:block) {double 'Block', call: nil}
-  let(:resize_event) {double'resize_event', widget: shell}
+  let(:resize_event) {double 'resize_event', widget: shell}
   let(:real) {double('Swt Real').as_null_object}
 
   subject {Shoes::Swt::ShellControlListener.new(app)}
   before :each do
     subject.controlResized(resize_event)
   end
-  
+
   describe 'resize' do
     let(:resize_callbacks ){[block]}
     it 'calls the resize block' do
-      expect(block).to have_received(:call) 
+      expect(block).to have_received(:call)
     end
   end
 end


### PR DESCRIPTION
```
== shoes-core/spec/shoes/app_spec.rb ==
W:303:  9: Useless assignment to variable - app.
== shoes-swt/spec/shoes/swt/shell_control_listener_spec.rb ==
W:  9: 29: Put space between the method name and the first argument.
== shoes-swt/spec/shoes/swt/mouse_move_listener_spec.rb ==
W: 15: 28: Put space between the method name and the first argument.
== shoes-package/spec/configuration_spec.rb ==
W:188: 22: Useless assignment to variable - config.
== shoes-package/spec/spec_helper.rb ==
W: 41: 48: Redundant use of Object#to_s in interpolation.
W: 53: 52: Redundant use of Object#to_s in interpolation.
== samples/expert-othello.rb ==
W: 91:  7: Useless assignment to variable - possibles.
W:102:  7: Useless assignment to variable - possible_moves.
```