### PR TITLE
Rename category to fullscreen, exclude on Mac

### DIFF
--- a/shoes-core/spec/shoes/app_spec.rb
+++ b/shoes-core/spec/shoes/app_spec.rb
@@ -230,7 +230,7 @@ describe Shoes::App do
         expect(app).not_to be_fullscreen
       end
 
-      it 'can enter fullscreen' do
+      it 'can enter fullscreen', :fullscreen do
         app.fullscreen = true
         expect(app).to be_fullscreen
       end
@@ -244,18 +244,15 @@ describe Shoes::App do
         app.fullscreen = false
       end
 
-      # Failing on Mac fullscreen doesnt seem to work see #397
-      it 'is not in fullscreen', :fails_on_osx do
+      it 'is not in fullscreen', :fullscreen do
         expect(app).not_to be_fullscreen
       end
 
-      # Failing on Mac fullscreen doesnt seem to work see #397
-      it 'has its origina', :fails_on_osx do
+      it 'has its original', :fullscreen do
         expect(app.width).to eq(defaults[:width])
       end
 
-      # Failing on Mac fullscreen doesnt seem to work see #397
-      it 'has its original height', :fails_on_osx do
+      it 'has its original height', :fullscreen do
         expect(app.height).to eq(defaults[:height])
       end
     end

--- a/shoes-core/spec/shoes/internal_app_spec.rb
+++ b/shoes-core/spec/shoes/internal_app_spec.rb
@@ -54,7 +54,7 @@ describe Shoes::InternalApp do
   describe 'fullscreen' do
     let(:input_opts) { {fullscreen: true} }
 
-    it "sets fullscreen" do
+    it "sets fullscreen", :fullscreen do
       expect(subject.start_as_fullscreen?).to be_truthy
     end
   end

--- a/tasks/rspec.rb
+++ b/tasks/rspec.rb
@@ -37,7 +37,9 @@ def swt_args(args)
   args = args.to_hash
   args[:swt] = true
   args[:excludes] = [:no_swt]
-  args[:excludes] << :fails_on_osx if RbConfig::CONFIG["host_os"] =~ /darwin/
+
+  # Fullscreen on later Mac OS's is awkward (grabs screen away), so skip them
+  args[:excludes] << :fullscreen if RbConfig::CONFIG["host_os"] =~ /darwin/
   args
 end
 


### PR DESCRIPTION
Mac OS X in later versions steals the screen annoyingly when going
fullscreen, so even the tests that work for it are awkward to run by
default.

Rename to indicate this isn't about failure and make sure we don't slip
screens when running the tests by default.