### PR TITLE
Add fallback to retry app on thread access error

### DIFF
--- a/shoes-swt/lib/shoes/swt.rb
+++ b/shoes-swt/lib/shoes/swt.rb
@@ -123,6 +123,17 @@ class Shoes
       require 'shoes/swt/redrawing_aspect'
 
       @initialized = true
+    rescue Java::OrgEclipseSwt::SWTException => e
+      if e.message == "Invalid thread access"
+        puts "Ooops, we couldn't start properly. We'll try again."
+        puts ""
+        puts "To avoid this restarting behavior, try one of the following:"
+        puts "  * Use the shoes executable to start your app"
+        puts "  * Add JRUBY_OPTS='-J-XstartOnFirstThread' to your environment before starting."
+
+        `JRUBY_OPTS=-J-XstartOnFirstThread #{$0} #{ARGV.join(" ")}`
+        exit $?.exitstatus
+      end
     end
   end
 end


### PR DESCRIPTION
If we are on Mac OS X and don't properly pass the `-J-XstartOnFirstThread`
flag at JVM startup, we end up failing with an error about thread
access.

While we handle this in bin/shoes for the majority of cases,
users that might be trying to do more esoteric things (or just doing the
wrong thing by not starting through our normal paths) will get a bad
result with the app crashing.

This change will give us a fallback position--we set the env we need and
retry starting the app up again after giving a warning about what went
wrong, and why they might want to fix it. While it will be slower than
we want for the mainline case, it still keeps the basic case running and
seems much kinder to me.