### PR TITLE
Ensure Bundler is there for Warbler to use

### DIFF
--- a/shoes-package/lib/shoes/package/configuration.rb
+++ b/shoes-package/lib/shoes/package/configuration.rb
@@ -1,3 +1,4 @@
+require 'bundler'
 require 'pathname'
 require 'yaml'
 require 'furoshiki/configuration'

--- a/shoes-package/shoes-package.gemspec
+++ b/shoes-package/shoes-package.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "shoes-core", Shoes::Package::VERSION
   s.add_dependency "furoshiki", "~> 0.3.1"
+  s.add_dependency "bundler"
 end


### PR DESCRIPTION
Over in #1148 (and perhaps others... will be digging through packaging issues later today) we had problems packaging with the gem's executable because of `Bundler` not being present. I tried to fix this by doing a full `bundler/setup` but that had bad side-effects.

Turns out, the issue is just that Warbler uses some of Bundler's classes in its work, so we need to make `require 'bundler'` available, **not** a full Bundler setup.

(Possible this should be over in `furoshiki` instead, but worked nicely here for the time being)