### PR TITLE
Correct slot height when margins are in play

### DIFF
--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -279,7 +279,7 @@ class Shoes
 
     def determine_slot_height
       content_height = compute_content_height
-      self.height = content_height if variable_height?
+      self.element_height = content_height if variable_height?
       content_height
     end
 
@@ -291,7 +291,7 @@ class Shoes
                     max
 
       if max_bottom
-        max_bottom - self.absolute_top + NEXT_ELEMENT_OFFSET
+        max_bottom - self.element_top + NEXT_ELEMENT_OFFSET
       else
         0
       end

--- a/shoes-core/spec/shoes/shared_examples/slot.rb
+++ b/shoes-core/spec/shoes/shared_examples/slot.rb
@@ -406,6 +406,14 @@ shared_examples_for 'margin and positioning' do
     it 'leaves the left value as zero' do
       expect(element.absolute_left).to eq 0
     end
+
+    it 'sets the slot element_height to the height of the child + adjustment' do
+      expect(subject.element_height).to eq element.height
+    end
+
+    it 'sets the slot total height to element height + margin' do
+      expect(subject.height).to eq element.height + margin_top
+    end
   end
 
   describe 'margin left' do


### PR DESCRIPTION
* elements are positioned inside the parent only, so set
  element_height, not height
* Same thing goes for calculating our height, it's the max
  absolute_bottom minus our element_top :)
* fixes #1205 

Sample from #1205 (ignore the over extending background, that is fixed in #1204 the important thing is the space underneath the edit_box)

![selection_039](https://cloud.githubusercontent.com/assets/606517/11767793/e019fcd0-a1b9-11e5-9600-1a5becb03379.png)

And finally good-vjot.rb (again the background over extending is fixed in #1204):

![good vjot](https://dl.dropboxusercontent.com/u/16854702/Selection_038.png)

It is curios/fun for me to see how both these issues in good-vjot.rb came from not fully embracing/adjusting calls to our `element_* dimensions from the legacy back when we made that change, which is sort of a recurring theme :)