### PR TITLE
Warn on second Shoes.app invocation

### DIFF
--- a/shoes-swt/spec/shoes/swt/app_spec.rb
+++ b/shoes-swt/spec/shoes/swt/app_spec.rb
@@ -149,6 +149,17 @@ describe Shoes::Swt::App do
     end
   end
 
+  describe "when it's closed, it's closed" do
+    it "doesn't allow a second window" do
+      allow(Shoes::Swt::App).to receive(:main_app_closed?).and_return(true)
+
+      expect(Shoes.logger).to receive(:error)
+      expect_any_instance_of(Shoes::Swt::App).to receive(:exit).with(1)
+
+      Shoes::Swt::App.new(dsl)
+    end
+  end
+
   def app_with_opts(opts)
     dsl_app_double = dsl_app_with_opts(opts)
 


### PR DESCRIPTION
Fixes #1298 and #1319.

As discussed in those issues, we aren't really looking to support the pattern of having two top-level `Shoes.app` calls in an app. If you need a second window, you can always do that by calling `Shoes.app` within your app block.

This PR tracks when we close out, and if another attempt to start an app is made, we give a friendly error message and exit (with non-zero status code for you POSIX fans).