### PR TITLE
Let link hover define own target

### DIFF
--- a/shoes-core/lib/shoes/common/hover.rb
+++ b/shoes-core/lib/shoes/common/hover.rb
@@ -23,10 +23,6 @@ class Shoes
         @hovered
       end
 
-      def eval_in_parent?
-        false
-      end
-
       def hover_class
         return @hover_class if @hover_class
 
@@ -57,9 +53,7 @@ class Shoes
       end
 
       def target
-        target = self
-        target = parent if eval_in_parent?
-        target
+        self
       end
 
       def eval_hover_block(blk)

--- a/shoes-core/lib/shoes/link.rb
+++ b/shoes-core/lib/shoes/link.rb
@@ -18,9 +18,9 @@ class Shoes
       super texts, @style
     end
 
-    # Force hovering evaluation up in parent where we have actual dimensions
-    def eval_in_parent?
-      true
+    # Hover must use containing text block since we're missing dimensions
+    def target
+      text_block
     end
 
     # Doesn't use Common::Clickable because of URL flavor option clicks

--- a/shoes-core/spec/shoes/link_spec.rb
+++ b/shoes-core/spec/shoes/link_spec.rb
@@ -9,10 +9,12 @@ describe Shoes::Link do
   let(:parent) { double("parent") }
   let(:internal_app) { double("internal app", app: app, gui: gui, style: {}, element_styles: {}) }
   let(:texts) { ["text", "goes", "first"] }
+  let(:text_block) { double 'text block', visible?: true, hidden?: false }
 
   subject {
     link = Shoes::Link.new(app, texts, color: :blue)
     link.parent = parent
+    link.text_block = text_block
     link
   }
 
@@ -21,7 +23,7 @@ describe Shoes::Link do
       element_styles[clazz] = styles
     end
 
-    allow(parent).to receive(:eval_hover_block) do |blk|
+    allow(text_block).to receive(:eval_hover_block) do |blk|
       blk.call(subject) if blk
     end
   end
@@ -106,13 +108,7 @@ describe Shoes::Link do
   end
 
   describe 'visibility' do
-    let(:text_block) { double 'text block', visible?: true, hidden?: false }
-
     describe 'with a containing text block' do
-      before :each do
-        subject.text_block = text_block
-      end
-
       it 'forwards #visible? calls' do
         subject.visible?
         expect(text_block).to have_received :visible?
@@ -137,8 +133,6 @@ describe Shoes::Link do
 
   # #979
   describe 'containing text block' do
-    let(:text_block) { double 'text block' }
-
     before :each do
       subject.parent = text_block
     end

--- a/shoes-core/spec/shoes/link_spec.rb
+++ b/shoes-core/spec/shoes/link_spec.rb
@@ -23,6 +23,11 @@ describe Shoes::Link do
       element_styles[clazz] = styles
     end
 
+    allow(subject).to receive(:eval_hover_block) do |_|
+      raise "Heck if hover evaluated on link itself. " +
+            "Needs to eval on TextBlock so redrawing can get dimensions."
+    end
+
     allow(text_block).to receive(:eval_hover_block) do |blk|
       blk.call(subject) if blk
     end

--- a/shoes-core/spec/shoes/link_spec.rb
+++ b/shoes-core/spec/shoes/link_spec.rb
@@ -24,7 +24,7 @@ describe Shoes::Link do
     end
 
     allow(subject).to receive(:eval_hover_block) do |_|
-      raise "Heck if hover evaluated on link itself. " +
+      raise "Heck if hover evaluated on link itself. " \
             "Needs to eval on TextBlock so redrawing can get dimensions."
     end
 


### PR DESCRIPTION
Fixes #1266

We were assuming that the immediate parent of a link would be the proper
hover handler (which needs dimensioning information, and thus needs to
be the TextBlock). But in fact, you can nest links within other span
types, so the single-parent lookup we were doing was insufficient.