### PR TITLE
Reverse order of tests and Rubocop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 script:
-  - bundle exec rake spec:all
   - bundle exec rubocop
+  - bundle exec rake spec:all
 rvm:
   - jruby-head
   - jruby-9.0.5.0


### PR DESCRIPTION
For reasons I haven't quite sussed out yet, running Rubocop locally gets me tons of errors that aren't happening in CI.

I probably have something misconfigured, but in the meantime it'd be nice for Travis to fail faster when I do miss something Rubocop-related. This can be accomplished by just running Rubocop first (which is much faster than the specs.)