### PR TITLE
"Run" button in expert-game-of-life sample now correctly toggles between "Run" and "Stop"

### DIFF
--- a/samples/expert-game-of-life.rb
+++ b/samples/expert-game-of-life.rb
@@ -165,47 +165,53 @@ class World
     result.compact
   end
 
-  def add_specie(*cells)
+  def add_species(*cells)
     cells.each do |y,x|
       @board[y][x].toggle_state
     end
   end
 
-  def add_glinder
-    add_specie [4,2], [4,3], [4,4], [3,4], [2,3]
+  def add_glider
+    add_species [4,2], [4,3], [4,4], [3,4], [2,3]
   end
 
   def add_spaceship
-    add_specie [12,3], [12,6], [13,7], [14,3], [14,7], [15,4], [15,5], [15,6], [15,7]
+    add_species [12,3], [12,6], [13,7], [14,3], [14,7], [15,4], [15,5], [15,6], [15,7]
   end
 
   def add_diehard
-    add_specie [18,12], [12,13], [13,13], [13,14], [17,14], [18,14], [19,14]
+    add_species [18,12], [12,13], [13,13], [13,14], [17,14], [18,14], [19,14]
   end
 end
 
 Shoes.app(title: "The Game of Life", width: 800, height: 620, resizable: false) do
   background white
-  @animate = false
+  @running = false
   stack(margin: 10) do
     @new_world = World.new(40, 40, self)
     animate(10) do
-      if @animate
+      if @running
         @new_world.tick
       end
     end
   end
 
-  def play
-    @animate = true
-    @run_button.style(displace_top: -100)
-    @stop_button.style(displace_top: 0)
+  def run
+    @running = true
+    @run_stop_button.text = 'Stop'
   end
 
   def stop
-    @animate = false
-    @stop_button.style(displace_top: -100)
-    @run_button.style(displace_top: 0)
+    @running = false
+    @run_stop_button.text = 'Run'
+  end
+
+  def toggle_run_stop
+    if @running
+      stop
+    else
+      run
+    end
   end
 
   def clear
@@ -214,8 +220,7 @@ Shoes.app(title: "The Game of Life", width: 800, height: 620, resizable: false) 
   end
 
   flow(displace_left: 650) do
-    @run_button  = button('Run',  displace_top: 0,                         width: 100) { play }
-    @stop_button = button('Stop', displace_top: -100, displace_left: -100, width: 100) { stop }
+    @run_stop_button = button('Run',  displace_top: 0, width: 100) { toggle_run_stop }
   end
 
   stack(displace_left: 650) do
@@ -224,9 +229,9 @@ Shoes.app(title: "The Game of Life", width: 800, height: 620, resizable: false) 
     end
 
     para "Species"
-    button('Glinder', width: 100) do
+    button('Glider', width: 100) do
       clear
-      @new_world.add_glinder
+      @new_world.add_glider
     end
 
     button('Spaceship', width: 100) do


### PR DESCRIPTION
Looking at the source for expert-game-of-life.rb, the intent was that when the "Run" button was clicked, its title would change to "Stop", and when "Stop" was clicked, its title would change back to "Run".  However, this didn't work, and the "Run" button always had the title "Run".  This changes and simplifies the implementation so that it now correctly toggles between "Run" and "Stop".

Corrected a typo, "Glinder" -> "Glider".

Minor code cleanups.

Tested on Windows 7 Professional SP 1 and Ubuntu 15.10.

Full Disclosure: The para "Species" usually appears above the "Glider" button.  But occasionally "Species" does not appear.  This happens sporadically, and I can't recreate the problem except by trial and error.  I'm reasonably certain this problem occurred before I made any changes to the code, and I don't see how my changes could have caused this, so I don't think I introduced this problem.

If these changes look OK, I'll make the corresponding changes to expert-game-of-life-adjusted.rb.