### PR TITLE
Remove unnecessary targetting logic in hover

### DIFF
--- a/samples/README
+++ b/samples/README
@@ -52,6 +52,7 @@ simple-logo-display.rb
 simple-loogink-cy.rb
 simple-lorem-ipsum.rb
 simple-manual.rb
+simple-menu.rb
 simple-mouse-follow.rb
 simple-oval.rb
 simple-polygon-line.rb

--- a/shoes-core/lib/shoes/common/hover.rb
+++ b/shoes-core/lib/shoes/common/hover.rb
@@ -36,7 +36,7 @@ class Shoes
         @hovered = true
 
         apply_style_from_hover_class
-        target.eval_hover_block(@hover_blk)
+        eval_hover_block(@hover_blk)
       end
 
       def mouse_left
@@ -45,15 +45,11 @@ class Shoes
         @hovered = false
 
         apply_style_from_pre_hover
-        target.eval_hover_block(@leave_blk)
+        eval_hover_block(@leave_blk)
       end
 
       def add_mouse_hover_control
         app.add_mouse_hover_control(self)
-      end
-
-      def target
-        self
       end
 
       def eval_hover_block(blk)

--- a/shoes-core/lib/shoes/link.rb
+++ b/shoes-core/lib/shoes/link.rb
@@ -18,11 +18,6 @@ class Shoes
       super texts, @style
     end
 
-    # Hover must use containing text block since we're missing dimensions
-    def target
-      text_block
-    end
-
     # Doesn't use Common::Clickable because of URL flavor option clicks
     def setup_click(blk)
       if blk.nil?

--- a/shoes-core/spec/shoes/link_spec.rb
+++ b/shoes-core/spec/shoes/link_spec.rb
@@ -27,12 +27,7 @@ describe Shoes::Link do
       element_styles[clazz] = styles
     end
 
-    allow(subject).to receive(:eval_hover_block) do |_|
-      raise "Heck if hover evaluated on link itself. " \
-            "Needs to eval on TextBlock so redrawing can get dimensions."
-    end
-
-    allow(text_block).to receive(:eval_hover_block) do |blk|
+    allow(subject).to receive(:eval_hover_block) do |blk|
       blk.call(subject) if blk
     end
   end


### PR DESCRIPTION
PR #1281 dealt with the dependency on actual coordinates in the SWT
`RedrawingAspect`. We don't need to jig the target around in the DSL layer
anymore.

Also restore the `simple-menu` sample to good standing since it works as
well as it did on Shoes 3 (and demonstrates `hover`)!