### PR TITLE
Lighten the load on Travis a bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: ruby
 script: "bundle exec rake spec:all"
 rvm:
-  - jruby-9.0.4.0
   - jruby-head
   - jruby-9.0.5.0
   - jruby-1.7.24
 jdk:
   - openjdk7
-  - oraclejdk7
   - oraclejdk8
 matrix:
   allow_failures:


### PR DESCRIPTION
* one JDK7 test should be enough (given that JRuby and SWT
  do their testing their already)
* for a pre release project worrying about that bit of backwards
  incompatibility from 9.0.5.0 to 9.0.4.0 that JRuby might
  introduce seems like a bit overkill in hindsight