### PR TITLE
Allow for selecting between multiple backends

### DIFF
--- a/shoes-core/lib/shoes/packager.rb
+++ b/shoes-core/lib/shoes/packager.rb
@@ -3,7 +3,11 @@ class Shoes
     attr_reader :packages, :backend
 
     def initialize
-      @backend = Shoes.configuration.backend_for(self)
+      begin
+        @backend = Shoes.configuration.backend_for(self)
+      rescue ArgumentError
+        # Packaging unsupported by this backend
+      end
       @packages = []
     end
 
@@ -16,10 +20,12 @@ class Shoes
     end
 
     def run(path)
+      raise "Packaging unsupported by this backend" if @backend.nil?
       @backend.run(path)
     end
 
     def help(program_name)
+      return "" if @backend.nil?
       @backend.help(program_name)
     end
   end

--- a/shoes-core/lib/shoes/ui/cli.rb
+++ b/shoes-core/lib/shoes/ui/cli.rb
@@ -43,13 +43,14 @@ Usage: #{opts.program_name} [-h] [-p package] file
     # Execute a shoes app.
     #
     # @param [String] app the location of the app to run
-    def execute_app(app)
+    # @param [String] backend name of backend to load with the app
+    def execute_app(app, backend)
       $LOAD_PATH.unshift(Dir.pwd)
-      require 'shoes/swt'
+      require "shoes/#{backend}"
       load app
     end
 
-    def run(args)
+    def run(args, backend)
       opts = parse!(args)
       if args.empty?
         puts opts.banner
@@ -60,7 +61,7 @@ Usage: #{opts.program_name} [-h] [-p package] file
       if @packager.should_package?
         @packager.run(args.shift)
       else
-        execute_app(args.first)
+        execute_app(args.first, backend)
       end
     end
   end

--- a/shoes-core/lib/shoes/ui/cli.rb
+++ b/shoes-core/lib/shoes/ui/cli.rb
@@ -5,7 +5,11 @@ class Shoes
   class CLI
     attr_reader :packager
 
-    def initialize
+    def initialize(backend)
+      $LOAD_PATH.unshift(Dir.pwd)
+      backend_const = Shoes.load_backend(backend)
+      backend_const.initialize_backend
+
       @packager = Shoes::Packager.new
     end
 
@@ -44,13 +48,11 @@ Usage: #{opts.program_name} [-h] [-p package] file
     #
     # @param [String] app the location of the app to run
     # @param [String] backend name of backend to load with the app
-    def execute_app(app, backend)
-      $LOAD_PATH.unshift(Dir.pwd)
-      require "shoes/#{backend}"
+    def execute_app(app)
       load app
     end
 
-    def run(args, backend)
+    def run(args)
       opts = parse!(args)
       if args.empty?
         puts opts.banner
@@ -61,7 +63,7 @@ Usage: #{opts.program_name} [-h] [-p package] file
       if @packager.should_package?
         @packager.run(args.shift)
       else
-        execute_app(args.first, backend)
+        execute_app(args.first)
       end
     end
   end

--- a/shoes-core/lib/shoes/ui/picker.rb
+++ b/shoes-core/lib/shoes/ui/picker.rb
@@ -39,7 +39,7 @@ class Shoes
 
       def output_candidates(candidates)
         @output.puts
-        @output.puts "Select a Shoes backend to use (This is a one-time operation):"
+        @output.puts "Enter a number to select a Shoes backend (This is a one-time operation):"
 
         candidates.each_with_index do |candidate, index|
           @output.puts " #{index + 1}. #{name_for_candidate(candidate)}"

--- a/shoes-core/spec/shoes/ui/picker_spec.rb
+++ b/shoes-core/spec/shoes/ui/picker_spec.rb
@@ -1,0 +1,60 @@
+require 'shoes/spec_helper'
+require 'shoes/ui/picker'
+
+describe Shoes::UI::Picker do
+
+  let(:swt_backend)  { "/gems/lib/shoes/swt/generate-backend.rb" }
+  let(:faux_backend) { "/gems/lib/shoes/faux/generate-backend.rb" }
+
+  let(:output) { StringIO.new }
+  let(:input)  { StringIO.new }
+
+  subject  { Shoes::UI::Picker.new(input, output) }
+
+  it "selects single backend generator" do
+    allow(Gem).to receive(:find_files) { [ swt_backend ] }
+    expect(subject.select_generator).to eq(swt_backend)
+  end
+
+  describe "with multiple backend generators" do
+    before do
+      allow(Gem).to receive(:find_files) { [ swt_backend, faux_backend ] }
+    end
+
+    it "prompts with multiple backend generators" do
+      select("1")
+      subject.select_generator
+
+      output.rewind
+      result = output.read
+
+      expect(result).to include("shoes-swt")
+      expect(result).to include("shoes-faux")
+    end
+
+    it "selects from multiple backend generators" do
+      select("2")
+      expect(subject.select_generator).to eq(faux_backend)
+    end
+
+    it "retries for index past bounds" do
+      select("3\n1")
+      expect(subject.select_generator).to eq(swt_backend)
+    end
+
+    it "retries for index before bounds" do
+      select("0\n1")
+      expect(subject.select_generator).to eq(swt_backend)
+    end
+
+    it "retries for junk" do
+      select("junk\n1")
+      expect(subject.select_generator).to eq(swt_backend)
+    end
+
+    def select(typed_input)
+      input.write(typed_input)
+      input.rewind
+    end
+  end
+end

