### PR TITLE
Fix packaged app initialization

### DIFF
--- a/shoes-package/lib/warbler/traits/shoes.rb
+++ b/shoes-package/lib/warbler/traits/shoes.rb
@@ -27,7 +27,7 @@ module Warbler
       end
 
       def after_configure
-        config.init_contents << StringIO.new("require 'shoes'\nShoes.configuration.backend = :swt\n")
+        config.init_contents << StringIO.new("require 'shoes'\nrequire 'shoes/swt'\nShoes::Swt.initialize_backend\n")
       end
 
       def update_archive(jar)


### PR DESCRIPTION
Previously was enough to set backend in config, now must call `Shoes::Swt.initialize_backend` since #1102.

Was failing with a missing constant on `Shoes::Swt::App` when running a packaged jar since the initialization wasn't properly getting things loaded anymore.