### PR TITLE
backend_for unification

### DIFF
--- a/shoes-core/lib/shoes/animation.rb
+++ b/shoes-core/lib/shoes/animation.rb
@@ -17,10 +17,10 @@ class Shoes
       @blk = @app.current_slot.create_bound_block(blk)
       @current_frame = 0
       @stopped = false
-      @gui = Shoes.configuration.backend_for(self, @app.gui)
+      @gui = Shoes.backend_for(self)
     end
 
-    attr_reader :current_frame, :framerate, :blk
+    attr_reader :current_frame, :framerate, :blk, :app
 
     def start
       @stopped = false

--- a/shoes-core/lib/shoes/configuration.rb
+++ b/shoes-core/lib/shoes/configuration.rb
@@ -49,19 +49,24 @@ class Shoes
         backend.const_get(class_name, false)
       end
 
-      # Creates an appropriate backend object, passing along additional arguments
-      #
-      # @param [Object] shoes_object A Shoes object
-      # @return [Object] An appropriate backend object
-      # @example
-      #   Shoes.configuration.backend_for(button, args) # => <Shoes::Swt::Button:0x12345678>
       def backend_for(shoes_object, *args)
         backend_factory(shoes_object).call(shoes_object, *args)
       end
 
-      # Experimental replacement for #backend_for
+      # Creates an appropriate backend object, passing along additional
+      # arguments
+      #
+      # @param [Object] shoes_object A Shoes object
+      # @return [Object] An appropriate backend object
+      #
+      # @example
+      #   Shoes.backend_for(button, args) # => <Shoes::Swt::Button:0x12345678>
       def backend_with_app_for(shoes_object, *args, &blk)
-        backend_factory(shoes_object).call(shoes_object, shoes_object.app.gui, *args, &blk)
+        # Some element types (packager for instance) legitimately don't have
+        # an app. In those cases, don't try to get it to pass along.
+        args.unshift(shoes_object.app.gui) if shoes_object.respond_to?(:app)
+
+        backend_factory(shoes_object).call(shoes_object, *args, &blk)
       end
 
       def backend_factory(shoes_object)

--- a/shoes-core/lib/shoes/configuration.rb
+++ b/shoes-core/lib/shoes/configuration.rb
@@ -49,10 +49,6 @@ class Shoes
         backend.const_get(class_name, false)
       end
 
-      def backend_for(shoes_object, *args)
-        backend_factory(shoes_object).call(shoes_object, *args)
-      end
-
       # Creates an appropriate backend object, passing along additional
       # arguments
       #
@@ -61,7 +57,7 @@ class Shoes
       #
       # @example
       #   Shoes.backend_for(button, args) # => <Shoes::Swt::Button:0x12345678>
-      def backend_with_app_for(shoes_object, *args, &blk)
+      def backend_for(shoes_object, *args, &blk)
         # Some element types (packager for instance) legitimately don't have
         # an app. In those cases, don't try to get it to pass along.
         args.unshift(shoes_object.app.gui) if shoes_object.respond_to?(:app)
@@ -95,7 +91,7 @@ def Shoes.configuration
 end
 
 def Shoes.backend_for(shoes_object, *args, &blk)
-  Shoes::Configuration.backend_with_app_for(shoes_object, *args, &blk)
+  Shoes::Configuration.backend_for(shoes_object, *args, &blk)
 end
 
 def Shoes.backend

--- a/shoes-core/lib/shoes/download.rb
+++ b/shoes-core/lib/shoes/download.rb
@@ -10,15 +10,17 @@ class Shoes
   end
 
   class Download
-    attr_reader :progress, :response, :content_length, :gui, :transferred
+    attr_reader :app, :progress, :response, :content_length, :gui, :transferred
+
     UPDATE_STEPS = 100
 
     def initialize(app, _parent, url, opts = {}, &blk)
+      @app = app
       @url = url
       @opts = opts
       initialize_blocks(app, blk)
 
-      @gui = Shoes.configuration.backend_for(self)
+      @gui = Shoes.backend_for(self)
 
       @response = HttpResponse.new
       @finished = false

--- a/shoes-core/lib/shoes/image_pattern.rb
+++ b/shoes-core/lib/shoes/image_pattern.rb
@@ -4,7 +4,7 @@ class Shoes
 
     def initialize(path)
       @path = path
-      @gui = Shoes.configuration.backend_for(self)
+      @gui = Shoes.backend_for(self)
     end
 
     attr_reader :gui, :path

--- a/shoes-core/lib/shoes/mock/sound.rb
+++ b/shoes-core/lib/shoes/mock/sound.rb
@@ -1,7 +1,7 @@
 class Shoes
   module Mock
     class Sound
-      def initialize(_dsl)
+      def initialize(_dsl, _app)
       end
     end
   end

--- a/shoes-core/lib/shoes/packager.rb
+++ b/shoes-core/lib/shoes/packager.rb
@@ -4,7 +4,7 @@ class Shoes
 
     def initialize
       begin
-        @backend = Shoes.configuration.backend_for(self)
+        @backend = Shoes.backend_for(self)
       rescue ArgumentError
         # Packaging unsupported by this backend
       end

--- a/shoes-core/lib/shoes/sound.rb
+++ b/shoes-core/lib/shoes/sound.rb
@@ -3,13 +3,14 @@ class Shoes
     include Common::Inspect
 
     def initialize(parent, filepath, _opts = {}, &_blk)
+      @app    = parent
       @parent = parent
       @filepath = filepath
 
-      @gui = Shoes.configuration.backend_for(self)
+      @gui = Shoes.backend_for(self)
     end
 
-    attr_reader :gui, :filepath, :parent
+    attr_reader :app, :gui, :filepath, :parent
 
     def play
       @gui.play

--- a/shoes-core/lib/shoes/timer.rb
+++ b/shoes-core/lib/shoes/timer.rb
@@ -6,9 +6,9 @@ class Shoes
       @app = app
       @n   = n
       @blk = @app.current_slot.create_bound_block(blk)
-      @gui = Shoes.configuration.backend_for(self, @app.gui, @blk)
+      @gui = Shoes.backend_for(self, @blk)
     end
 
-    attr_reader :n, :gui
+    attr_reader :app, :n, :gui
   end
 end

--- a/shoes-core/spec/shoes/configuration_spec.rb
+++ b/shoes-core/spec/shoes/configuration_spec.rb
@@ -18,18 +18,18 @@ describe Shoes::Configuration do
 
     let(:dsl_object) { Shoes::Shape.new app, parent }
 
-    describe "#backend_with_app_for" do
+    describe "#backend_for" do
       it "passes app.gui to backend" do
         expect(Shoes.configuration.backend::Shape).to receive(:new).with(an_instance_of(Shoes::Shape), app.gui).and_call_original
         dsl_object
       end
 
       it "returns shape backend object" do
-        expect(Shoes.configuration.backend_with_app_for(dsl_object)).to be_instance_of(Shoes.configuration.backend::Shape)
+        expect(Shoes.backend_for(dsl_object)).to be_instance_of(Shoes.configuration.backend::Shape)
       end
 
       it "raises ArgumentError for a non-Shoes object" do
-        expect { Shoes.configuration.backend_with_app_for(1..100) }.to raise_error(ArgumentError)
+        expect { Shoes.backend_for(1..100) }.to raise_error(ArgumentError)
       end
     end
   end

--- a/shoes-core/spec/shoes/sound_spec.rb
+++ b/shoes-core/spec/shoes/sound_spec.rb
@@ -1,7 +1,8 @@
 require 'shoes/spec_helper'
 
 describe Shoes::Sound do
-  let(:parent) { double("parent") }
+  let(:app_gui) { double("app gui") }
+  let(:parent) { double("parent", gui: app_gui) }
   let(:filepath) { "../../samples/sounds/61847__simon-rue__boink-v3.wav" }
   subject { Shoes::Sound.new(parent, filepath) }
 

--- a/shoes-swt/lib/shoes/swt/color_factory.rb
+++ b/shoes-swt/lib/shoes/swt/color_factory.rb
@@ -23,7 +23,7 @@ class Shoes
         return nil if element.nil?
         return @swt_elements[element] if @swt_elements.include?(element)
 
-        swt_element = ::Shoes.configuration.backend_for(element)
+        swt_element = ::Shoes.backend_for(element)
         @swt_elements[element] = swt_element
         swt_element
       end

--- a/shoes-swt/lib/shoes/swt/download.rb
+++ b/shoes-swt/lib/shoes/swt/download.rb
@@ -2,7 +2,7 @@ class Shoes
   module Swt
     class Download
       attr_accessor :busy
-      def initialize(_dsl)
+      def initialize(_dsl, _app)
         @busy = false
       end
 

--- a/shoes-swt/lib/shoes/swt/sound.rb
+++ b/shoes-swt/lib/shoes/swt/sound.rb
@@ -19,7 +19,7 @@ class Shoes
 
       BufferSize = 4096
 
-      def initialize(dsl)
+      def initialize(dsl, _app)
         @dsl = dsl
       end
 


### PR DESCRIPTION
Fixes #741

This settles on one version of `backend_for`. I found, though, that we had a number of elements (`Packager`, `ImagePattern` and `Color`) where usage was not really appropriate to expect an `app.gui` (it doesn't have it today, doesn't really need it), so I made the method flexible enough to allow for that.

Might do another pass through to pull some of this out into a separate class instead of leaving it in `Shoes::Configuration`, which seems like an odd home for it. However, that'd just be a basic extraction on top of what's here.