### PR TITLE
Restore spec in Core suite, fix type failure

### DIFF
--- a/shoes-core/spec/shoes_spec.rb
+++ b/shoes-core/spec/shoes_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe Shoes, 'load_backend' do
-  it "raises ArgumentError on bad input" do
-    expect { Shoes.load_backend :bogus }.to raise_error(ArgumentError)
+  it "raises on bad input" do
+    expect { Shoes.load_backend :bogus }.to raise_error(LoadError)
   end
 end
 

--- a/tasks/rspec.rb
+++ b/tasks/rspec.rb
@@ -97,7 +97,8 @@ namespace :spec do
   Limit the examples to specific :modules : "
   task :core, [:module] do |_t, args|
     argh = args.to_hash
-    files = Dir['shoes-core/spec/shoes/**/*_spec.rb'].join ' '
+    files = (Dir['shoes-core/spec/shoes/**/*_spec.rb'] +
+             Dir['shoes-core/spec/*_spec.rb']).join ' '
     jruby_rspec(files, argh)
   end
 


### PR DESCRIPTION
Fixes #1206

It was noted that the spec failed but our suite didn't. That was because
our `Dir` for files to run was overly constrainted and missed it in the
'shoes-core/spec' directory.

After restoring that to run, we still have the exception. This was just
a change at some point in behavior from `ArgumentError` to `LoadError`. I
think `LoadError` is actually more representative given what's happening
there, so I modified the test to match.