--- a/shoes-swt/bin/shoes-swt
+++ b/shoes-swt/bin/shoes-swt
@@ -8,4 +8,4 @@ if File.exists?("Gemfile")
 end
 
 require 'shoes/ui/cli'
-Shoes::CLI.new.run ARGV, "swt"
+Shoes::CLI.new("swt").run ARGV

--- a/shoes-swt/bin/shoes-swt
+++ b/shoes-swt/bin/shoes-swt
@@ -8,4 +8,4 @@ if File.exists?("Gemfile")
 end
 
 require 'shoes/ui/cli'
-Shoes::CLI.new.run ARGV
+Shoes::CLI.new.run ARGV, "swt"

--- a/shoes-swt/lib/shoes/swt.rb
+++ b/shoes-swt/lib/shoes/swt.rb
@@ -41,81 +41,88 @@ class Shoes
       def self.display
         ::Swt::Widgets::Display.getCurrent
       end
+    end
+
+    def self.initialize_backend
+      return if @initialized
+      @initialized = true
 
       ::Swt::Widgets::Display.new.getFontList(nil, true).each { |f| ::Shoes::FONTS << f.getName }
       ::Shoes::FONTS.uniq!
+
+      ::Shoes.configuration.backend = :swt
+
+      require 'shoes/swt/disposed_protection'
+      require 'shoes/swt/click_listener'
+      require 'shoes/swt/color'
+      require 'shoes/swt/color_factory'
+      require 'shoes/swt/common/child'
+      require 'shoes/swt/common/remove'
+      require 'shoes/swt/common/clickable'
+      require 'shoes/swt/common/container'
+      require 'shoes/swt/common/fill'
+      require 'shoes/swt/common/resource'
+      require 'shoes/swt/common/painter'
+      require 'shoes/swt/common/painter_updates_position'
+      require 'shoes/swt/common/visibility'
+      require 'shoes/swt/common/selection_listener'
+      require 'shoes/swt/common/stroke'
+      require 'shoes/swt/common/update_position'
+
+      require 'shoes/swt/input_box'
+      require 'shoes/swt/rect_painter.rb'
+      require 'shoes/swt/swt_button'
+      require 'shoes/swt/check_button'
+      require 'shoes/swt/radio_group'
+      require 'shoes/swt/text_block/painter'
+
+      require 'shoes/swt/app'
+      require 'shoes/swt/animation'
+      require 'shoes/swt/arc'
+      require 'shoes/swt/background'
+      require 'shoes/swt/border'
+      require 'shoes/swt/button'
+      require 'shoes/swt/check'
+      require 'shoes/swt/dialog'
+      require 'shoes/swt/download'
+      require 'shoes/swt/font'
+      require 'shoes/swt/gradient'
+      require 'shoes/swt/image'
+      require 'shoes/swt/image_pattern'
+      require 'shoes/swt/key_listener'
+      require 'shoes/swt/line'
+      require 'shoes/swt/link'
+      require 'shoes/swt/link_segment'
+      require 'shoes/swt/list_box'
+      require 'shoes/swt/mouse_move_listener'
+      require 'shoes/swt/oval'
+      require 'shoes/swt/progress'
+      require 'shoes/swt/radio'
+      require 'shoes/swt/rect'
+      require 'shoes/swt/shape'
+      require 'shoes/swt/shoes_layout'
+      require 'shoes/swt/slot'
+      require 'shoes/swt/star'
+      require 'shoes/swt/sound'
+      require 'shoes/swt/text_block'
+      require 'shoes/swt/timer'
+
+      require 'shoes/swt/text_block/text_segment'
+      require 'shoes/swt/text_block/centered_text_segment'
+      require 'shoes/swt/text_block/text_segment_collection'
+      require 'shoes/swt/text_block/cursor_painter'
+      require 'shoes/swt/text_block/fitter'
+      require 'shoes/swt/text_block/text_font_factory'
+      require 'shoes/swt/text_block/text_style_factory'
+
+      require 'shoes/swt/packager'
+
+      require 'shoes/swt/tooling/leak_hunter' if ENV["LEAK_HUNTER"]
+
+      # redrawing aspect needs to know all the classes
+      require 'shoes/swt/redrawing_aspect'
+
+      @initialized = true
     end
   end
 end
