### PR TITLE
Tighten versioning requirements to avoid breakages

### DIFF
--- a/shoes-swt/shoes-swt.gemspec
+++ b/shoes-swt/shoes-swt.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.add_dependency "swt", "~>4.4"
-  s.add_dependency "after_do", "~>0.3"
+  s.add_dependency "swt", "~>4.4.0"
+  s.add_dependency "after_do", "~>0.4.0"
   s.add_dependency "shoes-core", Shoes::Swt::VERSION
   s.add_dependency "shoes-package", Shoes::Swt::VERSION
 


### PR DESCRIPTION
* Noticed that if I were to release an after_do version
  0.x.y that breaks compatibility people would install
  it when gem installing shoes. That might happen so
  I rather tightened the dependency (along with the
  one of the swt gem)
* Also updated after_do to newest version