### PR TITLE
Rubocop: Disable Style/WordArray

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,3 +29,7 @@ Style/TrailingComma:
 # methods)
 Style/TrivialAccessors:
   Enabled: false
+
+# We don't care if you use %w or literal string arrays
+Style/WordArray:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -495,9 +495,3 @@ Style/SymbolProc:
 # Cop supports --auto-correct.
 Style/VariableInterpolation:
   Enabled: false
-
-# Offense count: 13
-# Cop supports --auto-correct.
-# Configuration parameters: WordRegex.
-Style/WordArray:
-  MinSize: 3


### PR DESCRIPTION
This one seems questionable to me - I think the array notation is sometimes clearer.

Merge away if you prefer `%w` though.