### PR TITLE
Set size when updating position too

### DIFF
--- a/shoes-swt/lib/shoes/swt/common/update_position.rb
+++ b/shoes-swt/lib/shoes/swt/common/update_position.rb
@@ -7,6 +7,10 @@ class Shoes
         def update_position
           unless @real.disposed?
             @real.set_location dsl.element_left, dsl.element_top
+
+            # Why update size too? On Mac, SWT snaps sizing to defaults after
+            # setting location for reasons I've yet to understand. #1323
+            @real.set_size dsl.element_width, dsl.element_height
           end
         end
       end


### PR DESCRIPTION
Fixes #1323

For reasons beyond my understanding, SWT on Mac seems to tweak button
heights when we `set_location` on them. Forcing the size again keeps
things happily proportioned as we'd like.

Have run through samples on the Mac and they're 👌 . ~~Checking on VMs for
other OSs to make sure this doesn't have negative side-effects there.~~
Windows and Ubuntu look good for at least a few samples with the effected
element types. Calling it 🙆 