### PR TITLE
Update to latest SWT version 4.6.1

### DIFF
--- a/shoes-swt/lib/shoes/swt/list_box.rb
+++ b/shoes-swt/lib/shoes/swt/list_box.rb
@@ -27,7 +27,7 @@ class Shoes
       end
 
       def update_items
-        @real.items = @dsl.items.to_a.map(&:to_s)
+        @real.set_items(*@dsl.items.to_a.map(&:to_s))
       end
 
       def text

--- a/shoes-swt/lib/shoes/swt/text_block/text_segment.rb
+++ b/shoes-swt/lib/shoes/swt/text_block/text_segment.rb
@@ -84,8 +84,17 @@ class Shoes
           }
         end
 
+        # Why not just use layout.bounds?  Recent versions of SWT have shown
+        # platform dependent behavior about whether spacing is included in
+        # bounds, leading to unpredictable placement.  Doing it more directly
+        # per-line in this fashion insulates us from the regression. #1295
         def height
-          layout.bounds.height - layout.spacing
+          line_count = layout.line_count
+          h = (line_count - 1) * layout.spacing
+          line_count.times do |i|
+            h += layout.get_line_bounds(i).height
+          end
+          h
         end
 
         def last_line_height

--- a/shoes-swt/shoes-swt.gemspec
+++ b/shoes-swt/shoes-swt.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.add_dependency "swt", "~>4.4.0"
+  s.add_dependency "swt", "~>4.6.1"
   s.add_dependency "after_do", "~>0.4.0"
   s.add_dependency "shoes-core", Shoes::Swt::VERSION
   s.add_dependency "shoes-package", Shoes::Swt::VERSION

--- a/shoes-swt/spec/shoes/swt/list_box_spec.rb
+++ b/shoes-swt/spec/shoes/swt/list_box_spec.rb
@@ -13,7 +13,7 @@ describe Shoes::Swt::ListBox do
   let(:block) { ->() {} }
 
   let(:real) do
-    double('real', text: "", :items= => true, :text= => true, set_size: true,
+    double('real', text: "", :set_items => true, :text= => true, set_size: true,
                    add_selection_listener: true, disposed?: false)
   end
 
@@ -33,7 +33,7 @@ describe Shoes::Swt::ListBox do
     allow(dsl).to receive(:items).and_return ["hello"]
     subject.update_items
     # creation already calls update_items once
-    expect(real).to have_received(:items=).with(["hello"]).twice
+    expect(real).to have_received(:set_items).with("hello").twice
   end
 
   it "should set real text if initialized with choose option" do
@@ -59,14 +59,14 @@ describe Shoes::Swt::ListBox do
 
   it 'sets the items on real upon initialization' do
     subject
-    expect(real).to have_received(:items=).with(items)
+    expect(real).to have_received(:set_items).with(*items)
   end
 
   it 'converts array to string' do
     allow(dsl).to receive(:items).and_return [1, 2, 3]
     subject.update_items
     # creation already calls update_items once
-    expect(real).to have_received(:items=).with(%w(1 2 3)).twice
+    expect(real).to have_received(:set_items).with("1", "2", "3").twice
   end
 
   describe "when the backend notifies us that the selection has changed" do

--- a/shoes-swt/spec/shoes/swt/text_block/text_segment_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block/text_segment_spec.rb
@@ -135,4 +135,34 @@ describe Shoes::Swt::TextBlock::TextSegment do
       expect(style_factory).to have_received(:dispose)
     end
   end
+
+  describe "height" do
+    let(:line_height)  { 17 }
+    let(:line_spacing) { 4 }
+    let(:line_bounds)  { ::Swt::Rectangle.new(-1, -1, -1, line_height) }
+
+    before do
+      allow(layout).to receive(:spacing).and_return(line_spacing)
+      allow(layout).to receive(:get_line_bounds).and_return(line_bounds)
+    end
+
+    it "has a single line" do
+      with_line_count(1)
+      expect(subject.height).to eq(17)
+    end
+
+    it "has two lines" do
+      with_line_count(2)
+      expect(subject.height).to eq(38)
+    end
+
+    it "has three lines" do
+      with_line_count(3)
+      expect(subject.height).to eq(59)
+    end
+
+    def with_line_count(count)
+      allow(layout).to receive(:line_count).and_return(count)
+    end
+  end
 end

--- a/shoes-swt/spec/shoes/swt/text_block/text_segment_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block/text_segment_spec.rb
@@ -47,7 +47,7 @@ describe Shoes::Swt::TextBlock::TextSegment do
     segment.position_at(element_left, element_top)
   end
 
-  context "disposal" do
+  describe "disposal" do
     it "disposes of underlying layout" do
       allow(layout).to receive(:disposed?) { false }
       expect(layout).to receive(:dispose)
@@ -61,7 +61,7 @@ describe Shoes::Swt::TextBlock::TextSegment do
     end
   end
 
-  context "setting style" do
+  describe "setting style" do
     it "on full range" do
       subject.set_style(style_hash)
       expect(layout).to have_received(:set_style)
@@ -91,7 +91,7 @@ describe Shoes::Swt::TextBlock::TextSegment do
     end
   end
 
-  context "bounds checking" do
+  describe "bounds checking" do
     before(:each) do
       set_bounds(0, 0, segment_width, segment_height)
     end


### PR DESCRIPTION
~~**DO NOT MERGE YET**~~

There was a small API breakage, which already surprised me. But running through the samples it seems like there is even more breakage and I aborted at some point. Breakage seems to be related to dimensions and seemingly mostly text :|

A week back or so I tried to find a good SWT changelog but came up short :|

First an image from master, then it's SWT 4.6.1 equivalent.

#### simple-loogink-cy.rb 

![photo frame _005](https://cloud.githubusercontent.com/assets/606517/20559829/b4ad2f0e-b176-11e6-8876-e9cadb25c07f.png)

![photo frame _003](https://cloud.githubusercontent.com/assets/606517/20559841/bde0c8ec-b176-11e6-8f4b-be47d9c6107f.png)

Text is cut off at the bottom.

#### simple-logo-display.rb 

![shoes 4 logo icon _001](https://cloud.githubusercontent.com/assets/606517/20559862/d0035102-b176-11e6-9f12-d8ece3239642.png)

![shoes 4 logo icon _002](https://cloud.githubusercontent.com/assets/606517/20559871/d37f4584-b176-11e6-87c4-9f46184489cc.png)

text is cut off at the bottom again

#### simple-color-selector.rb 

![shoes 4 _006](https://cloud.githubusercontent.com/assets/606517/20559892/f66ec7c2-b176-11e6-8ba8-de4471b4cd8b.png)

![shoes 4 _004](https://cloud.githubusercontent.com/assets/606517/20559895/fc788504-b176-11e6-9a2f-126fb66e4e4d.png)

Text starts wandering off into oblivion.

-------------------------------------------------------------------------------------

At best this is some off by x error where we manually add/remove something that adds up... worst case a very long debuggigng session. Sadly I need to work on some Elixir projects for a presentation in 1.5 weeks so don't have the time to dig deep :(
