### PR TITLE
Fix several issues in simple-calc-2 sample

### DIFF
--- a/samples/simple-calc-2.rb
+++ b/samples/simple-calc-2.rb
@@ -1,31 +1,45 @@
 Shoes.app height: 250, width: 198 do
-  def do_calc
-    @number = @previous.send(@op, @number)  if @op
+  def clear
+    @accumulator = 0
+    @display = 0
     @op = nil
   end
 
-  @previous, @number, @op = 0, 0, nil
+  def do_calc
+    @display = @accumulator.send(@op, @display) if @op
+
+    @op = nil
+  end
+
+  clear
+  @clear_display = false
   background rgb(235, 235, 210)
   flow margin: 5 do
     flow height: 240, width: 190, margin: [2, 5, 0, 0] do
-      background "#996".."#333", curve: 5
-      number_field = para strong(@number, ' '*20), stroke: white, margin: 8
+      background '#996'..'#333', curve: 5
+      number_field = para strong(@display, ' '*20), stroke: white, margin: 8
       flow width: 218 do
         %w(7 8 9 / 4 5 6 * 1 2 3 - 0 Clr = +).each do |btn|
           button btn, width: 46, height: 46 do
             case btn
             when /[0-9]/
-              @number = @number.to_i * 10 + btn.to_i
+              if @clear_display
+                @display = 0
+                @clear_display = false
+              end
+              @display = @display.to_i * 10 + btn.to_i
             when 'Clr'
-              @previous, @number, @op = 0, 0, nil
+              clear
             when '='
               do_calc
-            else
+              @clear_display = true
+            when '/','*','-','+'
               do_calc
-              @previous, @number = @number, nil
+              @accumulator = @display
               @op = btn
+              @clear_display = true
             end
-            number_field.text = @number.to_s
+            number_field.text = @display.to_s
           end
         end
       end


### PR DESCRIPTION
In any physical, real-world calculator I can recall using, if I wanted to compute 2+2 and 3+3 I would click the following buttons:

2 + 2 = 3 + 3 =

But if I do that in this program,

2 + 2 =

shows "4", as expected, but then clicking 3 changes the display to "43".

I appreciate that the sample is intended as an example of using Shoes, not an example of how to write calculator logic.  But this problem makes it hard to actually use the calculator.

Another fix is that on most calculators, doing:

1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 =

shows the running total every time + is clicked.  This program did not display any result until = was clicked.

Renamed several instance variables to be more precise.

Corrected 4 RuboCop issues.

If we'd like, I can make the corresponding changes to simple-calc.rb, also.