### PR TITLE
Modify #replace to use options hash and parse fonts.

### DIFF
--- a/shoes-core/lib/shoes/text_block.rb
+++ b/shoes-core/lib/shoes/text_block.rb
@@ -34,6 +34,10 @@ class Shoes
     end
 
     def replace(*texts)
+      opts = texts.pop if texts.last.is_a?(Hash)
+      style(opts)
+      handle_styles(opts || {}) # handle fonts, after any other merge
+
       # Order here matters as well--backend#replace shouldn't rely on DSL state
       # but the texts that it's passed if it needs information at this point.
       @gui.replace(*texts)

--- a/shoes-core/spec/shoes/text_block_spec.rb
+++ b/shoes-core/spec/shoes/text_block_spec.rb
@@ -72,6 +72,17 @@ describe Shoes::TextBlock do
       text_block.replace "Later Gator"
       expect(text_block.text_styles).to be_empty
     end
+
+    it "updates styles from options hash" do
+      text_block.replace "Later Gator", stroke: Shoes::COLORS[:aquamarine]
+      expect(text_block.stroke).to eq(Shoes::COLORS[:aquamarine])
+    end
+
+    it "updates font from options hash" do
+      text_block.replace "Later Gator", font: 'Monospace 18px'
+      expect(text_block.font).to eq('Monospace')
+      expect(text_block.size).to eq(18)
+    end
   end
 
   describe "#contents" do


### PR DESCRIPTION
Fixes #523 

Only the font parsing (and style setting) was still broken in the sample `simple-anim-text`. This modifies `TextBlock#replace` to look for an options hash in params and parse the font.