### PR TITLE
Don't choose at DSL level during initialization

### DIFF
--- a/shoes-core/lib/shoes/list_box.rb
+++ b/shoes-core/lib/shoes/list_box.rb
@@ -39,7 +39,6 @@ class Shoes
     def after_initialize
       proxy_array = Shoes::ProxyArray.new(items, @gui)
       @style[:items] = proxy_array
-      choose @style[:choose]
     end
 
     def items=(vanilla_array)

--- a/shoes-core/spec/shoes/list_box_spec.rb
+++ b/shoes-core/spec/shoes/list_box_spec.rb
@@ -68,8 +68,8 @@ describe Shoes::ListBox do
       list_box.choose "Wine"
     end
 
-    it 'should call @gui.choose when the choose option is passed' do
-      expect_gui_choose_with 'Wine'
+    it 'should not call @gui.choose when the choose option is passed' do
+      expect_any_instance_of(Shoes.configuration.backend::ListBox).to_not receive(:choose)
       Shoes::ListBox.new app, parent, input_opts.merge(choose: 'Wine')
     end
   end

--- a/shoes-swt/lib/shoes/swt/list_box.rb
+++ b/shoes-swt/lib/shoes/swt/list_box.rb
@@ -25,6 +25,10 @@ class Shoes
           @dsl.call_change_listeners
         end
         update_items
+
+        # Set initial selection without triggering callbacks!
+        choice = @dsl.style[:choose]
+        @real.text = choice if choice
       end
 
       def update_items

--- a/shoes-swt/spec/shoes/swt/list_box_spec.rb
+++ b/shoes-swt/spec/shoes/swt/list_box_spec.rb
@@ -8,7 +8,8 @@ describe Shoes::Swt::ListBox do
                         items: items, opts: {},
                         element_width: 200, element_height: 20).as_null_object }
   let(:block)  { ->(){} }
-  let(:real)   { double('real', text: "", :items= => true,
+  let(:real)   { double('real', text: "",
+                        :items= => true, :text= => true,
                         set_size: true, add_selection_listener: true,
                         disposed?: false) }
 
@@ -30,6 +31,12 @@ describe Shoes::Swt::ListBox do
     subject.update_items
     # creation already calls update_items once
     expect(real).to have_received(:items=).with(["hello"]).twice
+  end
+
+  it "should set real text if initialized with choose option" do
+    allow(dsl).to receive(:style) { { choose: "Apple" } }
+    subject
+    expect(real).to have_received(:text=).with("Apple")
   end
 
   it "should respond to choose" do


### PR DESCRIPTION
Calling choose triggers the callbacks on change for a listbox, and it's
common practice to refer to other elements in the change blocks which,
during initial app startup, aren't there yet.

While I often lean toward having the DSL do as much as possible, in
this case I think the simplest approach here is to just let the backend
be responsible for it.

Fixes #1120.