### PR TITLE
Fix 3 errors when running current rubocop (0.40.0)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,7 +29,7 @@ Style/StringLiterals:
 
 # We like the flexibility of adding additional items to the hash
 # see discussion in #859
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
   Enabled: false
 
 # We have several places where, because of instance scoping in apps,

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -354,7 +354,7 @@ Style/SingleLineMethods:
 
 # Offense count: 10
 # Cop supports --auto-correct.
-Style/SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false
 
 # Offense count: 13
@@ -369,7 +369,7 @@ Style/SpaceAfterComma:
 
 # Offense count: 6
 # Cop supports --auto-correct.
-Style/SpaceAfterControlKeyword:
+Style/SpaceAroundKeyword:
   Enabled: false
 
 # Offense count: 385


### PR DESCRIPTION
Fix the following 3 errors from rubocop 0.40.0:

Error: The `Style/SingleSpaceBeforeFirstArg` cop has been renamed to `Style/SpaceBeforeFirstArg.
(obsolete configuration found in .rubocop_todo.yml, please update it)

Error: The `Style/SpaceAfterControlKeyword` cop has been removed. Please use `Style/SpaceAroundKeyword` instead.
(obsolete configuration found in .rubocop_todo.yml, please update it)

Error: The `Style/TrailingComma` cop no longer exists. Please use `Style/TrailingCommaInLiteral` and/or `Style/TrailingCommaInArguments` instead.
(obsolete configuration found in .rubocop.yml, please update it)