### PR TITLE
Attaching elements

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,7 @@ Metrics/BlockLength:
 # Offense count: 16
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 236
+  Max: 250
 
 # Offense count: 21
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,7 @@ Metrics/BlockLength:
 # Offense count: 16
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 250
+  Max: 252
 
 # Offense count: 21
 Metrics/CyclomaticComplexity:

--- a/samples/README
+++ b/samples/README
@@ -13,6 +13,7 @@ simple-anim-shapes.rb
 simple-animate.rb
 simple-anim-text.rb
 # simple-arc.rb  Pending on #423
+simple-attach.rb
 simple-borderless.rb
 simple-border-image.rb
 simple-bounce.rb

--- a/samples/simple-attach.rb
+++ b/samples/simple-attach.rb
@@ -1,0 +1,25 @@
+Shoes.app do
+  stack do
+    background blue
+    3.times do
+      para "Three lines first!"
+    end
+  end
+
+  stack attach: Shoes::Window, height: 30, width: 300 do
+    background green
+    para "Attached to the window!"
+  end
+
+  @next = stack margin: 20 do
+    background yellow
+    3.times do
+      para "Three lines next!"
+    end
+  end
+
+  stack attach: @next, height: 30, width: 300 do
+    background red
+    para "Sneaked up!"
+  end
+end

--- a/shoes-core/lib/shoes/common/attachable.rb
+++ b/shoes-core/lib/shoes/common/attachable.rb
@@ -1,0 +1,9 @@
+class Shoes
+  module Common
+    module Attachable
+      def attached_to
+        style[:attach]
+      end
+    end
+  end
+end

--- a/shoes-core/lib/shoes/common/attachable.rb
+++ b/shoes-core/lib/shoes/common/attachable.rb
@@ -2,7 +2,9 @@ class Shoes
   module Common
     module Attachable
       def attached_to
-        style[:attach]
+        target = style[:attach]
+        target = @app.top_slot if target == Shoes::Window
+        target
       end
     end
   end

--- a/shoes-core/lib/shoes/common/ui_element.rb
+++ b/shoes-core/lib/shoes/common/ui_element.rb
@@ -1,6 +1,7 @@
 class Shoes
   module Common
     module UIElement
+      include Common::Attachable
       include Common::Initialization
       include Common::Inspect
       include Common::Visibility

--- a/shoes-core/lib/shoes/dsl.rb
+++ b/shoes-core/lib/shoes/dsl.rb
@@ -74,6 +74,7 @@ require 'shoes/text_block_dimensions'
 
 require 'shoes/color'
 
+require 'shoes/common/attachable'
 require 'shoes/common/background_element'
 require 'shoes/common/changeable'
 require 'shoes/common/clickable'

--- a/shoes-core/lib/shoes/dsl.rb
+++ b/shoes-core/lib/shoes/dsl.rb
@@ -130,6 +130,7 @@ require 'shoes/star'
 require 'shoes/sound'
 require 'shoes/text_block'
 require 'shoes/timer'
+require 'shoes/window'
 
 class Shoes
   # Methods for creating and manipulating Shoes elements

--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -29,7 +29,7 @@ class Shoes
     end
 
     def handle_block(blk)
-      @current_position = CurrentPosition.new element_left,
+      @current_position = Position.new element_left,
                                               element_top,
                                               element_top
       @blk = blk
@@ -167,10 +167,10 @@ class Shoes
 
     protected
 
-    CurrentPosition = Struct.new(:x, :y, :next_line_start)
+    Position = Struct.new(:x, :y, :next_line_start)
 
     def position_contents
-      @current_position = CurrentPosition.new element_left,
+      @current_position = Position.new element_left,
                                               element_top,
                                               element_top
 
@@ -212,7 +212,7 @@ class Shoes
 
       position_element_at element, attached_left, attached_top
 
-      CurrentPosition.new attached_left, attached_top, attached_top
+      Position.new attached_left, attached_top, attached_top
     end
 
     def position_slotted_element(element, current_position)

--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -183,16 +183,13 @@ class Shoes
 
     def positioning(element, current_position)
       if element.needs_positioning?
-        if element.attached_to
-          align_position = position_attached_element element
-        else
-          position_element element, current_position
-          align_position = current_position
-        end
+        align_position = if element.attached_to
+                           position_attached_element(element)
+                         else
+                           position_slotted_element(element, current_position)
+                         end
 
-        if element.respond_to?(:contents_alignment)
-          element.contents_alignment(align_position)
-        end
+        element.contents_alignment(align_position) if element.respond_to?(:contents_alignment)
       end
 
       update_current_position(current_position, element)
@@ -216,6 +213,11 @@ class Shoes
       position_element_at element, attached_left, attached_top
 
       CurrentPosition.new attached_left, attached_top, attached_top
+    end
+
+    def position_slotted_element(element, current_position)
+      position_element element, current_position
+      current_position
     end
 
     def position_in_current_line(element, current_position)

--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -30,8 +30,8 @@ class Shoes
 
     def handle_block(blk)
       @current_position = Position.new element_left,
-                                              element_top,
-                                              element_top
+                                       element_top,
+                                       element_top
       @blk = blk
       eval_block blk
     end
@@ -171,8 +171,8 @@ class Shoes
 
     def position_contents
       @current_position = Position.new element_left,
-                                              element_top,
-                                              element_top
+                                       element_top,
+                                       element_top
 
       contents.each do |element|
         next if element.hidden?

--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -207,8 +207,8 @@ class Shoes
     end
 
     def position_attached_element(element)
