### PR TITLE
Rename Shape#arc to Shape#arc_to

### DIFF
--- a/samples/README
+++ b/samples/README
@@ -39,6 +39,8 @@ simple-timer.rb
 simple-tictactoe.rb
 simple-visibility.rb
 
+shape-arc_to.rb
+
 good-arc.rb
 good-clock.rb
 good-follow.rb

--- a/samples/shape-arc_to.rb
+++ b/samples/shape-arc_to.rb
@@ -1,0 +1,9 @@
+Shoes.app do
+  shape do
+    move_to(90, 55)
+    arc_to(50, 55, 50, 20, 0, Shoes::PI/2)
+    arc_to(50, 55, 60, 60, Shoes::PI/2, Shoes::PI)
+    arc_to(50, 55, 70, 70, Shoes::PI, Shoes::TWO_PI-Shoes::PI/2)
+    arc_to(50, 55, 80, 80, Shoes::TWO_PI-Shoes::PI/2, Shoes::TWO_PI)
+  end
+end

--- a/shoes-core/lib/shoes/mock/shape.rb
+++ b/shoes-core/lib/shoes/mock/shape.rb
@@ -13,7 +13,7 @@ class Shoes
       def curve_to(*_args)
       end
 
-      def arc(*_args)
+      def arc_to(*_args)
       end
     end
   end

--- a/shoes-core/lib/shoes/shape.rb
+++ b/shoes-core/lib/shoes/shape.rb
@@ -99,10 +99,10 @@ class Shoes
     # @param [Integer] start_angle The start angle
     # @param [Integer] arc_angle The angular extent of the arc, relative to the start angle
     # @return [Shoes::Shape] This shape
-    def arc(x, y, width, height, start_angle, arc_angle)
+    def arc_to(x, y, width, height, start_angle, arc_angle)
       update_bounds_rect(x - width / 2, y - height / 2, x + width / 2, y + height / 2)
       @x, @y = x, y
-      @gui.arc(x, y, width, height, start_angle, arc_angle)
+      @gui.arc_to(x, y, width, height, start_angle, arc_angle)
       self
     end
 

--- a/shoes-core/spec/shoes/shape_spec.rb
+++ b/shoes-core/spec/shoes/shape_spec.rb
@@ -86,7 +86,7 @@ describe Shoes::Shape do
   describe "arc" do
     let(:draw) {
       Proc.new {
-        arc 10, 10, 100, 100, Shoes::PI, Shoes::TWO_PI
+        arc_to 10, 10, 100, 100, Shoes::PI, Shoes::TWO_PI
       }
     }
 

--- a/shoes-swt/lib/shoes/swt/shape.rb
+++ b/shoes-swt/lib/shoes/swt/shape.rb
@@ -43,7 +43,7 @@ class Shoes
         @element.cubic_to(cx1, cy1, cx2, cy2, x, y)
       end
 
-      def arc(x, y, width, height, start_angle, arc_angle)
+      def arc_to(x, y, width, height, start_angle, arc_angle)
         @element.add_arc(x - (width / 2), y - (height / 2), width, height,
                          -start_angle * 180 / ::Shoes::PI,
                          (start_angle - arc_angle) * 180 / ::Shoes::PI)

--- a/shoes-swt/spec/shoes/swt/shape_spec.rb
+++ b/shoes-swt/spec/shoes/swt/shape_spec.rb
@@ -45,6 +45,11 @@ describe Shoes::Swt::Shape do
       expect(element).to receive(:line_to).with(20, 30)
       subject.line_to 20, 30
     end
+
+    it "delegates #arc_to" do
+      expect(element).to receive(:add_arc).with(25, 45, 50, 20, 0.0, -90.0)
+      subject.arc_to 50, 55, 50, 20, 0, Shoes::PI/2
+    end
   end
 
   describe "moving" do


### PR DESCRIPTION
Fixes #795.

So a funny story... turns out we already had a method that behaved the same as the `Shape#arc_to` back on Shoes 3. It just ended up being called `Shape#arc` instead.

For compatibility, I'm renaming it back, along with adding a sample and some tests (I'm betting the lack of samples and only having one reference to it in the manual is why it got mixed up to begin with). The method `arc` remains accessible, as you can use base Shoes methods from within the shape anyway--they just aren't related to the shape drawing.

Results:

`samples/shape-arc_to.rb` on Shoes 3:
![image](https://cloud.githubusercontent.com/assets/130504/7335917/3bdc0630-eb94-11e4-9196-62404f5c47d7.png)

`samples/shape-arc_to.rb` on Shoes 4:
![image](https://cloud.githubusercontent.com/assets/130504/7335918/487d4354-eb94-11e4-985c-2e450aade565.png)
