### PR TITLE
Detect Mac properly on i386

### DIFF
--- a/shoes-core/bin/shoes-stub
+++ b/shoes-core/bin/shoes-stub
@@ -42,7 +42,7 @@ mac_readlink_f () {
   echo $RESULT
 }
 
-case "${MACHTYPE:-}" in
+case "${MACHTYPE:-}${OSTYPE:-}" in
   (*darwin*)
     SCRIPT=$(mac_readlink_f $0);;
   (*)


### PR DESCRIPTION
Fixes #1180

We've gotten reports that `$MACHTYPE` is occasionally `i386`
instead of the more full-formed `x86_64-apple-darwin14` we're counting on.
Include the `$OSTYPE` so we're sure to catch `'darwin'` somewhere in the
string.