### PR TITLE
Clean up slot click listeners

### DIFF
--- a/shoes-core/lib/shoes/mock/slot.rb
+++ b/shoes-core/lib/shoes/mock/slot.rb
@@ -8,6 +8,9 @@ class Shoes
         @dsl, @parent = dsl, parent
       end
 
+      def remove
+      end
+
       attr_reader :dsl
     end
 

--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -48,6 +48,11 @@ class Shoes
       eval_block blk
     end
 
+    def remove
+      clear
+      super
+    end
+
     def eval_block(blk, *args)
       old_current_slot = @app.current_slot
       @app.current_slot = self

--- a/shoes-core/lib/shoes/slot_contents.rb
+++ b/shoes-core/lib/shoes/slot_contents.rb
@@ -32,7 +32,7 @@ class Shoes
       # reverse_each is important as otherwise we always miss to delete one
       # element
       @contents.reverse_each do |element|
-        element.is_a?(Shoes::Slot) ? element.clear : element.remove
+        element.remove
       end
       @contents.clear
     end

--- a/shoes-core/spec/shoes/slot_spec.rb
+++ b/shoes-core/spec/shoes/slot_spec.rb
@@ -2,13 +2,14 @@ require 'spec_helper'
 
 describe Shoes::Slot do
   include_context "dsl app"
-  let(:parent) { app }
+  let(:parent) { Shoes::Stack.new(app, app, {}) }
 
   let(:left) { 44 }
   let(:top) { 66 }
   let(:width) { 111 }
   let(:height) { 333 }
   let(:input_opts) { {left: left, top: top, width: width, height: height} }
+
   subject(:slot) { Shoes::Slot.new(app, parent, input_opts) }
 
   before do
@@ -68,6 +69,22 @@ describe Shoes::Slot do
       it 'has one element afterwards' do
         expect(subject.contents.size).to eq 1
       end
+    end
+  end
+
+  describe '#remove' do
+    before :each do
+      Shoes::Para.new app, slot, ['text']
+    end
+
+    it 'removes the child element' do
+      subject.remove
+      expect(subject.contents).to be_empty
+    end
+
+    it 'notifies the gui' do
+      expect(subject.gui).to receive(:remove)
+      subject.remove
     end
   end
 

--- a/shoes-swt/lib/shoes/swt/slot.rb
+++ b/shoes-swt/lib/shoes/swt/slot.rb
@@ -34,7 +34,12 @@ class Shoes
           dsl.contents.each(&:show)
         end
       end
+
+      def remove
+        app.click_listener.remove_listeners_for(dsl)
+      end
     end
+
     class Flow < Slot; end
     class Stack < Slot; end
   end

--- a/shoes-swt/spec/shoes/swt/slot_spec.rb
+++ b/shoes-swt/spec/shoes/swt/slot_spec.rb
@@ -27,4 +27,11 @@ describe Shoes::Swt::Slot do
       expect(content).to have_received(:hide).once
     end
   end
+
+  describe '#remove' do
+    it 'cleans up click listeners' do
+      expect(swt_app.click_listener).to receive(:remove_listeners_for).with(dsl)
+      subject.remove
+    end
+  end
 end


### PR DESCRIPTION
When an outer slot cleared an inner slot, it ended up calling `clear`
instead of `remove` on the inner slot. This in turn didn't remove the
click listeners properly, which left them dangling.

Because clearing a slot shouldn't remove clicks, but when your parent
clears you should, this meant that slots needed to have a separate
`remove` method. Wonderfully, this lined up the handling around slots
during clear and got rid of a stray conditional.

Sample program to expose the issue:

```
Shoes.app do
  @outer = stack do
    @inner = stack do
      background darkblue
      title "Testing blue...", stroke: white, margin: 30
    end

    @inner.click do
      puts "whatever"
    end
  end

  button "clear" do
    @outer.clear
  end
end
```

Partial fix for #1212, which has issues with links as well before we're done.