### PR TITLE
Slot clipping for painted elements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ group :development do
   gem "kramdown"
   gem 'simplecov'
   gem "codeclimate-test-reporter"
-  gem 'jruby-lint'
   gem 'webmock'
   gem 'hometown'
   gem 'rubocop'

--- a/samples/expert-game-of-life-adjusted.rb
+++ b/samples/expert-game-of-life-adjusted.rb
@@ -192,7 +192,8 @@ end
 Shoes.app(title: "The Game of Life", width: 800, height: 620, resizable: false) do
   background white
   @animate = false
-  stack(margin: 10) do
+
+  stack(margin: 10, width: 650, height: 620) do
     @new_world = World.new(40, 40, self)
     animate(10) do
       if @animate

--- a/samples/simple-face.rb
+++ b/samples/simple-face.rb
@@ -2,13 +2,13 @@
 # Smiling face by Coraline Clark (age 5), 2013
 #
 Shoes.app do
-  stack top: 150 do
-    @oval = oval 200, 1, 200, 200, fill: mintcream
-    @hair = star 120, -80, 80, 80
-    @eye1 = star 290, 48, 10,  10, 6
-    @eye2 = star 320, 48, 10,  10, 6
-    @mouth= oval 310, 120, 70, 40, fill: red
-    @nose = line 310, 80, 340, 110
-    @line = line 310, 140, 380, 140
+  stack margin_top: 150, width: 1.0, height: 1.0 do
+    @oval  = oval 200, 1, 200, 200, fill: mintcream
+    @hair  = star 120, -80, 80, 80
+    @eye1  = star 290, 48, 10,  10, 6
+    @eye2  = star 320, 48, 10,  10, 6
+    @mouth = oval 310, 120, 70, 40, fill: red
+    @nose  = line 310, 80, 340, 110
+    @line  = line 310, 140, 380, 140
   end
 end

--- a/shoes-core/lib/shoes/shape.rb
+++ b/shoes-core/lib/shoes/shape.rb
@@ -39,6 +39,10 @@ class Shoes
       @app.height
     end
 
+    def fixed_height?
+      false
+    end
+
     # Moves the shape
     #
     # @param [Integer] left The new left value

--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -152,6 +152,14 @@ class Shoes
       "#<#{self.class}:0x#{hash.to_s(16)} @contents=#{@contents.inspect} and so much stuff literally breaks the memory limit. Look at it selectively.>"
     end
 
+    def fixed_height?
+      !!@fixed_height
+    end
+
+    def variable_height?
+      !@fixed_height
+    end
+
     protected
 
     CurrentPosition = Struct.new(:x, :y, :next_line_start)
@@ -287,10 +295,6 @@ class Shoes
       else
         0
       end
-    end
-
-    def variable_height?
-      !@fixed_height
     end
   end
 

--- a/shoes-swt/lib/shoes/swt/common/painter.rb
+++ b/shoes-swt/lib/shoes/swt/common/painter.rb
@@ -35,14 +35,16 @@ class Shoes
           graphics_context.set_transform(@obj.transform)
 
           obj = @obj.dsl
-          if obj.needs_rotate?
-            set_rotate graphics_context, obj.rotate,
-                       obj.element_left + obj.element_width / 2.0,
-                       obj.element_top + obj.element_height / 2.0 do
+          clip_context_to(graphics_context, obj.parent) do
+            if obj.needs_rotate?
+              set_rotate graphics_context, obj.rotate,
+                         obj.element_left + obj.element_width / 2.0,
+                         obj.element_top + obj.element_height / 2.0 do
+                fill_and_draw(graphics_context)
+              end
+            else
               fill_and_draw(graphics_context)
             end
-          else
-            fill_and_draw(graphics_context)
           end
         end
 

--- a/shoes-swt/lib/shoes/swt/common/painter.rb
+++ b/shoes-swt/lib/shoes/swt/common/painter.rb
@@ -35,7 +35,7 @@ class Shoes
           graphics_context.set_transform(@obj.transform)
 
           obj = @obj.dsl
-          clip_context_to(graphics_context, obj.parent) do
+          clip_context_to(graphics_context, obj.parent, obj.parent.fixed_height?) do
             if obj.needs_rotate?
               set_rotate graphics_context, obj.rotate,
                          obj.element_left + obj.element_width / 2.0,

--- a/shoes-swt/lib/shoes/swt/common/resource.rb
+++ b/shoes-swt/lib/shoes/swt/common/resource.rb
@@ -24,10 +24,12 @@ class Shoes
           @graphic_contexts << graphics_context
         end
 
-        def clip_context_to(graphics_context, element)
+        def clip_context_to(graphics_context, element, use_element_height = true)
           clipping = graphics_context.clipping
+          height   = use_element_height ? element.height : clipping.height
+
           graphics_context.set_clipping(element.absolute_left, element.absolute_top,
-                                        element.width, element.height)
+                                        element.width, height)
           yield graphics_context
         ensure
           if clipping

