### PR TITLE
Fix overlapping fill on rounded rectangles

### DIFF
--- a/shoes-swt/lib/shoes/swt/rect_painter.rb
+++ b/shoes-swt/lib/shoes/swt/rect_painter.rb
@@ -2,10 +2,6 @@ class Shoes
   module Swt
     class RectPainter < Common::Painter
       def fill(gc)
-        # If drawing a stroke around the shape, inset the fill so the draw
-        # isn't inside bounds of fill because of integer division remainders.
-        inset = inset_fill? ? 1 : 0
-
         gc.fill_round_rectangle(@obj.element_left + inset,
                                 @obj.element_top + inset,
                                 @obj.element_width - inset * 2,
@@ -21,6 +17,12 @@ class Shoes
                                 @obj.element_width - stroke_width,
                                 @obj.element_height - stroke_width,
                                 @obj.corners * 2, @obj.corners * 2)
+      end
+
+      def inset
+        # If drawing a stroke around the shape, inset the fill so the draw
+        # isn't inside bounds of fill because of integer division remainders.
+        inset_fill? ? 1 : 0
       end
 
       def inset_fill?

--- a/shoes-swt/lib/shoes/swt/rect_painter.rb
+++ b/shoes-swt/lib/shoes/swt/rect_painter.rb
@@ -1,13 +1,18 @@
 class Shoes
   module Swt
     class RectPainter < Common::Painter
-      def fill(graphics_context)
-        graphics_context.fill_round_rectangle(@obj.element_left,
-                                              @obj.element_top,
-                                              @obj.element_width,
-                                              @obj.element_height,
-                                              @obj.corners * 2,
-                                              @obj.corners * 2)
+      def fill(gc)
+        # If drawing a stroke around the shape, inset the fill so the draw
+        # isn't inside bounds of fill because of integer division remainders.
+        stroke_width = @obj.dsl.style[:strokewidth] || 0
+        bump_by = stroke_width == 1 ? 1 : stroke_width / 2
+
+        gc.fill_round_rectangle(@obj.element_left + bump_by,
+                                @obj.element_top + bump_by,
+                                @obj.element_width - stroke_width,
+                                @obj.element_height - stroke_width,
+                                @obj.corners * 2,
+                                @obj.corners * 2)
       end
 
       def draw(gc)

--- a/shoes-swt/lib/shoes/swt/rect_painter.rb
+++ b/shoes-swt/lib/shoes/swt/rect_painter.rb
@@ -24,15 +24,15 @@ class Shoes
       end
 
       def inset_fill?
-        rounded? && has_strokewidth?
+        rounded? && strokewidth?
       end
 
       def rounded?
-        @obj.corners || 0 > 0
+        (@obj.corners || 0) > 0
       end
 
-      def has_strokewidth?
-        @obj.dsl.style[:strokewidth] || 0 > 0
+      def strokewidth?
+        (@obj.dsl.style[:strokewidth] || 0) > 0
       end
     end
   end

--- a/shoes-swt/lib/shoes/swt/rect_painter.rb
+++ b/shoes-swt/lib/shoes/swt/rect_painter.rb
@@ -4,13 +4,12 @@ class Shoes
       def fill(gc)
         # If drawing a stroke around the shape, inset the fill so the draw
         # isn't inside bounds of fill because of integer division remainders.
-        stroke_width = @obj.dsl.style[:strokewidth]
-        bump = stroke_width && stroke_width > 0 ? 1 : 0
+        inset = inset_fill? ? 1 : 0
 
-        gc.fill_round_rectangle(@obj.element_left + bump,
-                                @obj.element_top + bump,
-                                @obj.element_width - bump * 2,
-                                @obj.element_height - bump * 2,
+        gc.fill_round_rectangle(@obj.element_left + inset,
+                                @obj.element_top + inset,
+                                @obj.element_width - inset * 2,
+                                @obj.element_height - inset * 2,
                                 @obj.corners * 2,
                                 @obj.corners * 2)
       end
@@ -22,6 +21,18 @@ class Shoes
                                 @obj.element_width - stroke_width,
                                 @obj.element_height - stroke_width,
                                 @obj.corners * 2, @obj.corners * 2)
+      end
+
+      def inset_fill?
+        rounded? && has_strokewidth?
+      end
+
+      def rounded?
+        @obj.corners || 0 > 0
+      end
+
+      def has_strokewidth?
+        @obj.dsl.style[:strokewidth] || 0 > 0
       end
     end
   end

--- a/shoes-swt/lib/shoes/swt/rect_painter.rb
+++ b/shoes-swt/lib/shoes/swt/rect_painter.rb
@@ -4,13 +4,13 @@ class Shoes
       def fill(gc)
         # If drawing a stroke around the shape, inset the fill so the draw
         # isn't inside bounds of fill because of integer division remainders.
