### PR TITLE
Replace Swt::Pattern with custom image drawing

### DIFF
--- a/shoes-swt/lib/shoes/swt/color.rb
+++ b/shoes-swt/lib/shoes/swt/color.rb
@@ -29,6 +29,7 @@ class Shoes
       def apply_as_fill(gc, _dsl = nil)
         gc.set_background real
         gc.set_alpha alpha
+        true
       end
 
       # @param [Swt::Graphics::GC] gc the graphics context on which to apply stroke
@@ -36,6 +37,7 @@ class Shoes
       def apply_as_stroke(gc, _dsl = nil)
         gc.set_foreground real
         gc.set_alpha alpha
+        true
       end
     end
 

--- a/shoes-swt/lib/shoes/swt/common/fill.rb
+++ b/shoes-swt/lib/shoes/swt/common/fill.rb
@@ -34,8 +34,8 @@ class Shoes
 
         def apply_fill(context)
           if fill
+            # Return value determines whether to continue upstream.
             fill.apply_as_fill(context, self)
-            true
           end
         end
       end

--- a/shoes-swt/lib/shoes/swt/common/stroke.rb
+++ b/shoes-swt/lib/shoes/swt/common/stroke.rb
@@ -36,9 +36,10 @@ class Shoes
 
         def apply_stroke(context)
           if stroke
-            stroke.apply_as_stroke(context, self)
             context.set_line_width strokewidth
-            true
+
+            # Return value determines whether to continue upstream.
+            stroke.apply_as_stroke(context, self)
           end
         end
       end

--- a/shoes-swt/lib/shoes/swt/gradient.rb
+++ b/shoes-swt/lib/shoes/swt/gradient.rb
@@ -32,11 +32,13 @@ class Shoes
       def apply_as_fill(gc, dsl)
         pattern = create_pattern(dsl)
         gc.set_background_pattern pattern
+        true
       end
 
       def apply_as_stroke(gc, dsl)
         pattern = create_pattern(dsl)
         gc.set_foreground_pattern pattern
+        true
       end
 
       private

--- a/shoes-swt/lib/shoes/swt/image_pattern.rb
+++ b/shoes-swt/lib/shoes/swt/image_pattern.rb
@@ -9,22 +9,48 @@ class Shoes
 
       def dispose
         @image.dispose if @image
-        @pattern.dispose if @pattern
       end
 
-      # Since colors are bound up (at least in specs) with image patterns,
-      # we can't safely touch images during initialize, so lazily load them.
-      def pattern
-        @image   ||= ::Swt::Image.new(Shoes.display, @dsl.path)
-        @pattern ||= ::Swt::Pattern.new(Shoes.display, @image)
+      def apply_as_fill(gc, dsl)
+        draw_image_pattern(gc, dsl)
+        false
       end
 
-      def apply_as_fill(gc, _dsl)
-        gc.set_background_pattern pattern
+      def apply_as_stroke(gc, dsl)
+        draw_image_pattern(gc, dsl)
+        false
       end
 
-      def apply_as_stroke(gc, _dsl)
-        gc.set_foreground_pattern pattern
+      def draw_image_pattern(gc, dsl)
+        # Since colors are bound up (at least in specs) with image patterns,
+        # we can't safely touch images during initialize, so lazily load them.
+        @image ||= ::Swt::Image.new(Shoes.display, @dsl.path)
+
+        # +1 on count to allow partial image at end of the line
+        bounds  = @image.bounds
+        cols = dsl.width / bounds.width + 1
+        rows = dsl.height / bounds.height + 1
+
+        cols.times do |col|
+          rows.times do |row|
+            desired_width = bounds.width
+            desired_height = bounds.height
+
+            left   = dsl.element_left + (col * bounds.width)
+            right  = left + desired_width
+            top    = dsl.element_top + (row * bounds.height)
+            bottom = top + desired_height
+
+            if left < dsl.element_right && top < dsl.element_bottom
+              desired_width = dsl.element_right - left  if right > dsl.element_right
+              desired_height = dsl.element_bottom - top if bottom > dsl.element_bottom
+
+              gc.draw_image @image,
+                            0, 0, desired_width, desired_height,
+                            left, top, desired_width, desired_height
+            end
+          end
+        end
       end
     end
   end

