### PR TITLE
Correct cursor height for empty text layouts

### DIFF
--- a/shoes-swt/lib/shoes/swt/text_block/text_segment_collection.rb
+++ b/shoes-swt/lib/shoes/swt/text_block/text_segment_collection.rb
@@ -164,9 +164,20 @@ class Shoes
         end
 
         # This could be smarter, basing height on the actual line the cursor's
-        # in. For now, just use the first line's height.
+        # in. For now, just use the first line's (purported) height.
         def cursor_height
-          @segments.first.line_bounds(0).height
+          if @segments.first.text.empty?
+            # Heights are off for empty text layouts. Fake it to make it (it
+            # being a real height).
+            new_segment = TextSegment.new(@dsl, "Hi", 100)
+            height_from_segment(new_segment)
+          else
+            height_from_segment(@segments.first)
+          end
+        end
+
+        def height_from_segment(segment)
+          segment.line_bounds(0).height
         end
       end
     end


### PR DESCRIPTION
Fixes #1114.

If a text block with a cursor starts out life empty, SWT returns the wrong height for that block. To get around this, we spin up a new segment (which won't be displayed) to get an appropriate height.

Minimal sample app (although `samples/simple-editor.rb` is pretty small too):

```
Shoes.app do
  p = para "", font: "Monospace 48px"
  p.cursor = -1

  keypress do
    p.replace(p.text + ".")
  end
end
```

Didn't spec this because the specs in this neighborhood all stub out the layout to a point where tests would be pretty much testing that we mocked things right. :grimacing: 