### PR TITLE
Fix to installation for jruby-complete

### DIFF
--- a/shoes-core/ext/install/Rakefile
+++ b/shoes-core/ext/install/Rakefile
@@ -19,11 +19,11 @@ task default: ['install_script']
 
 task :install_script do
   if Gem.win_platform?
-    source_path = File.join(File.dirname(__FILE__), "shoes.bat")
-    dest_path = File.join(Gem.bindir, "shoes.bat")
+    source_path = File.join(ENV["PWD"], "shoes.bat")
+    dest_path = File.join(Gem.bindir(Gem.user_dir), "shoes.bat")
   else
-    source_path = File.join(File.dirname(__FILE__), "..", "..", "bin", "shoes-stub")
-    dest_path = File.join(Gem.bindir, "shoes")
+    source_path = File.join(ENV["PWD"], "..", "..", "bin", "shoes-stub")
+    dest_path = File.join(Gem.bindir(Gem.user_dir), "shoes")
   end
   FileUtils.cp(source_path, dest_path)
 end

--- a/shoes-core/ext/install/Rakefile
+++ b/shoes-core/ext/install/Rakefile
@@ -18,7 +18,13 @@ require 'fileutils'
 task default: ['install_script']
 
 task :install_script do
-  dest_dir = Gem.bindir(Gem.user_dir)
+  # If we're run via jruby-complete.jar, bindir is within the jar itself so
+  # look for bin based on user directory. Otherwise, prefer Gem.bindir.
+  if Gem.bindir.start_with?("uri:classloader")
+    dest_dir = Gem.bindir(Gem.user_dir)
+  else
+    dest_dir = Gem.bindir
+  end
 
   if Gem.win_platform?
     source_path = File.join(Dir.pwd, "shoes.bat")

--- a/shoes-core/ext/install/Rakefile
+++ b/shoes-core/ext/install/Rakefile
@@ -19,10 +19,10 @@ task default: ['install_script']
 
 task :install_script do
   if Gem.win_platform?
-    source_path = File.join(ENV["PWD"], "shoes.bat")
+    source_path = File.join(Dir.pwd, "shoes.bat")
     dest_path = File.join(Gem.bindir(Gem.user_dir), "shoes.bat")
   else
-    source_path = File.join(ENV["PWD"], "..", "..", "bin", "shoes-stub")
+    source_path = File.join(Dir.pwd, "..", "..", "bin", "shoes-stub")
     dest_path = File.join(Gem.bindir(Gem.user_dir), "shoes")
   end
   FileUtils.cp(source_path, dest_path)

--- a/shoes-core/ext/install/Rakefile
+++ b/shoes-core/ext/install/Rakefile
@@ -18,12 +18,16 @@ require 'fileutils'
 task default: ['install_script']
 
 task :install_script do
+  dest_dir = Gem.bindir(Gem.user_dir)
+
   if Gem.win_platform?
     source_path = File.join(Dir.pwd, "shoes.bat")
-    dest_path = File.join(Gem.bindir(Gem.user_dir), "shoes.bat")
+    dest_path = File.join(dest_dir, "shoes.bat")
   else
     source_path = File.join(Dir.pwd, "..", "..", "bin", "shoes-stub")
-    dest_path = File.join(Gem.bindir(Gem.user_dir), "shoes")
+    dest_path = File.join(dest_dir, "shoes")
   end
+
+  FileUtils.mkdir_p(dest_dir)
   FileUtils.cp(source_path, dest_path)
 end


### PR DESCRIPTION
http://xkcd.com/356

*Might* be a fix for https://github.com/shoes/shoes4/issues/1165 but I'm not confident yet that it addresses everything.
Will see if I can do some further installation testing tomorrow to gain
certainty before any merge.

This does get me to properly installing with jruby-complete locally on
my Mac.

When installing with jruby-complete we hit two problems:

1) `__FILE__` points to a classloader path inside the .jar. Thankfully, it
appears that the Rakefile in which the installation is happening has
`ENV["PWD"]` set (which makes sense anyway), so we can use that instead.

2) `Gem.bindir` points in this situation to a path inside the .jar as
well. Similarly, we have an out, though, mimicking what Rubygems does by
calling `Gem.bindir(Gem.user_dir)` instead of just `Gem.bindir`.