### PR TITLE
Fix crash on global keypress

### DIFF
--- a/shoes-core/lib/shoes/internal_app.rb
+++ b/shoes-core/lib/shoes/internal_app.rb
@@ -191,7 +191,7 @@ class Shoes
     def setup_global_keypresses
       @app.keypress do |key|
         blk = self.class.global_keypresses[key]
-        execute_block(&blk) if blk
+        execute_block(blk) if blk
       end
     end
 


### PR DESCRIPTION
These keypresses aren't used often except by internal tools, so didn't
notice it broke when changing execute_block's contract.

Hard to write a spec since it requires actually driving a keypress, so
leaving it for now.

To duplicate the bug, run this:

```
$ LEAK_HUNTER=true bin/shoes --manual
```

Then press Ctrl+Alt+Q as prompted. You'll see an exception at the top above all the output, which shouldn't have happened:

```
Registered Ctrl+Alt+Q for leak hunting clean shutdown.
2015-04-03 16:06:30.053 java[17391:2307] *** WARNING: Method userSpaceScaleFactor in class NSWindow is deprecated on 10.7 and later. It should not be used in new applications. Use convertRectToBacking: instead.
ArgumentError: wrong number of arguments calling `execute_block` (0 for 1)
              execute_block at /Users/jclark/.rbenv/versions/jruby-1.7.16.1/lib/ruby/gems/shared/gems/after_do-0.3.1/lib/after_do.rb:99
    setup_global_keypresses at /Users/jclark/source/shoes4/shoes-core/lib/shoes/internal_app.rb:194
                       call at org/jruby/RubyProc.java:271
                 eval_block at /Users/jclark/source/shoes4/shoes-swt/lib/shoes/swt/key_listener.rb:74
                 eval_block at /Users/jclark/.rbenv/versions/jruby-1.7.16.1/lib/ruby/gems/shared/gems/after_do-0.3.1/lib/after_do.rb:99
           handle_key_event at /Users/jclark/source/shoes4/shoes-swt/lib/shoes/swt/key_listener.rb:40
  attach_key_event_listener at /Users/jclark/source/shoes4/shoes-swt/lib/shoes/swt/app.rb:260
                       each at org/jruby/RubyArray.java:1613
  attach_key_event_listener at /Users/jclark/source/shoes4/shoes-swt/lib/shoes/swt/app.rb:258
                handleEvent at org/jruby/gen/InterfaceImpl1729357240.gen:13
             run_event_loop at /Users/jclark/.rbenv/versions/jruby-1.7.16.1/lib/ruby/gems/shared/gems/swt-4.4/lib/swt/minimal.rb:109
                 event_loop at /Users/jclark/.rbenv/versions/jruby-1.7.16.1/lib/ruby/gems/shared/gems/swt-4.4/lib/swt/minimal.rb:92
                       open at /Users/jclark/source/shoes4/shoes-swt/lib/shoes/swt/app.rb:49
                   open_gui at /Users/jclark/source/shoes4/shoes-core/lib/shoes/internal_app.rb:106
                 initialize at /Users/jclark/source/shoes4/shoes-core/lib/shoes/app.rb:50
                        app at /Users/jclark/source/shoes4/shoes-core/lib/shoes/app.rb:19
                     (root) at /Users/jclark/.rbenv/versions/jruby-1.7.16.1/lib/ruby/gems/shared/gems/shoes-manual-4.0.0/lib/shoes/manual/app.rb:512
                       load at org/jruby/RubyKernel.java:1081
                     (root) at /Users/jclark/.rbenv/versions/jruby-1.7.16.1/lib/ruby/gems/shared/gems/shoes-manual-4.0.0/lib/shoes/manual.rb:1
                        run at /Users/jclark/.rbenv/versions/jruby-1.7.16.1/lib/ruby/gems/shared/gems/shoes-manual-4.0.0/lib/shoes/manual.rb:20
                       call at org/jruby/RubyProc.java:271
                     parse! at /Users/jclark/source/shoes4/shoes-core/lib/shoes/ui/cli.rb:32
                      catch at org/jruby/RubyKernel.java:1264
             parse_in_order at /Users/jclark/.rbenv/versions/jruby-1.7.16.1/lib/ruby/1.9/optparse.rb:1360
             parse_in_order at /Users/jclark/.rbenv/versions/jruby-1.7.16.1/lib/ruby/1.9/optparse.rb:1347
                     order! at /Users/jclark/.rbenv/versions/jruby-1.7.16.1/lib/ruby/1.9/optparse.rb:1341
                   permute! at /Users/jclark/.rbenv/versions/jruby-1.7.16.1/lib/ruby/1.9/optparse.rb:1432
                     parse! at /Users/jclark/.rbenv/versions/jruby-1.7.16.1/lib/ruby/1.9/optparse.rb:1453
                     parse! at /Users/jclark/source/shoes4/shoes-core/lib/shoes/ui/cli.rb:39
                        run at /Users/jclark/source/shoes4/shoes-core/lib/shoes/ui/cli.rb:53
                       load at org/jruby/RubyKernel.java:1081
                     (root) at /Users/jclark/source/shoes4/shoes-swt/bin/shoes-swt:11
```