-
-Shoes.configuration.backend = :swt
-
-require 'shoes/swt/disposed_protection'
-require 'shoes/swt/click_listener'
-require 'shoes/swt/color'
-require 'shoes/swt/color_factory'
-require 'shoes/swt/common/child'
-require 'shoes/swt/common/remove'
-require 'shoes/swt/common/clickable'
-require 'shoes/swt/common/container'
-require 'shoes/swt/common/fill'
-require 'shoes/swt/common/resource'
-require 'shoes/swt/common/painter'
-require 'shoes/swt/common/painter_updates_position'
-require 'shoes/swt/common/visibility'
-require 'shoes/swt/common/selection_listener'
-require 'shoes/swt/common/stroke'
-require 'shoes/swt/common/update_position'
-
-require 'shoes/swt/input_box'
-require 'shoes/swt/rect_painter.rb'
-require 'shoes/swt/swt_button'
-require 'shoes/swt/check_button'
-require 'shoes/swt/radio_group'
-require 'shoes/swt/text_block/painter'
-
-require 'shoes/swt/app'
-require 'shoes/swt/animation'
-require 'shoes/swt/arc'
-require 'shoes/swt/background'
-require 'shoes/swt/border'
-require 'shoes/swt/button'
-require 'shoes/swt/check'
-require 'shoes/swt/dialog'
-require 'shoes/swt/download'
-require 'shoes/swt/font'
-require 'shoes/swt/gradient'
-require 'shoes/swt/image'
-require 'shoes/swt/image_pattern'
-require 'shoes/swt/key_listener'
-require 'shoes/swt/line'
-require 'shoes/swt/link'
-require 'shoes/swt/link_segment'
-require 'shoes/swt/list_box'
-require 'shoes/swt/mouse_move_listener'
-require 'shoes/swt/oval'
-require 'shoes/swt/progress'
-require 'shoes/swt/radio'
-require 'shoes/swt/rect'
-require 'shoes/swt/shape'
-require 'shoes/swt/shoes_layout'
-require 'shoes/swt/slot'
-require 'shoes/swt/star'
-require 'shoes/swt/sound'
-require 'shoes/swt/text_block'
-require 'shoes/swt/timer'
-
-require 'shoes/swt/text_block/text_segment'
-require 'shoes/swt/text_block/centered_text_segment'
-require 'shoes/swt/text_block/text_segment_collection'
-require 'shoes/swt/text_block/cursor_painter'
-require 'shoes/swt/text_block/fitter'
-require 'shoes/swt/text_block/text_font_factory'
-require 'shoes/swt/text_block/text_style_factory'
-
-require 'shoes/swt/packager'
-
-require 'shoes/swt/tooling/leak_hunter' if ENV["LEAK_HUNTER"]
-
-# redrawing aspect needs to know all the classes
-require 'shoes/swt/redrawing_aspect'

--- a/shoes-swt/spec/shoes/cli_spec.rb
+++ b/shoes-swt/spec/shoes/cli_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Shoes::CLI do
-  subject {Shoes::CLI.new}
+  subject {Shoes::CLI.new("swt")}
 
   before :each do
     allow(subject.packager).to receive :run

--- a/shoes-swt/spec/shoes/swt/spec_helper.rb
+++ b/shoes-swt/spec/shoes/swt/spec_helper.rb
@@ -1,6 +1,8 @@
 require "shoes/swt"
 require "spec_helper"
 
+Shoes.load_backend("swt").initialize_backend
+
 RSpec.configure do |config|
   config.before(:each) do
     allow(Swt).to receive(:event_loop)


### PR DESCRIPTION
First step (though potentially not only?) toward #929.

So to help test things out, I made a fake Shoes backend at https://github.com/jasonrclark/shoes-faux which I then did testing against by including in my Gemfile locally for Shoes, removing my `shoes-backend` file, and seeing what happened.

This resulted in a few specific changes:
* First off, the straight-forward selection logic in `Shoes::UI::Picker` to ask for which backend to generate.
* Needed to not hard-code loading `shoes/swt` in `Shoes::UI::CLI`, so got away from that and enforced that we pass the backend explicitly when constructing the CLI.
* Then I noticed that things were very unhappy having two backend gems present in the same Gemfile. This turned out to be because just requiring `shoes/swt` was forcing it all to load. So I moved that into an explicit method, and new backends should follow the same practice--don't assume you're the backend just because you're required, wait for the `Shoes::Backend.initialize_backend` call.
* That loading broke the SWT tests which relied on loading the backend automatically. Now it loads it explicitly like a good citizen (from a spec_helper)
* Also sneaked in some changes so the `Shoes::Packager` is actually fine if we don't have a backend. `run` will fail on it, but it will not stop you from running an app against a backend just because it can't package yet. This eases a little of the on-ramp for stubbing out a new backend.

This *might* qualify as something fully-featured enough to land, but it's late and I want to consider it further before saying it's ready :sleeping: