### PR TITLE
Add super_ prefix for command key on Mac

### DIFF
--- a/shoes-swt/lib/shoes/swt/key_listener.rb
+++ b/shoes-swt/lib/shoes/swt/key_listener.rb
@@ -79,6 +79,7 @@ class Shoes
         modifier_keys += 'control_' if control?(event)
         modifier_keys += 'shift_' if shift?(event) && special_key?(event)
         modifier_keys += 'alt_' if alt?(event)
+        modifier_keys += 'super_' if super?(event)
         modifier_keys
       end
 
@@ -86,18 +87,23 @@ class Shoes
         is_this_modifier_key?(event, ::Swt::SWT::ALT)
       end
 
-      # NOTE: state_mask and key_code error for me so the java version is used
-      def is_this_modifier_key?(event, key)
-        (event.stateMask & key) == key
+      def control?(event)
+        is_this_modifier_key?(event, ::Swt::SWT::CTRL)
       end
 
       def shift?(event)
         is_this_modifier_key?(event, ::Swt::SWT::SHIFT)
       end
 
-      def control?(event)
-        is_this_modifier_key?(event, ::Swt::SWT::CTRL)
+      def super?(event)
+        is_this_modifier_key?(event, ::Swt::SWT::COMMAND)
       end
+
+      # NOTE: state_mask and key_code error for me so the java version is used
+      def is_this_modifier_key?(event, key)
+        (event.stateMask & key) == key
+      end
+
 
       def character_key(event)
         return '' if current_key_is_modifier?(event)

--- a/shoes-swt/spec/shoes/swt/key_listener_spec.rb
+++ b/shoes-swt/spec/shoes/swt/key_listener_spec.rb
@@ -37,6 +37,7 @@ describe Shoes::Swt::Keypress do
   CTRL = ::Swt::SWT::CTRL
   ALT = ::Swt::SWT::ALT
   SHIFT = ::Swt::SWT::SHIFT
+  COMMAND = ::Swt::SWT::COMMAND
 
   subject {key_listener}
 
@@ -51,6 +52,12 @@ describe Shoes::Swt::Keypress do
   def test_alt_character_press(character, state_mask_modifier = 0)
     state_modifier = ALT | state_mask_modifier
     result = ('alt_' + character).to_sym
+    test_character_press(character, state_modifier, result)
+  end
+
+  def test_command_character_press(character, state_mask_modifier = 0)
+    state_modifier = COMMAND | state_mask_modifier
+    result = ('super_' + character).to_sym
     test_character_press(character, state_modifier, result)
   end
 
@@ -152,6 +159,20 @@ describe Shoes::Swt::Keypress do
     end
   end
 
+  describe 'works with command key pressed such as' do
+    it ':super_a' do
+      test_command_character_press 'a'
+    end
+
+    it ':super_z' do
+      test_command_character_press 'z'
+    end
+
+    it ':super_/' do
+      test_command_character_press '/'
+    end
+  end
+
   describe 'only modifier keys yield nothing' do
     def test_receive_nothing_with_modifier(modifier, last_key_press = modifier)
       expect(block).not_to receive :call
@@ -171,8 +192,16 @@ describe Shoes::Swt::Keypress do
       test_receive_nothing_with_modifier CTRL
     end
 
+    it 'command' do
+      test_receive_nothing_with_modifier COMMAND
+    end
+
     it 'shift + ctrl' do
       test_receive_nothing_with_modifier SHIFT | CTRL, SHIFT
+    end
+
+    it 'shift + command' do
+      test_receive_nothing_with_modifier SHIFT | COMMAND, SHIFT
     end
 
     it 'ctrl + alt' do
@@ -181,6 +210,10 @@ describe Shoes::Swt::Keypress do
 
     it 'shift + ctrl + alt' do
       test_receive_nothing_with_modifier CTRL | SHIFT | ALT, ALT
+    end
+
+    it 'shift + ctrl + command + alt' do
+      test_receive_nothing_with_modifier CTRL | SHIFT | ALT | COMMAND, ALT
     end
   end
 


### PR DESCRIPTION
Part of a fix for #392, this handles the Mac side of things for mapping Command to a prefix.

I've done some searching, and I don't see a ready-made way to sense the press of a Windows key to map to the same `super_` prefix. Might try to test on my actual Windows machine this weekend to see what, if any, event is fired to determine if we can even support that.

No clue what, if anything, is the right thing to map over in Linux-land.

:key: 