### PR TITLE
Always set up Bundler

### DIFF
--- a/shoes-swt/bin/shoes-swt
+++ b/shoes-swt/bin/shoes-swt
@@ -2,8 +2,8 @@
 lib_directory = File.expand_path('../../lib', __FILE__)
 $LOAD_PATH << lib_directory
 
+require "bundler/setup"
 if File.exist?("Gemfile")
-  require "bundler/setup"
   Bundler.require
 end
 


### PR DESCRIPTION
This deals with the first issue in #1148 where folks were getting
constant not found errors on `Bundler`.

We only `Bundler.require` if we find that we have a Gemfile, but parts of
packaging really, really want to have Bundler's code available, so
requiring `bundler/setup` keeps those bits happy.