--- a/shoes-swt/lib/shoes/swt/image_pattern.rb
+++ b/shoes-swt/lib/shoes/swt/image_pattern.rb
@@ -33,24 +33,45 @@ class Shoes
 
         cols.times do |col|
           rows.times do |row|
-            desired_width = bounds.width
-            desired_height = bounds.height
-
             left   = dsl.element_left + (col * bounds.width)
-            right  = left + desired_width
+            right  = left + bounds.width
+
             top    = dsl.element_top + (row * bounds.height)
-            bottom = top + desired_height
+            bottom = top + bounds.height
 
-            if left < dsl.element_right && top < dsl.element_bottom
-              desired_width = dsl.element_right - left  if right > dsl.element_right
-              desired_height = dsl.element_bottom - top if bottom > dsl.element_bottom
-
-              gc.draw_image @image,
-                            0, 0, desired_width, desired_height,
-                            left, top, desired_width, desired_height
+            if fits_in_dsl?(left, top, dsl)
+              draw_image(gc, left, top,
+                         desired_width(left, right, bounds, dsl),
+                         desired_height(top, bottom, bounds, dsl))
             end
           end
         end
+      end
+
+      def fits_in_dsl?(left, top, dsl)
+        left < dsl.element_right && top < dsl.element_bottom
+      end
+
+      def desired_width(left, right, bounds, dsl)
+        if right > dsl.element_right
+          dsl.element_right - left
+        else
+          bounds.width
+        end
+      end
+
+      def desired_height(top, bottom, bounds, dsl)
+        if bottom > dsl.element_bottom
+          dsl.element_bottom - top
+        else
+          bounds.height
+        end
+      end
+
+      def draw_image(gc, left, top, desired_width, desired_height)
+        gc.draw_image @image,
+                      0, 0, desired_width, desired_height,
+                      left, top, desired_width, desired_height
       end
     end
   end

--- a/shoes-swt/spec/shoes/swt/image_pattern_spec.rb
+++ b/shoes-swt/spec/shoes/swt/image_pattern_spec.rb
@@ -2,43 +2,38 @@ require 'shoes/swt/spec_helper'
 
 describe Shoes::Swt::ImagePattern do
   let(:dsl)         { Shoes::ImagePattern.new("some/path/to") }
-  let(:applied_to)  { double("applied to") }
-  let(:swt_image)   { double("swt image") }
-  let(:swt_pattern) { double("swt pattern") }
+  let(:applied_to)  { double("applied to", width: 100, height: 100,
+                             element_left: 0, element_top: 0,
+                             element_right: 100, element_bottom: 100) }
+
+  let(:swt_image)   { double("swt image", bounds: bounds) }
+  let(:bounds)      { double("bounds", width: 100, height: 100) }
+  let(:gc)          { double("gc", draw_image: nil) }
 
   subject { Shoes::Swt::ImagePattern.new(dsl) }
 
-  it_behaves_like "an swt pattern"
-
   before do
-    allow(::Swt::Image).to receive(:new)   { swt_image }
-    allow(::Swt::Pattern).to receive(:new) { swt_pattern }
+    allow(::Swt::Image).to receive(:new) { swt_image }
   end
 
   describe "#dispose" do
     it "disposes of sub-resources" do
       expect(swt_image).to receive(:dispose)
-      expect(swt_pattern).to receive(:dispose)
-
-      expect(subject.pattern).to_not be_nil
+      subject.apply_as_fill(gc, applied_to)
       subject.dispose
     end
   end
 
   describe "#apply_as_stroke" do
