### PR TITLE
Add require 'shoes' to the welcome script in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Shoes is a little DSL for cross-platform (Mac, Windows, and Linux) GUI programmi
 Want to see what Shoes looks like? Well, here you go! Given the script:
 
 ```ruby
+require 'shoes'
+
 Shoes.app width: 300, height: 200 do
   background lime..blue
 


### PR DESCRIPTION
Trivial change, but without the require 'shoes', JRuby gives the error:
NameError: uninitialized constant Shoes
which could be confusing to someone new to Ruby.