### PR TITLE
Bump rspec version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :development do
   gem "pry"
   gem "pry-nav"
 
-  gem "rspec", "~>3.0.0"
+  gem "rspec", "~>3.2.0"
   gem "rspec-its", "~>1.0.1"
   gem "rake"
 


### PR DESCRIPTION
After cloning I tried to run `bundle install` and got the following error:

```
Bundler could not find compatible versions for gem "rspec-expectations":
  In Gemfile:
    rspec (~> 3.0.0) java depends on
      rspec-expectations (~> 3.0.0) java

    rspec-its (~> 1.0.1) java depends on
      rspec-expectations (3.2.1)
```

I updated the rspec version in the gemfile to resolve the issue.
