### PR TITLE
Resolved 9 RuboCop issues

### DIFF
--- a/shoes-core/lib/shoes/color/hex_converter.rb
+++ b/shoes-core/lib/shoes/color/hex_converter.rb
@@ -3,13 +3,13 @@ class Shoes
     class HexConverter
       def initialize(hex)
         @hex = validate(hex) || fail(ArgumentError, "Bad hex color: #{hex}")
-        @red, @green, @blue = hex_to_rgb(pad_if_necessary @hex)
+        @red, @green, @blue = hex_to_rgb(pad_if_necessary(@hex))
       end
 
       def to_rgb
         [@red, @green, @blue]
       end
-      
+
       private
 
       def hex_to_rgb(hex)

--- a/shoes-core/lib/shoes/common/initialization.rb
+++ b/shoes-core/lib/shoes/common/initialization.rb
@@ -25,7 +25,6 @@ class Shoes
         after_initialize(*args)
       end
 
-
       # This method will get called with the incoming styles hash and the
       # other arguments passed to initialize.
       #

--- a/shoes-core/lib/shoes/common/state.rb
+++ b/shoes-core/lib/shoes/common/state.rb
@@ -18,6 +18,7 @@ class Shoes
       end
 
       private
+
       def enabled?
         !(state.to_s == DISABLED_STATE)
       end

--- a/shoes-core/lib/shoes/dimension.rb
+++ b/shoes-core/lib/shoes/dimension.rb
@@ -202,7 +202,7 @@ class Shoes
     end
 
     def int_from_string(result)
-      (result.gsub(' ', '')).to_i
+      result.gsub(' ', '').to_i
     end
 
     NUMBER_REGEX = /^-?\s*\d+/

--- a/shoes-core/lib/shoes/dimensions.rb
+++ b/shoes-core/lib/shoes/dimensions.rb
@@ -88,7 +88,7 @@ class Shoes
     def margin=(margin)
       margin = [margin, margin, margin, margin] unless margin.is_a? Array
       self.margin_left, self.margin_top,
-      self.margin_right, self.margin_bottom =  margin
+      self.margin_right, self.margin_bottom = margin
     end
 
     def needs_positioning?

--- a/shoes-core/lib/shoes/input_box.rb
+++ b/shoes-core/lib/shoes/input_box.rb
@@ -5,7 +5,6 @@ class Shoes
     include Common::Changeable
     include Common::State
 
-
     def before_initialize(styles, text)
       styles[:text] = text.to_s
     end

--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -166,8 +166,8 @@ class Shoes
 
     def position_contents
       @current_position = CurrentPosition.new element_left,
-                                             element_top,
-                                             element_top
+                                              element_top,
+                                              element_top
 
       contents.each do |element|
         next if element.hidden?


### PR DESCRIPTION
```
shoes-core\lib\shoes\color\hex_converter.rb:6:42: C: Style/NestedParenthesizedCalls: Add parentheses to nested method call pad_if_necessary @hex.
       @red, @green, @blue = hex_to_rgb(pad_if_necessary @hex)
                                        ^^^^^^^^^^^^^^^^^^^^^

shoes-core\lib\shoes\color\hex_converter.rb:12:1: C: Style/TrailingWhitespace: Trailing whitespace detected.

shoes-core\lib\shoes\dimension.rb:205:7: C: Style/RedundantParentheses: Don't use parentheses around a method call.
     (result.gsub(' ', '')).to_i
     ^^^^^^^^^^^^^^^^^^^^^^

shoes-core\lib\shoes\dimensions.rb:91:46: C: Style/ExtraSpacing: Unnecessary spacing detected.
     self.margin_right, self.margin_bottom =  margin
                                            ^

shoes-core\lib\shoes\input_box.rb:8:1: C: Style/EmptyLines: Extra blank line detected.

shoes-core\lib\shoes\common\initialization.rb:28:1: C: Style/EmptyLines: Extra blank line detected.

shoes-core\lib\shoes\common\state.rb:20:7: C: Style/EmptyLinesAroundAccessModifier: Keep a blank line before and after private.
     private
     ^^^^^^^

shoes-core\lib\shoes\slot.rb:169:46: C: Style/AlignParameters: Align the parameters of a method call if they span more than one line.
                                            element_top,
                                            ^^^^^^^^^^^
shoes-core\lib\shoes\slot.rb:170:46: C: Style/AlignParameters: Align the parameters of a method call if they span more than one line.
                                            element_top
                                            ^^^^^^^^^^^
```