### PR TITLE
Load system colors during backend initialization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ group :development do
   gem "kramdown"
   gem 'simplecov'
   gem "codeclimate-test-reporter"
-  gem 'jruby-lint'
   gem 'webmock'
   gem 'hometown'
   gem 'rubocop'

--- a/shoes-core/lib/shoes/internal_app.rb
+++ b/shoes-core/lib/shoes/internal_app.rb
@@ -16,8 +16,7 @@ class Shoes
     DEFAULT_OPTIONS = { width: 600,
                         height: 500,
                         title: "Shoes 4",
-                        resizable: true,
-                        background: Shoes::COLORS.fetch(:system_background) }.freeze
+                        resizable: true }.freeze
 
     def initialize(app, opts, &blk)
       @app = app
@@ -36,8 +35,6 @@ class Shoes
 
       setup_global_keypresses
       register_console_keypress
-
-      @gui.setup_system_colors
     end
 
     def ensure_backend_loaded

--- a/shoes-core/lib/shoes/mock/app.rb
+++ b/shoes-core/lib/shoes/mock/app.rb
@@ -44,9 +44,6 @@ class Shoes
 
       def wait_until_closed
       end
-
-      def setup_system_colors
-      end
     end
   end
 end

--- a/shoes-swt/lib/shoes/swt.rb
+++ b/shoes-swt/lib/shoes/swt.rb
@@ -121,6 +121,7 @@ class Shoes
       # redrawing aspect needs to know all the classes
       require 'shoes/swt/redrawing_aspect'
 
+      ::Shoes::Swt::App.setup_system_colors
       @initialized = true
     rescue Java::OrgEclipseSwt::SWTException => e
       if e.message == "Invalid thread access"

--- a/shoes-swt/lib/shoes/swt/app.rb
+++ b/shoes-swt/lib/shoes/swt/app.rb
@@ -24,7 +24,8 @@ class Shoes
       def initialize(dsl)
         @dsl = dsl
         ::Swt::Widgets::Display.app_name = @dsl.app_title
-        @background = Color.new(@dsl.opts[:background])
+        @background = Color.new(@dsl.opts[:background] ||
+                               ::Shoes::COLORS.fetch(:system_background))
         @started = false
         initialize_shell
         initialize_real
@@ -152,7 +153,7 @@ class Shoes
         end
       end
 
-      def setup_system_colors
+      def self.setup_system_colors
         # just one color for now
         background_color = Shoes.display.getSystemColor(::Swt::SWT::COLOR_WIDGET_BACKGROUND)
         ::Shoes::DSL.define_shoes_color(:system_background, background_color.red,

--- a/shoes-swt/spec/shoes/swt/app_spec.rb
+++ b/shoes-swt/spec/shoes/swt/app_spec.rb
@@ -137,12 +137,6 @@ describe Shoes::Swt::App do
       default_background = ::Swt.display.getSystemColor(::Swt::SWT::COLOR_WIDGET_BACKGROUND)
       app = Shoes::Swt::App.new(Shoes::InternalApp.new(Shoes::App.new, {}))
       background = app.shell.background
-      puts background.red
-      puts background.green
-      puts background.blue
-      puts default_background.red
-      puts default_background.green
-      puts default_background.blue
       expect(background).to eq default_background
     end
 
@@ -153,7 +147,7 @@ describe Shoes::Swt::App do
                                     default_background.red,
                                     default_background.green,
                                     default_background.blue)
-      subject.setup_system_colors
+      subject.class.setup_system_colors
     end
   end
 end


### PR DESCRIPTION
Proposed changes for #1166. **Note this merges onto `system_background`
NOT onto `master`!**

This fixes the defaulting problems we were having and prevents us from
having to do the color loading multiple times (which could happen in the
prior scheme if you had multiple windows.)

Downside, it does remove the defaulting in the DSL layer since there's
not an elegant way to get the value when we need it. Assigning it in the
backend just ends up cleaner.