### PR TITLE
Look to redraw_target in RedrawingAspect

### DIFF
--- a/shoes-core/lib/shoes/dimensions.rb
+++ b/shoes-core/lib/shoes/dimensions.rb
@@ -219,5 +219,9 @@ class Shoes
     extend Forwardable
 
     def_delegators :dsl, *DimensionsDelegations::CANDIDATE_METHODS
+
+    def redraw_target
+      @dsl
+    end
   end
 end

--- a/shoes-swt/lib/shoes/swt/link.rb
+++ b/shoes-swt/lib/shoes/swt/link.rb
@@ -13,6 +13,10 @@ class Shoes
         @dsl = dsl
       end
 
+      def redraw_target
+        @dsl.text_block
+      end
+
       def remove
         @link_segments.clear
         app.click_listener.remove_listeners_for(self)

--- a/shoes-swt/lib/shoes/swt/redrawing_aspect.rb
+++ b/shoes-swt/lib/shoes/swt/redrawing_aspect.rb
@@ -88,15 +88,23 @@ class Shoes
       end
 
       def redraw_element(element, include_children = true)
-        redraw_target = element.gui&.redraw_target || element
-        redraw_area redraw_target.element_left, redraw_target.element_top,
-                    redraw_target.element_width, redraw_target.element_height,
+        target = redraw_target(element)
+        redraw_area target.element_left, target.element_top,
+                    target.element_width, target.element_height,
                     include_children
       end
 
       def redraw_area(left, top, width, height, include_children = true)
         unless app.disposed?
           app.redraw left, top, width, height, include_children
+        end
+      end
+
+      def redraw_target(element)
+        if element.gui
+          element.gui.redraw_target
+        else
+          element
         end
       end
 

--- a/shoes-swt/lib/shoes/swt/redrawing_aspect.rb
+++ b/shoes-swt/lib/shoes/swt/redrawing_aspect.rb
@@ -88,8 +88,9 @@ class Shoes
       end
 
       def redraw_element(element, include_children = true)
-        redraw_area element.element_left, element.element_top,
-                    element.element_width, element.element_height,
+        redraw_target = element.gui&.redraw_target || element
+        redraw_area redraw_target.element_left, redraw_target.element_top,
+                    redraw_target.element_width, redraw_target.element_height,
                     include_children
       end
 

--- a/shoes-swt/lib/shoes/swt/shape.rb
+++ b/shoes-swt/lib/shoes/swt/shape.rb
@@ -31,6 +31,10 @@ class Shoes
       attr_reader :element, :transform
       attr_reader :painter
 
+      def redraw_target
+        @dsl
+      end
+
       def line_to(x, y)
         @element.line_to(x, y)
       end

--- a/shoes-swt/lib/shoes/swt/slot.rb
+++ b/shoes-swt/lib/shoes/swt/slot.rb
@@ -35,6 +35,10 @@ class Shoes
         end
       end
 
+      def redraw_target
+        @dsl
+      end
+
       def remove
         app.click_listener.remove_listeners_for(dsl)
       end

--- a/shoes-swt/spec/shoes/swt/check_spec.rb
+++ b/shoes-swt/spec/shoes/swt/check_spec.rb
@@ -7,6 +7,7 @@ describe Shoes::Swt::Check do
 
   let(:dsl) do
     double('dsl', app: shoes_app,
+                  gui: real,
                   visible?: true,
                   left: 42,
                   top: 66,


### PR DESCRIPTION
Going with @PragTob suggestion of having the `RedrawingAspect` look for an explicit `redraw_target` object that `Link` can override. This nicely allows us to keep this all in SWT-land too, which is great!

~~Simplest (but possibly hacky?) proposal for fixing #1136.~~

~~As was noted in an earlier PR, links and spans have trouble if they do anything which triggers a redrawing against them, which expects them to have `element_left`, `element_top`, etc dimensions solely for the purpose of calculating a redrawing area.~~

~~This change gets the code from #1136 fully working (no idea what the `strokewidth` problem was at the time, but it doesn't manifest now) at the cost of `Link` and `Span` advertising `element_*` methods that aren't actually quite right.~~

~~Looking for feedback whether this is an acceptable compromise to get link styling working. I can see two alternatives:~~

~~1) Create a new `redraw_left`, `redraw_top`... set of methods which the `RedrawingAspect` could use instead of `element_*`. The majority of Shoes elements would just plumb `redraw_*` -> `element_*`, but it would give us the wiggle-room for `Link` and `Span` to point it to the broader `TextBlock`~~

~~2) Actually get the `Link` and `Span` set up with true, correctly calculated dimensions. This turns out to look modestly hard, because the lower-level text fitting is the only thing which knows about those dimensions, and it's forgotten about the specific segment objects long before it gets to really drawing things.~~

FWIW, I'm in favor of either just rolling with this (for simplicity and momentum), or doing option 1) which is relatively low impact. @PragTob what do you think?