### PR TITLE
Only touch contents visibility on actual state change

### DIFF
--- a/shoes-swt/lib/shoes/swt/slot.rb
+++ b/shoes-swt/lib/shoes/swt/slot.rb
@@ -25,7 +25,10 @@ class Shoes
       # responsibility, although this is more DSL code
       # #904 #905
       def update_visibility
-        if dsl.hidden?
+        # Only alter contents on a visibility change
+        return if @last_hidden_state == dsl.hidden?
+
+        if @last_hidden_state = dsl.hidden?
           dsl.contents.each(&:hide)
         else
           dsl.contents.each(&:show)

--- a/shoes-swt/spec/shoes/swt/slot_spec.rb
+++ b/shoes-swt/spec/shoes/swt/slot_spec.rb
@@ -14,11 +14,17 @@ describe Shoes::Swt::Slot do
       expect(swt_app.real).not_to have_received(:set_visible)
     end
 
-    # spec may be deleted if we can hide slots as a whole and not each element
-    # on its own
+    # spec may be deleted if we can hide entire rather than their contents
     it 'tries to hide the content' do
       subject.update_visibility
       expect(content).to have_received :hide
+    end
+
+    # spec may be deleted if we can hide entire rather than their contents
+    it 'only hides on visibility changes' do
+      subject.update_visibility
+      subject.update_visibility
+      expect(content).to have_received(:hide).once
     end
   end
 end


### PR DESCRIPTION
Fixes #1174

`update_visibility` gets called plenty of times when nothing has changed, so hiding/showing the children forcibly in those cases overrides their own defaults unnecessarily.

Additionally, this doesn't break the following sample from #904 which is why this whole mechanism was introduced in the first place:

```
Shoes.app do
  my_stack = stack do para 'hide me' end
  button 'hide stack' do my_stack.hide end
end
```