### PR TITLE
Be able to create a borderless window (by popular demand)

### DIFF
--- a/samples/README
+++ b/samples/README
@@ -12,6 +12,7 @@ simple-anim-shapes.rb
 simple-animate.rb
 simple-anim-text.rb
 # simple-arc.rb  Pending on #423
+simple-borderless.rb
 simple-bounce.rb
 simple-brightness-transitions.rb
 simple-button-animate.rb

--- a/samples/simple-borderless.rb
+++ b/samples/simple-borderless.rb
@@ -1,3 +1,3 @@
-Shoes.app borderless: true do
+Shoes.app border: false do
   title "Look, no borders!"
 end

--- a/samples/simple-borderless.rb
+++ b/samples/simple-borderless.rb
@@ -1,0 +1,3 @@
+Shoes.app borderless: true do
+  title "Look, no borders!"
+end

--- a/shoes-core/lib/shoes/internal_app.rb
+++ b/shoes-core/lib/shoes/internal_app.rb
@@ -13,10 +13,13 @@ class Shoes
 
     extend Forwardable
 
-    DEFAULT_OPTIONS = { width: 600,
-                        height: 500,
-                        title: "Shoes 4",
-                        resizable: true }.freeze
+    DEFAULT_OPTIONS = {
+                        width:     600,
+                        height:    500,
+                        title:     "Shoes 4",
+                        resizable: true,
+                        border:    true
+                      }.freeze
 
     def initialize(app, opts, &blk)
       @app = app

--- a/shoes-swt/lib/shoes/swt/app.rb
+++ b/shoes-swt/lib/shoes/swt/app.rb
@@ -200,7 +200,7 @@ class Shoes
         style |= ::Swt::SWT::RESIZE | ::Swt::SWT::MAX if @dsl.opts[:resizable]
         style |= ::Swt::SWT::APPLICATION_MODAL        if @dsl.opts[:modal]
         style |= ::Swt::SWT::ON_TOP                   if @dsl.opts[:always_on_top]
-        style |= ::Swt::SWT::NO_TRIM                  if @dsl.opts[:borderless]
+        style |= ::Swt::SWT::NO_TRIM                  unless @dsl.opts.fetch(:border, true)
         style
       end
 

--- a/shoes-swt/lib/shoes/swt/app.rb
+++ b/shoes-swt/lib/shoes/swt/app.rb
@@ -199,7 +199,8 @@ class Shoes
         style  = ::Swt::SWT::CLOSE | ::Swt::SWT::MIN | ::Swt::SWT::V_SCROLL
         style |= ::Swt::SWT::RESIZE | ::Swt::SWT::MAX if @dsl.opts[:resizable]
         style |= ::Swt::SWT::APPLICATION_MODAL        if @dsl.opts[:modal]
-        style |= ::Swt::SWT::ON_TOP if @dsl.opts[:always_on_top]
+        style |= ::Swt::SWT::ON_TOP                   if @dsl.opts[:always_on_top]
+        style |= ::Swt::SWT::NO_TRIM                  if @dsl.opts[:borderless]
         style
       end
 

--- a/shoes-swt/spec/shoes/swt/app_spec.rb
+++ b/shoes-swt/spec/shoes/swt/app_spec.rb
@@ -2,17 +2,11 @@ require 'spec_helper'
 
 describe Shoes::Swt::App do
   let(:opts) { {background: Shoes::COLORS[:salmon], resizable: true} }
-  let(:app)  { double('app') }
-  let(:dsl)  { double('dsl', app: app,
-                             opts: opts,
-                             width: width,
-                             height: 0,
-                             app_title: 'double') }
   let(:width) {0}
+  let(:dsl) { dsl_app_with_opts(opts) }
+  let(:app) {double 'app' }
 
-  let(:swt_salmon) {  }
-
-  subject { Shoes::Swt::App.new(dsl) }
+  subject { described_class.new dsl }
 
   it { is_expected.to respond_to :clipboard }
   it { is_expected.to respond_to :clipboard= }
@@ -73,12 +67,12 @@ describe Shoes::Swt::App do
     end
 
     it "should return a bitmask that represents always being on top" do
-      always_on_top = app_with_opts always_on_top: true
+      always_on_top = app_with_opts always_on_top: true, resizable: false
       expect(always_on_top.send(:main_window_style)).to eq(BASE_BITMASK | Swt::SWT::ON_TOP)
     end
 
     it "should return an bitmask that indicates no trim" do