--- a/shoes-swt/lib/shoes/swt/common/resource.rb
+++ b/shoes-swt/lib/shoes/swt/common/resource.rb
@@ -26,7 +26,7 @@ class Shoes
 
         def clip_context_to(graphics_context, element, use_element_height = true)
           clipping = graphics_context.clipping
-          height   = use_element_height ? element.height : clipping.height
+          height   = use_element_height ? element.height : element.app.height
 
           graphics_context.set_clipping(element.absolute_left, element.absolute_top,
                                         element.width, height)

--- a/shoes-swt/lib/shoes/swt/common/resource.rb
+++ b/shoes-swt/lib/shoes/swt/common/resource.rb
@@ -25,7 +25,7 @@ class Shoes
         end
 
         def clip_context_to(graphics_context, element)
-          clipping = graphics_context.get_clipping
+          clipping = graphics_context.clipping
           graphics_context.set_clipping(element.absolute_left, element.absolute_top,
                                         element.width, element.height)
           yield graphics_context

--- a/shoes-swt/lib/shoes/swt/common/resource.rb
+++ b/shoes-swt/lib/shoes/swt/common/resource.rb
@@ -23,6 +23,18 @@ class Shoes
         def track_graphics_context(graphics_context)
           @graphic_contexts << graphics_context
         end
+
+        def clip_context_to(graphics_context, element)
+          clipping = graphics_context.get_clipping
+          graphics_context.set_clipping(element.absolute_left, element.absolute_top,
+                                        element.width, element.height)
+          yield graphics_context
+        ensure
+          if clipping
+            graphics_context.set_clipping(clipping.x, clipping.y,
+                                          clipping.width, clipping.height)
+          end
+        end
       end
     end
   end

--- a/shoes-swt/lib/shoes/swt/text_block/painter.rb
+++ b/shoes-swt/lib/shoes/swt/text_block/painter.rb
@@ -20,7 +20,10 @@ class Shoes
                     @dsl.gui.segments.empty?
 
           reset_graphics_context(paint_event.gc)
-          @dsl.gui.segments.paint_control(paint_event.gc)
+
+          clip_context_to(paint_event.gc, @dsl.parent) do |gc|
+            @dsl.gui.segments.paint_control(gc)
+          end
         end
       end
     end

--- a/shoes-swt/spec/shoes/swt/common/painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/common/painter_spec.rb
@@ -3,10 +3,14 @@ require 'spec_helper'
 describe Shoes::Swt::Common::Painter do
   let(:object) {double 'object', dsl: dsl, transform: transform,
                                  apply_fill: nil, apply_stroke: nil}
-  let(:dsl) {double 'dsl', visible?: true, positioned?: true, style: {}}
+  let(:parent) {double 'parent', absolute_left: 0, absolute_top: 0,
+                       height: 100, width: 200}
+  let(:dsl) {double 'dsl', parent: parent,
+                    visible?: true, positioned?: true, style: {}}
   let(:event) {double 'paint event', gc: graphics_context}
   let(:graphics_context) { double 'graphics_context',
                                   dispose: nil,
+                                  get_clipping: nil, set_clipping: nil,
                                   set_antialias: nil, set_line_cap: nil,
                                   set_transform: nil, setTransform: nil }
   let(:transform) { double 'transform', disposed?: false }

--- a/shoes-swt/spec/shoes/swt/common/painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/common/painter_spec.rb
@@ -4,7 +4,7 @@ describe Shoes::Swt::Common::Painter do
   let(:object) {double 'object', dsl: dsl, transform: transform,
                                  apply_fill: nil, apply_stroke: nil}
   let(:parent) {double 'parent', absolute_left: 0, absolute_top: 0,
-                       height: 100, width: 200}
+                       width: 200, height: 100, fixed_height?: true}
   let(:dsl) {double 'dsl', parent: parent,
                     visible?: true, positioned?: true, style: {}}
   let(:event) {double 'paint event', gc: graphics_context}

--- a/shoes-swt/spec/shoes/swt/common/painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/common/painter_spec.rb
@@ -38,6 +38,12 @@ describe Shoes::Swt::Common::Painter do
       subject.paint_control event
     end
 
+    it 'clips to parent region' do
+      allow(dsl).to receive(:needs_rotate?) { false }
+      expect(graphics_context).to receive(:set_clipping).with(0, 0, 200, 100)
+      subject.paint_control event
+    end
+
     it 'rotates' do
       allow(dsl).to receive(:needs_rotate?) { true }
       allow(dsl).to receive(:rotate) { 10 }

--- a/shoes-swt/spec/shoes/swt/common/painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/common/painter_spec.rb
@@ -10,7 +10,7 @@ describe Shoes::Swt::Common::Painter do
   let(:event) {double 'paint event', gc: graphics_context}
   let(:graphics_context) { double 'graphics_context',
                                   dispose: nil,
-                                  get_clipping: nil, set_clipping: nil,
+                                  clipping: nil, set_clipping: nil,
                                   set_antialias: nil, set_line_cap: nil,
                                   set_transform: nil, setTransform: nil }
   let(:transform) { double 'transform', disposed?: false }

