### PR TITLE
DNM: Packaging love :heart:

### DIFF
--- a/shoes-core/shoes-core.gemspec
+++ b/shoes-core/shoes-core.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
 
   # Curious why we don't install shoes? See ext/Rakefile for the nitty-gritty.
   s.executables   = ['shoes-picker', 'shoes-stub']
-  s.extensions    = ['ext/install/Rakefile']
+  # s.extensions    = ['ext/install/Rakefile']
 end

--- a/shoes-swt/lib/shoes/swt/app.rb
+++ b/shoes-swt/lib/shoes/swt/app.rb
@@ -1,7 +1,7 @@
 class Shoes
   module Swt
     shoes_icon = ::Shoes::ICON
-    if shoes_icon.include? '.jar!'
+    if shoes_icon.include? 'uri:classloader'
       ICON = File.join(Dir.tmpdir, 'shoes-icon.png').freeze
       open ICON, 'wb' do |fw|
         open shoes_icon, 'rb' do |fr|


### PR DESCRIPTION
This is a WIP PR to start thrashing out packaging. Fair warning, this PR is probably gonna get long and involved, so buckle your seatbelts! 🚗 💥 

First things first, I'm aiming to get packaging from `bin/shoes` to generate a run-able jar.

## furoshiki update
This relies on https://github.com/shoes/furoshiki/pull/21 to pull in newest `warbler`. This gets the generated package up onto JRuby 9.1, which I believe will address #1209.

(Side note for those following along at home, testing this packaging is a pain in the 🍑! One of the biggest causes is that warbler picks up installed gems (which makes sense). But that means if we make a change to a Shoes gem to get things working, gotta re-build and install to test it. Aw, yeah.)

## Problem with `shoes-core` extensions
Next stall that I hit was that the generated jar refused to load `shoes-core` with this error:

```
✔ ♥♥♥♥ [jruby-9.1.6.0] (master)*
~/source/shoes4:java -XstartOnFirstThread -jar samples/packaging/pkg/package_me.jar
Ignoring shoes-core-4.0.0.pre7 because its extensions are not built.  Try: gem pristine shoes-core --version 4.0.0.pre7
LoadError: no such file to load -- shoes
  require at org/jruby/RubyKernel.java:959
  require at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:55
   <main> at uri:classloader:/META-INF/init.rb:5
  require at org/jruby/RubyKernel.java:959
   (root) at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1
   <main> at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:55
ERROR: org.jruby.embed.EvalFailedException: (LoadError) no such file to load -- shoes
```

Done a little digging but haven't gotten a good solution to this quite yet in configuring warbler. Will see if I can get a minimal test-case together and open an issue over there to see if it's something known and/or a bug.

That said, we do have a workaround in the form of 1ec80f9b9e06c6d93666d577ff7f25df3e69c637. We only have "native extensions" to do our funky shell-script installation and avoid double-loading JRuby ([sigh](https://github.com/shoes/shoes4/blob/master/shoes-core/ext/install/Rakefile#L4)). If I can't get traction on the warbler/rubygems end of this, we could instead move the executable generation over into the `shoes` metagem, which we don't even bother pulling into our packaged apps. Then `shoes-core` could be extension-free, install happily, and no one would be the wiser. It actually makes a little sense to me that `shoes` would be the home for executable shenanigans vs `shoes-core` which is intended as the squeaky clean home for our DSL.

## Packaging detection issue
So, once dropping the extension building temporarily to get things chugging along, ran into a second snag with detecting when we're in a packaged state from the SWT app code for writing out the icon image. This changed from JRuy 1.7 to 9.x. We already properly handle it the new way elsewhere, so this will update it to be happy.

## Success?
I did get a packaged jar to actually run at the end of this. Wahoo! 🎉 🌮 💃 

## Next steps
Done for tonight, but will work next on getting a minimal duplication of our pain with `warbler` + `shoes-core`. Will probably do the move of executable fun from `shoes-core` to `shoes` in parallel on speculation since it's just mechanics.

After that, may play with testing out from a full `shoes` gem installation since there seemed to be other issues at play there related to Bundler.