### PR TITLE
Default class styles do not override app styles

### DIFF
--- a/shoes-core/lib/shoes/common/style.rb
+++ b/shoes-core/lib/shoes/common/style.rb
@@ -8,7 +8,6 @@ class Shoes
   module Common
     module Style
       DEFAULT_STYLES = {
-        fill:        Shoes::COLORS[:black],
         rotate:      0,
         stroke:      Shoes::COLORS[:black],
         strokewidth: 1
@@ -35,11 +34,10 @@ class Shoes
 
       def style_init(arg_styles, new_styles = {})
         default_element_styles = {}
-        default_element_styles = self.class::STYLES if defined? self.class::STYLES
-
+        default_element_styles = self.class::STYLES if defined?(self.class::STYLES)
         create_style_hash
-        merge_app_styles
         @style.merge!(default_element_styles)
+        merge_app_styles
         @style.merge!(@app.element_styles[self.class]) if @app.element_styles[self.class]
         @style.merge!(new_styles)
         @style.merge!(arg_styles)

--- a/shoes-core/lib/shoes/image.rb
+++ b/shoes-core/lib/shoes/image.rb
@@ -8,6 +8,8 @@ class Shoes
 
     style_with :art_styles, :common_styles, :dimensions, :file_path
 
+    STYLES = { fill: Shoes::COLORS[:black] }
+
     def before_initialize(styles, file_path_or_data)
       styles[:file_path] = normalized_source(file_path_or_data)
     end

--- a/shoes-core/lib/shoes/line.rb
+++ b/shoes-core/lib/shoes/line.rb
@@ -9,7 +9,7 @@ class Shoes
     attr_reader :point_a, :point_b
 
     style_with :angle, :art_styles, :dimensions, :x2, :y2
-    STYLES = { angle: 0 }
+    STYLES = { angle: 0, fill: Shoes::COLORS[:black] }
 
     def create_dimensions(point_a, point_b)
       @point_a = point_a

--- a/shoes-core/lib/shoes/oval.rb
+++ b/shoes-core/lib/shoes/oval.rb
@@ -5,6 +5,7 @@ class Shoes
     include Common::Clickable
 
     style_with :art_styles, :center, :common_styles, :dimensions, :radius
+    STYLES = { fill: Shoes::COLORS[:black] }
 
     def create_dimensions(left, top, width, height)
       left   ||= @style[:left]

--- a/shoes-core/lib/shoes/rect.rb
+++ b/shoes-core/lib/shoes/rect.rb
@@ -5,7 +5,7 @@ class Shoes
     include Common::Clickable
 
     style_with :angle, :art_styles, :curve, :common_styles, :dimensions
-    STYLES = { angle: 0, curve: 0 }
+    STYLES = { angle: 0, curve: 0, fill: Shoes::COLORS[:black] }
 
     def create_dimensions(left, top, width, height)
       left   ||= @style[:left] || 0

--- a/shoes-core/lib/shoes/shape.rb
+++ b/shoes-core/lib/shoes/shape.rb
@@ -8,6 +8,8 @@ class Shoes
 
     style_with :art_styles, :center, :common_styles, :dimensions
 
+    STYLES = { fill: Shoes::COLORS[:black] }
+
     def create_dimensions()
       @dimensions = AbsoluteDimensions.new @style
     end

--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -12,7 +12,7 @@ class Shoes
     attr_reader :parent, :dimensions, :gui, :contents, :blk, :hover_proc, :leave_proc
 
     style_with :art_styles, :attach, :common_styles, :dimensions, :scroll
-    STYLES = { scroll: false }
+    STYLES = { scroll: false, fill: Shoes::COLORS[:black] }
 
     def create_dimensions(*args)
       super(*args)

--- a/shoes-core/lib/shoes/star.rb
+++ b/shoes-core/lib/shoes/star.rb
@@ -5,7 +5,7 @@ class Shoes
     include Common::Clickable
 
     style_with :angle, :art_styles, :common_styles, :dimensions, :inner, :outer, :points
-    STYLES = { angle: 0 }
+    STYLES = { angle: 0, file: Shoes::COLORS[:black] }
 
     def create_dimensions(left, top, points, outer, inner)
       # Don't use param defaults as DSL explicit passes nil for missing params

--- a/shoes-core/lib/shoes/text_block.rb
+++ b/shoes-core/lib/shoes/text_block.rb
@@ -12,7 +12,7 @@ class Shoes
     attr_accessor :cursor, :textcursor
 
     style_with :common_styles, :dimensions, :text_block_styles
-    STYLES = { font: "Arial" } # used in TextBlock specs only
+    STYLES = { font: DEFAULT_TEXTBLOCK_FONT } # used in TextBlock specs only
 
     def create_dimensions(*_)
       @dimensions = TextBlockDimensions.new @parent, @style
@@ -130,7 +130,7 @@ class Shoes
     "Inscription" => { size: 10 }
   }.each do |name, styles|
     clazz = Class.new(TextBlock) do
-      const_set("STYLES", { font: "Arial", fill: nil }.merge(styles))
+      const_set("STYLES", { font: DEFAULT_TEXTBLOCK_FONT, fill: nil }.merge(styles))
     end
     Shoes.const_set(name, clazz)
   end


### PR DESCRIPTION
A work in progress for #1077 . Here's how it looks now:
![image](https://cloud.githubusercontent.com/assets/10567153/6824628/fae4a364-d304-11e4-91d5-aad866a86fe8.png)

and the code for the above example:
```ruby
Shoes.app do
  stack do
    font = 'Impact'
    style(font: font)
    txt = 'The quick fox runs fast'
    title txt
    style(Shoes::Title, font: font)
    title txt
    para txt
    rect(200, 200, 100, 100)
  end
end
```
Tests are all red due to the removal of `:fill` from `Shoes::Common::Style::DEFAULT_STYLES`. More explanation in the commit notes. 