### PR TITLE
Resolve 3 RuboCop issues

### DIFF
--- a/shoes-core/lib/shoes/dimension.rb
+++ b/shoes-core/lib/shoes/dimension.rb
@@ -202,7 +202,7 @@ class Shoes
     end
 
     def int_from_string(result)
-      result.gsub(' ', '').to_i
+      result.delete(' ').to_i
     end
 
     NUMBER_REGEX = /^-?\s*\d+/

--- a/shoes-core/lib/shoes/ui/picker.rb
+++ b/shoes-core/lib/shoes/ui/picker.rb
@@ -74,8 +74,8 @@ class Shoes
       end
 
       def name_for_candidate(candidate)
-        /.*lib\/shoes\/(.*)\/generate-backend.rb/.match(candidate)
-        return "shoes-#{$1.gsub('/', '-')}"
+        /.*lib\/shoes\/(.*)\/generate-backend.rb/ =~ candidate
+        return "shoes-#{$1.tr('/', '-')}"
       end
 
       def write_backend(generator_file, bin_dir)


### PR DESCRIPTION
```
shoes/dimension.rb:205:14: C: Performance/StringReplacement: Use delete instead of gsub.
      result.gsub(' ', '').to_i
             ^^^^^^^^^^^^^

shoes/ui/picker.rb:77:9: C: Performance/RedundantMatch: Use =~ in places where the MatchData returned by #match will not be used.
        /.*lib\/shoes\/(.*)\/generate-backend.rb/.match(candidate)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

shoes/ui/picker.rb:78:28: C: Performance/StringReplacement: Use tr instead of gsub.
        return "shoes-#{$1.gsub('/', '-')}"
                           ^^^^^^^^^^^^^^
```