-        stroke_width = @obj.dsl.style[:strokewidth] || 0
-        bump_by = stroke_width == 1 ? 1 : stroke_width / 2
+        stroke_width = @obj.dsl.style[:strokewidth]
+        bump = stroke_width && stroke_width > 0 ? 1 : 0
 
-        gc.fill_round_rectangle(@obj.element_left + bump_by,
-                                @obj.element_top + bump_by,
-                                @obj.element_width - stroke_width,
-                                @obj.element_height - stroke_width,
+        gc.fill_round_rectangle(@obj.element_left + bump,
+                                @obj.element_top + bump,
+                                @obj.element_width - bump * 2,
+                                @obj.element_height - bump * 2,
                                 @obj.corners * 2,
                                 @obj.corners * 2)
       end

--- a/shoes-swt/spec/shoes/swt/background_spec.rb
+++ b/shoes-swt/spec/shoes/swt/background_spec.rb
@@ -51,7 +51,7 @@ describe Shoes::Swt::Background do
       let(:corners) { 0 }
 
       it "fills rect" do
-        expect(gc).to receive(:fill_round_rectangle).with(left + 1, top + 1, width - 2, height - 2, corners * 2, corners * 2)
+        expect(gc).to receive(:fill_round_rectangle).with(left, top, width, height, corners * 2, corners * 2)
         subject.paint_control(event)
       end
     end

--- a/shoes-swt/spec/shoes/swt/background_spec.rb
+++ b/shoes-swt/spec/shoes/swt/background_spec.rb
@@ -51,7 +51,7 @@ describe Shoes::Swt::Background do
       let(:corners) { 0 }
 
       it "fills rect" do
-        expect(gc).to receive(:fill_round_rectangle).with(left + 1, top + 1, width - 1, height - 1, corners * 2, corners * 2)
+        expect(gc).to receive(:fill_round_rectangle).with(left + 1, top + 1, width - 2, height - 2, corners * 2, corners * 2)
         subject.paint_control(event)
       end
     end
@@ -60,7 +60,7 @@ describe Shoes::Swt::Background do
       let(:corners) { 13 }
 
       it "fills rect" do
-        expect(gc).to receive(:fill_round_rectangle).with(left + 1, top + 1, width - 1, height - 1, corners * 2, corners * 2)
+        expect(gc).to receive(:fill_round_rectangle).with(left + 1, top + 1, width - 2, height - 2, corners * 2, corners * 2)
         subject.paint_control(event)
       end
     end

--- a/shoes-swt/spec/shoes/swt/background_spec.rb
+++ b/shoes-swt/spec/shoes/swt/background_spec.rb
@@ -13,7 +13,8 @@ describe Shoes::Swt::Background do
     double("dsl object", app: shoes_app,
                          element_left: left, element_top: top,
                          element_width: width, element_height: height,
-                         strokewidth: 1, curve: corners, fill: fill,
+                         style: { strokewidth: 1 }, strokewidth: 1,
+                         curve: corners, fill: fill,
                          hidden: false).as_null_object
   end
 
@@ -50,7 +51,7 @@ describe Shoes::Swt::Background do
       let(:corners) { 0 }
 
       it "fills rect" do
-        expect(gc).to receive(:fill_round_rectangle).with(left, top, width, height, corners * 2, corners * 2)
+        expect(gc).to receive(:fill_round_rectangle).with(left + 1, top + 1, width - 1, height - 1, corners * 2, corners * 2)
         subject.paint_control(event)
       end
     end
@@ -59,7 +60,7 @@ describe Shoes::Swt::Background do
       let(:corners) { 13 }
 
       it "fills rect" do
-        expect(gc).to receive(:fill_round_rectangle).with(left, top, width, height, corners * 2, corners * 2)
+        expect(gc).to receive(:fill_round_rectangle).with(left + 1, top + 1, width - 1, height - 1, corners * 2, corners * 2)
         subject.paint_control(event)
       end
     end

--- a/shoes-swt/spec/shoes/swt/rect_painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/rect_painter_spec.rb
@@ -10,7 +10,8 @@ describe Shoes::Swt::RectPainter do
   let(:dsl) do
     double("dsl object", hidden: false, rotate: 0, element_left: left,
                          element_top: top, element_width: width,
-                         element_height: height, curve: corners).as_null_object
+                         element_height: height, curve: corners,
+                         style: {}, strokewidth: 1).as_null_object
   end
 
   let(:left) { 55 }


### PR DESCRIPTION
Fixes #1013

Integer math being slightly off between inner fill and outer draw on
borders sometimes let a single pixel show in the corners, which looked
ugly.

Want to give this some thorough sample testing and more thought before
calling it done.