### PR TITLE
Rubocop: Fix all Style/SpaceInsideBlockBraces

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,10 @@ Style/CollectionMethods:
   PreferredMethods:
     inject: 'inject'
 
+# We don't have a strong opinion on how you use spaces inside braces
+Style/SpaceInsideHashLiteralBraces:
+  Enabled: false
+
 # We like to be flexible if we want to add in interpolation
 # see discussion #859
 Style/StringLiterals:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -383,9 +383,3 @@ Style/SpaceAroundOperators:
 # Configuration parameters: EnforcedStyle, SupportedStyles, EnforcedStyleForEmptyBraces, SpaceBeforeBlockParameters.
 Style/SpaceInsideBlockBraces:
   Enabled: false
-
-# Offense count: 200
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces, SupportedStyles.
-Style/SpaceInsideHashLiteralBraces:
-  Enabled: false


### PR DESCRIPTION
With configuration for no space before block parameters

This one's questionable, so let's discuss.