### PR TITLE
Properly detect when running from packaged app

### DIFF
--- a/shoes-swt/lib/shoes/swt/app.rb
+++ b/shoes-swt/lib/shoes/swt/app.rb
@@ -1,7 +1,7 @@
 class Shoes
   module Swt
     shoes_icon = ::Shoes::ICON
-    if shoes_icon.include? '.jar!'
+    if shoes_icon.include? 'uri:classloader'
       ICON = File.join(Dir.tmpdir, 'shoes-icon.png').freeze
       open ICON, 'wb' do |fw|
         open shoes_icon, 'rb' do |fr|


### PR DESCRIPTION
This is an extract from #1324 to just fix our icon issue when running from the package. Because of other blockers this won't be exercisable directly, but getting it into `master` makes it simpler for us to test and resolve the other issues.