### PR TITLE
Fix up handling of explicitly sized text blocks

### DIFF
--- a/shoes-core/lib/shoes/text_block_dimensions.rb
+++ b/shoes-core/lib/shoes/text_block_dimensions.rb
@@ -29,15 +29,31 @@ class Shoes
       10
     end
 
-    # This is the width the text block initially wants to try and fit into.
-    def desired_width(containing = containing_width)
-      parent.absolute_left + containing - absolute_left - margin_left - margin_right
+    # This is the width the text block initially wants to try to fit in.
+    #
+    # If an explicit containing width is provided, trust that most
+    # If we've gotten an explicit width, use that but check that we fit still
+    # Last but certainly not least, consult what's remaining in our parent.
+    def desired_width(containing = nil)
+      if containing
+        desired = parent.absolute_left + containing - absolute_left
+      elsif element_width
+        desired = [element_width, remaining_in_parent].min
+      else
+        desired = remaining_in_parent
+      end
+
+      desired - margin_left - margin_right
     end
 
     # If an explicit width's set, use that when asking how much space we need.
     # If not, we look to the parent.
     def containing_width
       element_width || parent.element_width
+    end
+
+    def remaining_in_parent
+      parent.absolute_left + parent.element_width - absolute_left
     end
   end
 

--- a/shoes-core/spec/shoes/text_block_spec.rb
+++ b/shoes-core/spec/shoes/text_block_spec.rb
@@ -203,8 +203,12 @@ describe Shoes::TextBlock do
       end
 
       it "is used for desired width" do
-        subject.absolute_left = 20
-        expect(subject.desired_width).to eql 100
+        expect(subject.desired_width).to eql 120
+      end
+
+      it "factors in if parent space is too small" do
+        subject.absolute_left = parent.element_width - 100
+        expect(subject.desired_width).to eql(100)
       end
     end
   end

--- a/shoes-swt/lib/shoes/swt/text_block.rb
+++ b/shoes-swt/lib/shoes/swt/text_block.rb
@@ -94,7 +94,11 @@ class Shoes
       def set_absolutes(starting_left, starting_top)
         last_segment = segments.last
 
-        @dsl.absolute_right  = starting_left + last_segment.last_line_width +
+        # If we have an explicit width, use that.
+        # If not, take our trailing line's width.
+        width_to_offset = @dsl.element_width || last_segment.last_line_width
+
+        @dsl.absolute_right  = starting_left + width_to_offset +
           margin_right - NEXT_ELEMENT_OFFSET
 
         @dsl.absolute_bottom = starting_top + last_segment.height +

--- a/shoes-swt/spec/shoes/swt/text_block_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block_spec.rb
@@ -56,6 +56,7 @@ describe Shoes::Swt::TextBlock do
         allow(dsl).to receive(:absolute_left)   { 50 }
         allow(dsl).to receive(:absolute_top)    { 0 }
         allow(dsl).to receive(:absolute_bottom) { layout_height }
+        allow(dsl).to receive(:element_width)   { nil }
       end
 
       it "positions single line of text" do
@@ -143,6 +144,7 @@ describe Shoes::Swt::TextBlock do
       before(:each) do
         allow(dsl).to receive(:parent) { double("dsl parent", absolute_left: 0) }
         allow(dsl).to receive(:absolute_bottom) { layout_height }
+        allow(dsl).to receive(:element_width)   { nil }
 
         current_position.next_line_start = 0
 


### PR DESCRIPTION
Fixes #664

If we were provided a text block with an explicitly declared width, that
wasn't being properly respected in deciding where to position the next
element after it, or in how much space we asked for. These conditions
are now properly handled.