### PR TITLE
Gentler, kinder error handling for downloads

### DIFF
--- a/shoes-core/lib/shoes/download.rb
+++ b/shoes-core/lib/shoes/download.rb
@@ -31,6 +31,7 @@ class Shoes
       @blk = slot.create_bound_block(blk)
       @progress_blk = slot.create_bound_block(@opts[:progress])
       @finish_blk = slot.create_bound_block(@opts[:finish])
+      @error_blk = slot.create_bound_block(@opts[:error] || default_error_proc)
     end
 
     def start
@@ -84,14 +85,16 @@ class Shoes
         rescue SocketError => e
           Shoes.logger.error e
         rescue => e
-          eval_block(error_proc, e)
+          eval_block(@error_blk, e)
         end
       end
     end
 
-    def error_proc
+    def default_error_proc
       lambda do |exception|
-        raise exception
+        Shoes.logger.error "Failure downloading #{@url}. To handle this yourself, pass `:error` option to the download call."
+        Shoes.logger.error exception.message
+        Shoes.logger.error exception.backtrace.join("\n\t")
       end
     end
 

--- a/shoes-core/spec/shoes/download_spec.rb
+++ b/shoes-core/spec/shoes/download_spec.rb
@@ -15,10 +15,8 @@ describe Shoes::Download do
   let(:length) {download.length}
   let(:content_length) {download.content_length}
 
-  let(:bound_block) { Proc.new {} }
-
   before do
-    expect(app.current_slot).to receive(:create_bound_block).at_least(1) { |blk| blk ? bound_block : nil }
+    expect(app.current_slot).to receive(:create_bound_block).at_least(1) { |blk| blk ? blk : nil }
 
     stub_request(:get, name)
       .to_return(:status => response_status, :body => response_body, :headers => response_headers)
@@ -79,7 +77,7 @@ describe Shoes::Download do
     context 'with content length' do
       it 'calls the progress proc from start, download and finish' do
         expect(download.gui).to have_received(:eval_block).
-                                  with(bound_block, download).
+                                  with(progress_proc, download).
                                   exactly(3).times
       end
     end
@@ -89,7 +87,7 @@ describe Shoes::Download do
 
       it 'does not call on progress, but called from content length and finish' do
         expect(download.gui).to have_received(:eval_block).
-          with(bound_block, download).
+          with(progress_proc, download).
           twice
       end
 
@@ -111,7 +109,7 @@ describe Shoes::Download do
 
     context 'with a block' do
       it 'calls the block with a result' do
-        expect(download.gui).to have_received(:eval_block).with(bound_block, result)
+        expect(download.gui).to have_received(:eval_block).with(input_block, result)
       end
 
       describe 'response object' do
@@ -138,11 +136,12 @@ describe Shoes::Download do
     end
 
     context 'with a finish proc' do
-      let(:opts) { {save: "nasa50th.gif", finish: input_block} }
+      let(:finish_proc) { Proc.new {} }
+      let(:opts) { {save: "nasa50th.gif", finish: finish_proc} }
       subject(:download) { Shoes::Download.new app, parent, name, opts }
 
       it 'calls the finish proc' do
-        expect(download.gui).to have_received(:eval_block).with(bound_block, subject)
+        expect(download.gui).to have_received(:eval_block).with(finish_proc, subject)
       end
     end
 
@@ -168,6 +167,21 @@ describe Shoes::Download do
 
       download.start
       download.join_thread
+    end
+
+    describe 'with custom error blocks' do
+      let(:error_proc) { Proc.new { } }
+      let(:opts) { {save: "nasa50th.gif", error: error_proc} }
+
+      it 'gets called' do
+        error = StandardError.new("Nope")
+
+        expect(download.gui).to receive(:eval_block).with(error_proc, error)
+        allow(download).to receive(:open).and_raise(error)
+
+        download.start
+        download.join_thread
+      end
     end
   end
 end


### PR DESCRIPTION
Changes to percolate errors during Download up to the app were making it
so a simple 404 caused a crash. Oops, not quite what we want.

But we don't want things to go away silently either. In light of that,
we now log when there's a downloading failure, and also provide a
callback proc that can be set to handle errors on the Download yourself
if you want it.

This also prompted some revision of the tests, which were being
unnecessarily inexact in their expectations around which proc would get
executed at what point in time.

Fixes #1121.