### PR TITLE
Restore idea of needs_positioning for backgrounds

### DIFF
--- a/shoes-core/lib/shoes/common/background_element.rb
+++ b/shoes-core/lib/shoes/common/background_element.rb
@@ -5,6 +5,11 @@ class Shoes
         @dimensions = ParentDimensions.new @parent, @style
       end
 
+      # We derive everything from our parent, so we skip slot positioning.
+      def needs_positioning?
+        false
+      end
+
       def takes_up_space?
         false
       end

--- a/shoes-core/lib/shoes/dimensions.rb
+++ b/shoes-core/lib/shoes/dimensions.rb
@@ -91,6 +91,10 @@ class Shoes
       self.margin_right, self.margin_bottom =  margin
     end
 
+    def needs_positioning?
+      true
+    end
+
     def takes_up_space?
       true
     end

--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -169,8 +169,11 @@ class Shoes
     end
 
     def positioning(element, current_position)
-      position_element element, current_position
-      element.contents_alignment(current_position) if element.respond_to? :contents_alignment
+      if element.needs_positioning?
+        position_element element, current_position
+        element.contents_alignment(current_position) if element.respond_to? :contents_alignment
+      end
+
       if element.takes_up_space?
         update_current_position(current_position, element)
       else

--- a/shoes-core/spec/shoes/helpers/fake_absolute_element.rb
+++ b/shoes-core/spec/shoes/helpers/fake_absolute_element.rb
@@ -1,0 +1,30 @@
+class Shoes
+  class FakeAbsoluteElement
+    include Common::Inspect
+    include Common::Visibility
+    include Common::Positioning
+    include Common::Remove
+
+    include Shoes::DimensionsDelegations
+
+    def initialize
+      @dimensions = AbsoluteDimensions.new 0, 0, 100, 100
+    end
+
+    def add_child(element)
+      true
+    end
+
+    def adjust_current_position(*_)
+    end
+
+    # Fake this out instead of using Common::Style to avoid things like touching
+    # app level styles, etc. that we don't need for testing purposes
+    def style
+      @style ||= {}
+      @style
+    end
+
+    attr_accessor :dimensions, :parent, :gui
+  end
+end

--- a/shoes-core/spec/shoes/shared_examples/slot.rb
+++ b/shoes-core/spec/shoes/shared_examples/slot.rb
@@ -108,10 +108,33 @@ shared_examples_for 'positioning through :_position' do
     subject.contents_alignment
   end
 
+  it 'does not send _position if element does not need positioning' do
+    allow(element).to receive(:takes_up_space?)    { false }
+    allow(element).to receive(:needs_positioning?) { false }
+    expect(element).not_to receive(:_position)
+    add_child_and_align
+  end
+
+  it 'sends _position even when element does not take up space' do
+    allow(element).to receive(:takes_up_space?)    { false }
+    allow(element).to receive(:needs_positioning?) { true }
+    expect(element).to receive(:_position).and_call_original
+    add_child_and_align
+  end
+
   it 'is resilient to exceptions during positioning' do
     allow(element).to receive(:contents_alignment).and_raise("O_o")
     allow(subject).to receive(:puts)  # Quiet, you
     add_child_and_align
+  end
+
+  describe 'absolute dimensions' do
+    let(:element) { Shoes::FakeAbsoluteElement.new }
+
+    it 'positions element via _position' do
+      expect(element).to receive(:_position).and_call_original
+      add_child_and_align
+    end
   end
 end
 

--- a/shoes-core/spec/spec_helper.rb
+++ b/shoes-core/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require 'shoes/core'
 require 'shoes/ui/cli'
 require 'fileutils'
 require 'shoes/helpers/fake_element'
+require 'shoes/helpers/fake_absolute_element'
 require 'shoes/helpers/inspect_helpers'
 
 require 'webmock/rspec'

--- a/shoes-swt/spec/spec_helper.rb
+++ b/shoes-swt/spec/spec_helper.rb
@@ -13,6 +13,7 @@ require 'shoes'
 require 'shoes/ui/cli'
 require 'fileutils'
 require 'shoes/helpers/fake_element'
+require 'shoes/helpers/fake_absolute_element'
 require 'shoes/helpers/inspect_helpers'
 
 require 'webmock/rspec'


### PR DESCRIPTION
Fixes #599

Background and Border derive their whole positioning from their parent,
so they need to be skipped in the explicit positioning logic that slots
run over elements.