### PR TITLE
Fix for JRuby 9.0.5.0 and later

### DIFF
--- a/shoes-swt/lib/shoes/swt/text_block/text_segment.rb
+++ b/shoes-swt/lib/shoes/swt/text_block/text_segment.rb
@@ -88,11 +88,11 @@ class Shoes
         end
 
         def last_line_height
-          layout.line_bounds(layout.line_count - 1).height
+          layout.get_line_bounds(layout.line_count - 1).height
         end
 
         def last_line_width
-          layout.line_bounds(layout.line_count - 1).width
+          layout.get_line_bounds(layout.line_count - 1).width
         end
 
         def draw(graphics_context)


### PR DESCRIPTION
A change in JRuby means that the Java method `getLineBounds` can no
longer be called as simply `line_bounds`, it has to be called as
`get_line_bounds`.

Closes #1217