### PR TITLE
Fix test coverage

### DIFF
--- a/shoes-core/spec/spec_helper.rb
+++ b/shoes-core/spec/spec_helper.rb
@@ -2,7 +2,14 @@ SHOESSPEC_ROOT = File.expand_path('..', __FILE__)
 $LOAD_PATH << File.join(SHOESSPEC_ROOT)
 $LOAD_PATH << File.join(SHOESSPEC_ROOT, "../lib")
 
-require_relative '../../spec/code_coverage'
+# loaded again when executing DSL specs with the SWT backend, therefore
+# we souldn't start the test coverage again or override the command as it'd
+# mess up merging
+unless defined?(SimpleCov)
+  require_relative '../../spec/code_coverage'
+  SimpleCov.command_name 'spec:shoes'
+end
+
 require 'rspec'
 require 'rspec/its'
 require 'pry'

--- a/shoes-swt/spec/spec_helper.rb
+++ b/shoes-swt/spec/spec_helper.rb
@@ -4,8 +4,10 @@ $LOAD_PATH << File.join(SHOESSPEC_ROOT, '../lib')
 $LOAD_PATH << File.join(SHOESSPEC_ROOT, '../../shoes-core/spec')
 $LOAD_PATH << File.join(SHOESSPEC_ROOT, '../../shoes-core/lib')
 
-require 'shoes/swt/spec_helper'
 require_relative '../../spec/code_coverage'
+SimpleCov.command_name 'spec:swt'
+
+require 'shoes/swt/spec_helper'
 require 'rspec'
 require 'rspec/its'
 require 'pry'


### PR DESCRIPTION
* remember kids, always load simplecov before any code (something
  somewhere was flipped around so that swt was loaded before the
  DSL spec_helper so that it couldn't be covered)
* adds command_name so that results are correctly merged
* does not run it with package, as that has a sample app and seems
  to mess with test coverage somehow (we end up with 99.xx%
  coverage then covering things that are definitely not covered
  like the logger app)
* fixes #1287