### PR TITLE
Fix for zombie apps remaining in Shoes.apps list

### DIFF
--- a/shoes-swt/lib/shoes/swt/app.rb
+++ b/shoes-swt/lib/shoes/swt/app.rb
@@ -235,6 +235,7 @@ class Shoes
       def unregister_app
         proc do |_event|
           ::Shoes::Swt.unregister(self)
+          ::Shoes.unregister(self.dsl.app)
         end
       end
 

--- a/shoes-swt/spec/shoes/swt/app_spec.rb
+++ b/shoes-swt/spec/shoes/swt/app_spec.rb
@@ -2,11 +2,12 @@ require "shoes/swt/spec_helper"
 
 describe Shoes::Swt::App do
   let(:opts) { {:background => Shoes::COLORS[:salmon], :resizable => true} }
-  let(:app) { double('app', :opts => opts,
-                            :width => width,
-                            :height => 0,
-                            :app_title => 'double') }
-  let(:dsl) { app }
+  let(:app)  { double('app') }
+  let(:dsl)  { double('dsl', :app => app,
+                             :opts => opts,
+                             :width => width,
+                             :height => 0,
+                             :app_title => 'double') }
 
   let(:opts_unresizable) { {:background => Shoes::COLORS[:salmon],
                             :resizable => false} }
@@ -16,7 +17,7 @@ describe Shoes::Swt::App do
                                         :app_title => 'double') }
   let(:width) {0}
 
-  subject { Shoes::Swt::App.new(app) }
+  subject { Shoes::Swt::App.new(dsl) }
 
   it { is_expected.to respond_to :clipboard }
   it { is_expected.to respond_to :clipboard= }
@@ -42,6 +43,14 @@ describe Shoes::Swt::App do
       subject
       expect(Shoes::Swt.apps.length).to eq(old_apps_length + 1)
       expect(Shoes::Swt.apps.include?(subject)).to be_truthy
+    end
+
+    it "unregisters" do
+      old_apps_length = Shoes::Swt.apps.length
+      expect(Shoes).to receive(:unregister)
+
+      subject.send(:unregister_app).call()
+      expect(Shoes::Swt.apps.length).to eq(old_apps_length)
     end
   end
 


### PR DESCRIPTION
Fixes #1065

When a window was closed, we were properly unregistering it from the `Shoes::Swt.apps` list, but Shoes keeps a list of the DSL-side apps as well over in `Shoes.apps` that needed to get notified.

IRB works relatively well as in the bug report, although you need some extra business to get Shoes started up these days (a call to `Shoes::Swt.initialize_backend`). To that end, I found this test app useful:

```
Shoes.app do
  button "Apps?" do
    alert Shoes.apps
  end

  click do
    Shoes.app do
      para "Yo"
    end
  end
end
```

Click anywhere to make a new window, click the Apps button to see a list. The list should always match the open window count.