-      no_border = app_with_opts(borderless: true)
+      no_border = app_with_opts(border: false, resizable: false)
       expect(no_border.send(:main_window_style)).to eq(BASE_BITMASK | Swt::SWT::NO_TRIM)
     end
   end
@@ -155,12 +149,18 @@ describe Shoes::Swt::App do
   end
 
   def app_with_opts(opts)
-    dsl_app_double = double('app',
-                            opts: opts,
-                            width: 0,
-                            height: 0,
-                            app_title: 'double')
+    dsl_app_double = dsl_app_with_opts(opts)
 
     Shoes::Swt::App.new dsl_app_double
   end
+
+  def dsl_app_with_opts(opts)
+    double('app',
+           app:       app,
+           opts:      Shoes::InternalApp::DEFAULT_OPTIONS.merge(opts),
+           width:     0,
+           height:    0,
+           app_title: 'double')
+  end
+
 end

--- a/shoes-swt/spec/shoes/swt/app_spec.rb
+++ b/shoes-swt/spec/shoes/swt/app_spec.rb
@@ -8,26 +8,9 @@ describe Shoes::Swt::App do
                              width: width,
                              height: 0,
                              app_title: 'double') }
-
-  let(:opts_unresizable) { { background: Shoes::COLORS[:salmon],
-                            resizable: false } }
-  let(:app_unresizable) { double('app', opts: opts_unresizable,
-                                        width: 0,
-                                        height: 0,
-                                        app_title: 'double') }
-  let(:opts_always_on_top) { {background: Shoes::COLORS[:salmon],
-                              always_on_top: true} }
-  let(:app_always_on_top) { double('app', opts: opts_always_on_top,
-                                          width: 0,
-                                          height: 0,
-                                          app_title: 'double') }
-  let(:plain_app) { double('app', opts: {},
-                                  width: 2,
-                                  height: 2,
-                                  app_title: 'double') }
   let(:width) {0}
 
-  let(:swt_salmon) { Shoes::Swt::Color.new(Shoes::COLORS[:salmon]).real }
+  let(:swt_salmon) {  }
 
   subject { Shoes::Swt::App.new(dsl) }
 
@@ -85,13 +68,18 @@ describe Shoes::Swt::App do
     end
 
     it "should return a bitmask that represents not being resizable" do
-      not_resizable = Shoes::Swt::App.new app_unresizable
+      not_resizable = app_with_opts resizable: false
       expect(not_resizable.send(:main_window_style)).to eq(BASE_BITMASK)
     end
 
     it "should return a bitmask that represents always being on top" do
-      always_on_top = Shoes::Swt::App.new app_always_on_top
+      always_on_top = app_with_opts always_on_top: true
       expect(always_on_top.send(:main_window_style)).to eq(BASE_BITMASK | Swt::SWT::ON_TOP)
+    end
+
+    it "should return an bitmask that indicates no trim" do
+      no_border = app_with_opts(borderless: true)
+      expect(no_border.send(:main_window_style)).to eq(BASE_BITMASK | Swt::SWT::NO_TRIM)
     end
   end
 
@@ -142,11 +130,11 @@ describe Shoes::Swt::App do
 
   describe 'App Background color' do
     it 'has the given background when specified' do
-      not_resizable = Shoes::Swt::App.new app_unresizable
-      background = not_resizable.shell.background
-      expect(background).to eq swt_salmon
+      color = Shoes::COLORS[:salmon]
+      colored = app_with_opts background: color
+      background = colored.shell.background
+      expect(background).to eq Shoes::Swt::Color.new(color).real
     end
-
 
     it 'has the default system background when unspecified' do
       default_background = ::Swt.display.getSystemColor(::Swt::SWT::COLOR_WIDGET_BACKGROUND)
@@ -164,5 +152,15 @@ describe Shoes::Swt::App do
                                     default_background.blue)
       subject.class.setup_system_colors
     end
+  end
+
+  def app_with_opts(opts)
+    dsl_app_double = double('app',
+                            opts: opts,
+                            width: 0,
+                            height: 0,
+                            app_title: 'double')
+
+    Shoes::Swt::App.new dsl_app_double
   end
 end


### PR DESCRIPTION
* fixes #1052

Not too sure about calling the option `borderless` - thoughts @jasonrclark ?

```ruby
Shoes.app borderless: true, width: 400, height: 287 do
  image 'http://moonmoonwolf.weebly.com/uploads/2/5/5/8/25581328/2095238.jpg', width: 400, height: 287
end
```

![selection_004](https://cloud.githubusercontent.com/assets/606517/13795741/de16c5f2-eb02-11e5-8418-c2222e545c1f.png)