-      attached_left = element.attached_to.element_left + element.style[:left].to_i
-      attached_top  = element.attached_to.element_top + element.style[:top].to_i
+      attached_left = element.attached_to.absolute_left + element.style[:left].to_i
+      attached_top  = element.attached_to.absolute_top + element.style[:top].to_i
 
       position_element_at element, attached_left, attached_top
 

--- a/shoes-core/lib/shoes/window.rb
+++ b/shoes-core/lib/shoes/window.rb
@@ -1,0 +1,6 @@
+class Shoes
+  # This class serves as a placeholder for referring to the overall window of
+  # a Shoes app, such as attaching a slot to the top.
+  class Window
+  end
+end

--- a/shoes-core/spec/shoes/common/attachable_spec.rb
+++ b/shoes-core/spec/shoes/common/attachable_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Shoes::Common::Attachable do
+  include_context "dsl app"
+
+  subject do
+    Class.new do
+      include Shoes::Common::Attachable
+
+      attr_reader :style
+
+      def initialize(app, attached_to)
+        @app   = app
+        @style = { attach: attached_to }
+      end
+    end
+  end
+
+  let(:slot) { double('slot') }
+
+  it "isn't attached" do
+    expect(subject.new(app, nil).attached_to).to eq(nil)
+  end
+
+  it "attaches" do
+    expect(subject.new(app, slot).attached_to).to eq(slot)
+  end
+
+  it "attaches to Shoes::Window" do
+    expect(subject.new(app, Shoes::Window).attached_to).to eq(app.top_slot)
+  end
+end

--- a/shoes-core/spec/shoes/helpers/fake_absolute_element.rb
+++ b/shoes-core/spec/shoes/helpers/fake_absolute_element.rb
@@ -1,9 +1,10 @@
 class Shoes
   class FakeAbsoluteElement
+    include Common::Attachable
     include Common::Inspect
-    include Common::Visibility
     include Common::Positioning
     include Common::Remove
+    include Common::Visibility
 
     include Shoes::DimensionsDelegations
 

--- a/shoes-core/spec/shoes/helpers/fake_element.rb
+++ b/shoes-core/spec/shoes/helpers/fake_element.rb
@@ -1,9 +1,10 @@
 class Shoes
   class FakeElement < Dimensions
+    include Common::Attachable
     include Common::Inspect
-    include Common::Visibility
     include Common::Positioning
     include Common::Remove
+    include Common::Visibility
 
     def add_child(_element)
       true

--- a/shoes-core/spec/shoes/shared_examples/slot.rb
+++ b/shoes-core/spec/shoes/shared_examples/slot.rb
@@ -128,6 +128,17 @@ shared_examples_for 'positioning through :_position' do
     add_child_and_align
   end
 
+  describe 'attached' do
+    let(:attached_to) { double('attached slot', element_left: 101, element_top: 101) }
+    let(:element) { Shoes::FakeElement.new nil }
+
+    it "gets positioned where it's attached" do
+      element.style[:attach] = attached_to
+      expect(element).to receive(:_position).with(101, 101).at_least(1)
+      add_child_and_align
+    end
+  end
+
   describe 'absolute dimensions' do
     let(:element) { Shoes::FakeAbsoluteElement.new }
 

--- a/shoes-core/spec/shoes/shared_examples/slot.rb
+++ b/shoes-core/spec/shoes/shared_examples/slot.rb
@@ -129,7 +129,7 @@ shared_examples_for 'positioning through :_position' do
   end
 
   describe 'attached' do
-    let(:attached_to) { double('attached slot', element_left: 101, element_top: 101) }
+    let(:attached_to) { double('attached slot', absolute_left: 101, absolute_top: 101) }
     let(:element) { Shoes::FakeElement.new nil }
 
     it "gets positioned where it's attached" do

--- a/shoes-swt/spec/shoes/swt/text_block_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block_spec.rb
@@ -46,7 +46,7 @@ describe Shoes::Swt::TextBlock do
     let(:segment) { create_segment }
     let(:second_segment) { create_segment }
 
-    let(:current_position) { Shoes::Slot::CurrentPosition.new(0, 0) }
+    let(:current_position) { Shoes::Slot::Position.new(0, 0) }
 
     before(:each) do
       allow(::Shoes::Swt::TextBlock::Fitter).to receive(:new) { fitter }


### PR DESCRIPTION
Revises slot positioning to take advantage of attaching an element to another slot. Fixes #807.

## Sample
Sample program exercising `attach`:

```
Shoes.app do
  stack do
    para "blah"
    para "blah"
    para "blah"
    para "blah"
  end

  @s = stack do
    background blue
    para "The Body!!", stroke: white
  end

  flow height: 60, width: 50, attach: @s, left: 20, top: 30 do
    background black
    para "Footnotes!", stroke: white
  end
end
```

**Before**
![image](https://cloud.githubusercontent.com/assets/130504/20615513/a99b2796-b28f-11e6-8445-ca6d7f0c1606.png)

**After**
![image](https://cloud.githubusercontent.com/assets/130504/20615508/9edb671c-b28f-11e6-8ac8-d26be52a7604.png)

## TODO

* [x] Look into `Shoes::Window` as attachment target, although that class doesn't exist at all (yet?) in Shoes 4 (http://shoesrb.com/manual/Styles.html#:attach)
* [x] Add a sample using attach... something with real purpose behind fiddling with positioning
* [x] More testing, particularly see how things work with margins
* [x] Rename `CurrentPosition` to `Position`