### PR TITLE
Symlinks have trouble with JRuby + Rubygems

### DIFF
--- a/bin/shoes
+++ b/bin/shoes
@@ -6,4 +6,4 @@ cd ./bin
 export SHOES_PICKER_BIN_DIR=`pwd -P`
 
 cd ..
-shoes-core/bin/shoes $@
+shoes-core/bin/shoes-stub $@

--- a/shoes-core/bin/shoes
+++ b/shoes-core/bin/shoes
@@ -1,1 +1,0 @@
-shoes-stub


### PR DESCRIPTION
Fixes #1313 

Getting caught by https://github.com/rubygems/rubygems/issues/1623, but turns out our symlink isn't really necessary or desired at all. Just getting rid of it.

Our helpful `bin/shoes` which only gets used in dev can just point to the stub, no worries.

Tested by locally building a `pre7` set of gems, installed on Window 7 and looking 🎉 