### PR TITLE
Make jruby-head run again hopefully

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ notifications:
       - jason@jasonrclark.net
     on_success: change # [always|never|change] # default: change
     on_failure: change # [always|never|change] # default: always
+before_install:
+  - gem install bundler
 before_script:
   - "export DISPLAY=:99.0"
   - "export SWT_GTK3=0"


### PR DESCRIPTION
It hasn't succeeded forever, so there's not much worth there right
now with jruby-head. The error is:

```
bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}

/home/travis/build.sh: line 218: bundle: command not found
```

so head doesn't seem to have bundler, as installing bundler
shouldn't hurt even for the others I just put it in the general
before_script.