### PR TITLE
Call change blocks on programmatic list updates

### DIFF
--- a/shoes-swt/lib/shoes/swt/list_box.rb
+++ b/shoes-swt/lib/shoes/swt/list_box.rb
@@ -38,6 +38,7 @@ class Shoes
 
       def choose(item)
         @real.text = item
+        @dsl.call_change_listeners
       end
 
       def enabled(value)

--- a/shoes-swt/spec/shoes/swt/list_box_spec.rb
+++ b/shoes-swt/spec/shoes/swt/list_box_spec.rb
@@ -41,6 +41,12 @@ describe Shoes::Swt::ListBox do
     subject.choose "Bacon"
   end
 
+  it "should notify dsl of changes when choosing" do
+    allow(real).to receive(:text=)
+    expect(dsl).to receive(:call_change_listeners)
+    subject.choose "Bacon"
+  end
+
   it 'sets the items on real upon initialization' do
     subject
     expect(real).to have_received(:items=).with(items)


### PR DESCRIPTION
Fixes #1089

Calling `ListBox#choose` wasn't triggering the change blocks in the DSL
layer because SWT apparently only sends selection events for
user-initiated changes.

Fixed by simply calling the updates when we explicitly alter the list
choice.

Chose to do this at the SWT layer so that if future backends do
appropriately trigger changes on choose already, they don't have to work
around the DSL enforcing it.