-    let(:gc) { double("gc") }
-
-    it "sets foreground" do
-      expect(gc).to receive(:set_foreground_pattern)
+    it "draws" do
+      expect(gc).to receive(:draw_image)
       subject.apply_as_stroke(gc, applied_to)
     end
   end
 
   describe "#apply_as_fill" do
-    let(:gc) { double("gc") }
-
-    it "sets background" do
-      expect(gc).to receive(:set_background_pattern)
+    it "draws" do
+      expect(gc).to receive(:draw_image)
       subject.apply_as_fill(gc, applied_to)
     end
   end

--- a/shoes-swt/spec/shoes/swt/image_pattern_spec.rb
+++ b/shoes-swt/spec/shoes/swt/image_pattern_spec.rb
@@ -37,4 +37,45 @@ describe Shoes::Swt::ImagePattern do
       subject.apply_as_fill(gc, applied_to)
     end
   end
+
+  describe "#draw_image_pattern" do
+    let(:partial) { 20 }
+    let(:full)    { 100 }
+
+    it "draws once if too small" do
+      allow(applied_to).to receive(:width)  { 10 }
+      allow(applied_to).to receive(:height) { 10 }
+
+      expect_drawn(0, 0)
+      subject.draw_image_pattern(gc, applied_to)
+    end
+
+    it "draws partial horizontally" do
+      allow(applied_to).to receive(:width)         { full + partial }
+      allow(applied_to).to receive(:element_right) { full + partial }
+
+      expect_drawn(0, 0,   width: full)
+      expect_drawn(100, 0, width: partial)
+      subject.draw_image_pattern(gc, applied_to)
+    end
+
+    it "draws partial vertically" do
+      allow(applied_to).to receive(:height)         { full + partial }
+      allow(applied_to).to receive(:element_bottom) { full + partial }
+
+      expect_drawn(0, 0,   height: full)
+      expect_drawn(0, 100, height: partial)
+      subject.draw_image_pattern(gc, applied_to)
+    end
+
+    def expect_drawn(left, top, opts={})
+      width  = opts[:width] || 100
+      height = opts[:height] || 100
+
+      expect(gc).to receive(:draw_image).with(swt_image, 0, 0,
+                                              width, height,
+                                              left, top,
+                                              width, height)
+    end
+  end
 end


### PR DESCRIPTION
All right, here's a beginning to addressing #526

Turns out that we get minimal control over the positioning when `Swt::Pattern` is used to draw images, so we have to take control ourselves to get the results we want.

Specifically, when an element applies the image pattern as a background, I expect it will start over with the images from the corner of that new element, not just show the images cut off wherever they end up positioning on a repeat from the window's edge.

Modifying the sample file `menu-gray.png` to give it a border, you can see the issue when you run it against master with this app:

```
Shoes.app do
  file = File.expand_path(File.join(__FILE__, "..", "..", "samples/menu-gray.png"))

  background file
  rect 120, 120, 200, 200, strokewidth: 5, fill: pattern(file)
end
```

**master**
![image](https://cloud.githubusercontent.com/assets/130504/7342699/cdda8d08-ec6c-11e4-9318-d270209a471a.png)

**This PR**
![image](https://cloud.githubusercontent.com/assets/130504/7342710/f7ac0bca-ec6c-11e4-8f42-937ff3443a07.png)

Bonus shot of `samples/simple-form.rb` looking nice:
![image](https://cloud.githubusercontent.com/assets/130504/7342754/64fa3ac6-ec6d-11e4-8c21-7105f73e1cc8.png)

One change is that this pushes the return value for deciding whether to do further drawing down to the `Color`, `Gradient` and `ImagePattern` classes. This was necessary because our drawing in `ImagePattern` gets overwritten by `RectPainter#fill` if we don't short-circuit it. I left comments as the return value there was a bit subtle to rely on.

TODO:
* [x] Legit tests around drawing the images, especially all the edge cases and cut-offs
* [x] Break down the drawing method further
* [ ] Test against all the samples to catch any issues with tweaking contracts on fill/stroke for rect drawing