### PR TITLE
Improve perf on Common::Visibility

### DIFF
--- a/shoes-core/lib/shoes/common/initialization.rb
+++ b/shoes-core/lib/shoes/common/initialization.rb
@@ -14,6 +14,7 @@ class Shoes
 
         style_init(styles)
         create_dimensions(*args)
+        update_dimensions if styles_with_dimensions?
 
         @parent.add_child self
         @gui = Shoes.backend_for self

--- a/shoes-core/lib/shoes/common/style.rb
+++ b/shoes-core/lib/shoes/common/style.rb
@@ -29,7 +29,6 @@ class Shoes
       # Adds styles, or just returns current style if no argument
       def style(new_styles = nil)
         update_style(new_styles) if need_to_update_style?(new_styles)
-        update_dimensions if styles_with_dimensions?
         @style
       end
 
@@ -144,7 +143,10 @@ class Shoes
 
       def update_dimensions # so that @style hash matches actual values
         STYLE_GROUPS[:dimensions].each do |style|
-          @style[style] = send(style) if self.respond_to? style
+          if self.respond_to?(style)
+            value = send(style)
+            @style[style] = value if value
+          end
         end
       end
 

--- a/shoes-core/spec/shoes/common/style_spec.rb
+++ b/shoes-core/spec/shoes/common/style_spec.rb
@@ -6,17 +6,21 @@ describe Shoes::Common::Style do
 
   class StyleTester
     include Shoes::Common::Visibility
+    include Shoes::DimensionsDelegations
     include Shoes::Common::Style
 
-    attr_accessor :left
+    attr_reader :dimensions
     style_with :key, :left, :click, :strokewidth, :fill
 
     STYLES = {fill: Shoes::COLORS[:blue]}
 
     def initialize(app, styles = {})
       @app = app #needed for style init
+      @dimensions = Shoes::Dimensions.new(@app, left: 15)
+
+      # Would normally be done by Common::Initialization
       style_init(styles, key: 'value')
-      @left = 15
+      update_dimensions
     end
 
     def click(&arg)
@@ -34,12 +38,12 @@ describe Shoes::Common::Style do
   subject {StyleTester.new(app)}
 
   its(:style) { should eq (initial_style) }
-  let(:initial_style) { {key: 'value', left: 15, click: nil, strokewidth: 1, fill: blue} }
+  let(:initial_style) { {key: 'value', left: 15, click: nil, strokewidth: 1, fill: blue,
+      margin: [0,0,0,0], margin_left: 0, margin_top: 0, margin_right: 0, margin_bottom: 0 } }
 
   describe 'reading and writing through #style(hash)' do
     let(:input_proc) { Proc.new {} }
     let(:changed_style) { {key: 'changed value'} }
-
 
     before :each do
       subject.style changed_style


### PR DESCRIPTION
First of what I expect to be a number of PR's spawned from #1078. I'm having fun doing perf tuning now that I've started digging into it :rocket: 

The bottleneck here proved to be accessing `#style` when doing visibility updates. This did heavy lifting every time to update the dimensions in the styles hash, despite the fact they were almost never changing. This PR updates to just touch the styles directly when we write a dimension, instead of trying to frequently reconstruct it on reading.

I located this with a basic bisect between `v4.0.0.pre3` and `master` where the perf issue @PragTob had highlighted was even worse than he'd reported between `pre2` -> `pre3`. It resolved to 5d2e6196e3ce84f2d9c0771a376fa38b68aba9d8, and then it was fairly simple to isolate by commenting things out to determine the primary culprit here.

While it's a little ugly to have the dimension updating touch the styles, I found it more confusing to try and separate those out to a different unrelated module.