### PR TITLE
Load up backend if not already done when app starts

### DIFF
--- a/shoes-core/lib/shoes/configuration.rb
+++ b/shoes-core/lib/shoes/configuration.rb
@@ -29,6 +29,8 @@ class Shoes
       # @example
       #   Shoes::Configuration.backend = :swt # => Shoes::Swt
       def backend=(name)
+        return if @backend_name == name
+
         unless @backend.nil?
           fail "Can't switch backend to Shoes::#{name.capitalize}, Shoes::#{backend_name.capitalize} backend already loaded."
         end

--- a/shoes-core/lib/shoes/internal_app.rb
+++ b/shoes-core/lib/shoes/internal_app.rb
@@ -27,6 +27,7 @@ class Shoes
     end
 
     def setup_gui
+      ensure_backend_loaded
       @gui = Shoes.configuration.backend::App.new self
 
       self.current_slot = create_top_slot
@@ -35,6 +36,13 @@ class Shoes
 
       setup_global_keypresses
       register_console_keypress
+    end
+
+    def ensure_backend_loaded
+      if !defined?(Shoes.configuration.backend::App)
+        backend_const = Shoes.load_backend(Shoes.configuration.backend_name)
+        backend_const.initialize_backend
+      end
     end
 
     attr_reader :gui, :top_slot, :app, :dimensions,


### PR DESCRIPTION
Fixes #1146.

This helps when not running through `bin/shoes`. We end up with a defaulted backend value, but nothing actually loaded yet.

This also required allowing multiple attempts to set the backend to the same value.