### PR TITLE
Correctly using parents margin for background

### DIFF
--- a/shoes-core/lib/shoes/dimension.rb
+++ b/shoes-core/lib/shoes/dimension.rb
@@ -238,11 +238,7 @@ class Shoes
 
   class ParentDimension < Dimension
     def absolute_start
-      @absolute_start ? super : parent.absolute_start
-    end
-
-    def start
-      @start ? super : parent.start
+      parent.element_start
     end
 
     def extent
@@ -253,27 +249,18 @@ class Shoes
 
     # Represents the extent, bounded by the parent container's sizing
     def extent_in_parent
-      if parent.element_end
-        # Why subtracting an absolute from an element dimension value? A
-        # diagram helped me reason out what we wanted.
-        #
-        # parent.      parent.      self.       self.    parent.      parent.
-        # abs_start    elem_start   abs_start   abs_end  elem_end     abs_end
-        # |   margin   |            |           |        |   margin   |
-        #
-        # To get our extent respecting the parent's margins, it's our absolute
-        # start, minus parent's element end (so we don't blow past the margin)
-        parent.element_end - absolute_start - PIXEL_COUNTING_ADJUSTMENT
+      if parent.element_extent
+        parent.element_extent
       else
         # If we hit this, then the extent in parent isn't available and will be
-        # ignored by the min call below
+        # ignored by the min call in extent
         Float::INFINITY
       end
     end
 
     # Represents the raw value set for extent, either on element or on parent
-    def raw_extent(original_value)
-      original_value || parent.extent
+    def raw_extent(own_original_extent)
+      own_original_extent || parent.extent
     end
   end
 end

--- a/shoes-core/spec/shoes/dimensions_spec.rb
+++ b/shoes-core/spec/shoes/dimensions_spec.rb
@@ -718,10 +718,10 @@ describe Shoes::Dimensions do
                                           margin: 20}
       subject {Shoes::ParentDimensions.new parent}
 
-      its(:left)   {should eq parent.left}
-      its(:top)    {should eq parent.top}
-      its(:width)  {should eq parent.width}
-      its(:height) {should eq parent.height}
+      its(:left)   {should eq nil}
+      its(:top)    {should eq nil}
+      its(:width)  {should eq parent.element_width}
+      its(:height) {should eq parent.element_height}
 
       its(:margin_left)   {should eq 0}
       its(:margin_top)    {should eq 0}
@@ -734,10 +734,10 @@ describe Shoes::Dimensions do
           parent.absolute_top  = top
         end
 
-        its(:absolute_left) {should eq parent.absolute_left}
-        its(:absolute_top)  {should eq parent.absolute_top}
-        its(:element_left)  {should eq parent.absolute_left}
-        its(:element_top)   {should eq parent.absolute_top}
+        its(:absolute_left) {should eq parent.element_left}
+        its(:absolute_top)  {should eq parent.element_top}
+        its(:element_left)  {should eq parent.element_left}
+        its(:element_top)   {should eq parent.element_top}
       end
     end
 


### PR DESCRIPTION
This rethinks ParentDimension a bunch, from 3 main observations:

* we should not position backgrounds, it works when they are
  the first element in a slot but not after that
* backgrounds need to respect the margins of parents, which means
  their absolute_starts should be the parents element_starts
* beyond that, there doesn't seem to be much need to get
  parent position values, as they all somehow end up
  influencing absolute_top/left (I hope, this might come back
  later)

That also removes a lot of ambiguity and difficult code.
Better code through increased domain understanding :+1:

* fixes #1193 

succeeds #1203 


A look at a couple of examples between shoes 4 and shoes 3.2:

```ruby
Shoes.app do
  stack margin: 20, height: 100 do
    background green
  end

  stack margin: 40, height: 100 do
    background blue
  end
end
```

![selection_031](https://cloud.githubusercontent.com/assets/606517/11767355/26f7f59e-a1ab-11e5-806b-1c41dac76cc6.png)


```ruby
Shoes.app do
  banner 'What up'
  background red
end
```

(see #599)

![selection_032](https://cloud.githubusercontent.com/assets/606517/11767359/527eb19e-a1ab-11e5-8688-332f7feb0100.png)


```ruby
Shoes.app do
  stack height: 150, bottom: 50 do
    background red
  end
end
```

(some more advanced positioning)

![selection_033](https://cloud.githubusercontent.com/assets/606517/11767368/b1d24f7a-a1ab-11e5-82ed-5ab30cab0cef.png)


```ruby
Shoes.app do
  stack margin: 20, height: 200 do
    background blue
    background green, margin: 20
  end
end
```

(double margin)

![selection_034](https://cloud.githubusercontent.com/assets/606517/11767383/1fe1aca4-a1ac-11e5-89af-4680498e475c.png)

last but not least `good-vjot.rb` which still has some issues but those are of another nature (or at least I believe so ;))


![good-vjot](https://dl.dropboxusercontent.com/u/16854702/Selection_035.png)



