### PR TITLE
Introduce Code of Conduct for the Shoes project

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,16 @@
+# Contributor Code of Conduct
+Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms.
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.1.0, available at [http://contributor-covenant.org/version/1/1/0/](http://contributor-covenant.org/version/1/1/0/)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,4 @@
 # Contributor Code of Conduct
-Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms.
 
 As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,12 @@ or set `JRUBY_OPTS` directly on the command line:
 
 
 ## Code of Conduct
-Everyone interacting in the Shoes project's codebases, issue trackers, chat rooms, and mailing lists is expected to follow the [code of conduct](https://github.com/shoes/shoes4/blob/master/CODE_OF_CONDUCT.md).
+
+Way way back in the day, there was a guy named _why. He created a project known as Hackety Hack to teach programming to everyone. In order to reach all corners of the earth, _why decided to make Hackety Hack work on Windows, Mac OS X, and Linux. This was a lot of work, and so _why decided to share his toolkit with the world. Thus, Shoes was born.
+
+Shoes was born to teach programming to everyone, in all corners of the earth. It's not cool to make new programmers or programmers with bad English feel bad because they don't write Ruby / English very well. And clearly any other anti-social comments directed at someone's religion, ethnicity, race, gender identity, or any of that personal stuff won't be tolerated here in the land of chunky-bacon! If community members feel like your comments are out of line in any project space (code, issues, chat rooms, mailing lists), they'll kindly let you know how to improve per our [code of conduct](https://github.com/shoes/shoes4/blob/master/CODE_OF_CONDUCT.md).
+
+The bottom-line is: Have Fun with Shoes!
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ There are rake tasks for running specs. Some examples (run `rake --tasks` to see
 Sometimes you only want to run specs from individual files rather than entire suites. You can run individual specs from the project root directory like this:
 
     $ rspec shoes-swt/spec/shoes/swt/app_spec.rb
-    
+
 If you're on OS X and you are running specs that require SWT, you will have to set the `JRUBY_OPTS` environment variable first:
 
     $ export JRUBY_OPTS=-J-XstartOnFirstThread
@@ -202,7 +202,10 @@ If you're on OS X and you are running specs that require SWT, you will have to s
 or set `JRUBY_OPTS` directly on the command line:
 
     $ JRUBY_OPTS=-J-XstartOnFirstThread rspec shoes-swt/spec/shoes/swt/app_spec.rb
-    
+
+
+## Code of Conduct
+Everyone interacting in the Shoes project's codebases, issue trackers, chat rooms, and mailing lists is expected to follow the [code of conduct](https://github.com/shoes/shoes4/blob/master/CODE_OF_CONDUCT.md).
 
 ## Contact
 


### PR DESCRIPTION
Hey all!
One of the best things about Shoes is how welcoming and open it is. It's been an awesome place for me to grow as an open source contributor, and I'd like to see it stay that way.

For many people, an explicit code of conduct is part of creating a safe environment online. I'd like to propose that we adopt one. The text here was drawn from the excellent http://contributor-covenant.org.

I'm super glad that we haven't had any significant problems to date, but that's all the more reason to put one in place now. With it, there are clearly stated expectations of how people will be treated when interacting with Shoes, and how the maintainers will handle issues that might arise in the future.

Obviously this is a big change to introduce well after a project has started, but I hope that we can come together on it. @PragTob @wasnotrice @KCErb @steveklabnik, what do you all think?