--- a/shoes-swt/spec/shoes/swt/shared_examples/swt_app_context.rb
+++ b/shoes-swt/spec/shoes/swt/shared_examples/swt_app_context.rb
@@ -23,7 +23,9 @@ shared_context "swt app" do
   end
 
   let(:shoes_app) { double('shoes app', gui: swt_app, rotate: 0, style: {}, element_styles: {}) }
-  let(:parent) { double('parent', app: swt_app, add_child: true, real: true) }
+  let(:parent) { double('parent', app: swt_app, add_child: true, real: true,
+                        absolute_left: 0, absolute_top: 0,
+                        height: 100, width: 200) }
   let(:parent_dsl) {double("parent dsl", add_child: true, contents: [],
                                          gui: parent, x_dimension: double.as_null_object,
                                          y_dimension: double.as_null_object)}

--- a/shoes-swt/spec/shoes/swt/shared_examples/swt_app_context.rb
+++ b/shoes-swt/spec/shoes/swt/shared_examples/swt_app_context.rb
@@ -25,7 +25,7 @@ shared_context "swt app" do
   let(:shoes_app) { double('shoes app', gui: swt_app, rotate: 0, style: {}, element_styles: {}) }
   let(:parent) { double('parent', app: swt_app, add_child: true, real: true,
                         absolute_left: 0, absolute_top: 0,
-                        height: 100, width: 200) }
+                        width: 200, height: 100, fixed_height?: true) }
   let(:parent_dsl) {double("parent dsl", add_child: true, contents: [],
                                          gui: parent, x_dimension: double.as_null_object,
                                          y_dimension: double.as_null_object)}

--- a/shoes-swt/spec/shoes/swt/text_block/painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block/painter_spec.rb
@@ -11,7 +11,7 @@ describe Shoes::Swt::TextBlock::Painter do
   let(:event)  { double("event", gc: graphics_context).as_null_object }
   let(:graphics_context) { double("graphics context", set_antialias: nil,
                                   set_line_cap: nil, set_transform: nil,
-                                  get_clipping: nil, set_clipping: nil) }
+                                  clipping: nil, set_clipping: nil) }
 
   subject { Shoes::Swt::TextBlock::Painter.new(dsl) }
 

--- a/shoes-swt/spec/shoes/swt/text_block/painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block/painter_spec.rb
@@ -3,9 +3,10 @@ require 'spec_helper'
 describe Shoes::Swt::TextBlock::Painter do
   include_context "swt app"
 
-  let(:dsl)   { double("dsl", app: shoes_app, gui: gui, hidden?: false) }
-  let(:gui)   { double("gui", dispose: nil, segments: segment_collection) }
-  let(:event) { double("event").as_null_object }
+  let(:dsl)    { double("dsl", app: shoes_app, gui: gui, parent: parent, hidden?: false) }
+  let(:gui)    { double("gui", dispose: nil, segments: segment_collection) }
+  let(:event)  { double("event").as_null_object }
+  let(:parent) { double("parent", absolute_left: 0, absolute_top: 0, height: 100, width: 200) }
   let(:segment_collection) { double("segment collection", empty?: false) }
 
   subject { Shoes::Swt::TextBlock::Painter.new(dsl) }

--- a/shoes-swt/spec/shoes/swt/text_block/painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block/painter_spec.rb
@@ -3,11 +3,15 @@ require 'spec_helper'
 describe Shoes::Swt::TextBlock::Painter do
   include_context "swt app"
 
+  let(:parent) { double("parent", absolute_left: 0, absolute_top: 0, height: 100, width: 200) }
   let(:dsl)    { double("dsl", app: shoes_app, gui: gui, parent: parent, hidden?: false) }
   let(:gui)    { double("gui", dispose: nil, segments: segment_collection) }
-  let(:event)  { double("event").as_null_object }
-  let(:parent) { double("parent", absolute_left: 0, absolute_top: 0, height: 100, width: 200) }
   let(:segment_collection) { double("segment collection", empty?: false) }
+
+  let(:event)  { double("event", gc: graphics_context).as_null_object }
+  let(:graphics_context) { double("graphics context", set_antialias: nil,
+                                  set_line_cap: nil, set_transform: nil,
+                                  get_clipping: nil, set_clipping: nil) }
 
   subject { Shoes::Swt::TextBlock::Painter.new(dsl) }
 
@@ -29,6 +33,12 @@ describe Shoes::Swt::TextBlock::Painter do
     allow(segment_collection).to receive(:empty?) { true }
     expect(segment_collection).to_not receive(:paint_control)
 
+    subject.paintControl(event)
+  end
+
+  it "clips to parent" do
+    expect(segment_collection).to receive(:paint_control)
+    expect(graphics_context).to receive(:set_clipping).with(0, 0, 200, 100)
     subject.paintControl(event)
   end
 


### PR DESCRIPTION
This PR will cover what we need on #1036 for non-control elements--all art and text elements in Shoes.

Basically all that's necessary is to set the "clipping" on any graphics context before we draw with it. We set the clipping back to it's original state afterward, using a helper method added on the (poorly named) `Shoes::Swt::Common::Resource`.

WIP because this deserves some actual specs, not just to pass the existing ones, and I might rename `Resource` while I'm at it.