### PR TITLE
Don't advance position for right aligned text

### DIFF
--- a/shoes-core/lib/shoes/text_block.rb
+++ b/shoes-core/lib/shoes/text_block.rb
@@ -33,6 +33,10 @@ class Shoes
       @gui.in_bounds?(*args)
     end
 
+    def takes_up_space?
+      @style[:align] != "right"
+    end
+
     def remove
       super
       links.each do |link|

--- a/shoes-core/spec/shoes/text_block_spec.rb
+++ b/shoes-core/spec/shoes/text_block_spec.rb
@@ -47,6 +47,22 @@ describe Shoes::TextBlock do
     end
   end
 
+  describe "#takes_up_space?" do
+    it "does with default alignment" do
+      expect(text_block.takes_up_space?).to eq(true)
+    end
+
+    it "does when left aligned" do
+      text_block.align = "left"
+      expect(text_block.takes_up_space?).to eq(true)
+    end
+
+    it "doesn't when right aligned" do
+      text_block.align = "right"
+      expect(text_block.takes_up_space?).to eq(false)
+    end
+  end
+
   describe "#to_s" do
     it "is the same as #text" do
       text = text_block.text

--- a/tasks/yard.rb
+++ b/tasks/yard.rb
@@ -9,4 +9,9 @@ rescue LoadError
   task :yard do
     abort 'YARD is not available. Try: gem install yard'
   end
+rescue StandardError => ex
+  desc "Generate YARD Documentation"
+  task :yard do
+    abort "YARD is not available. Error was '#{ex.message}'"
+  end
 end


### PR DESCRIPTION
As noted in https://github.com/shoes/shoes4/issues/1194 we get odd effects in flowing if we allow right-aligned elements bump the current position when doing slot alignment.

While this is a breaking change with Shoes 3, it behaves more consistently, and we'll be happier with it in the long haul this way.

![image](https://cloud.githubusercontent.com/assets/130504/13660849/8d20188e-e642-11e5-8f69-148a24c4676b.png)
