### PR TITLE
Less git, more lists

### DIFF
--- a/shoes-core/shoes-core.gemspec
+++ b/shoes-core/shoes-core.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = "Shoes is the best little GUI toolkit for Ruby. Shoes makes building for Mac, Windows, and Linux super simple. This is the DSL for writing your app. You'll need a backend to run it."
   s.license     = 'MIT'
 
-  s.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  s.files         = Dir["LICENSE", "README.md", "ext/install/**/*", "fonts/**/*", "lib/**/*", "static/**/*"]
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 

--- a/shoes-core/shoes-core.gemspec
+++ b/shoes-core/shoes-core.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version     = Shoes::Core::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Team Shoes"]
-  s.email       = ["shoes@librelist.com"]
+  s.email       = ["shoes@lists.mvmanila.com"]
   s.homepage    = "https://github.com/shoes/shoes4"
   s.summary     = 'The best little DSL for the best little GUI toolkit for Ruby.'
   s.description = "Shoes is the best little GUI toolkit for Ruby. Shoes makes building for Mac, Windows, and Linux super simple. This is the DSL for writing your app. You'll need a backend to run it."

--- a/shoes-package/shoes-package.gemspec
+++ b/shoes-package/shoes-package.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = 'Application packaging for Shoes, the best little GUI toolkit for Ruby. Shoes makes building for Mac, Windows, and Linux super simple.'
   s.license     = 'MIT'
 
-  s.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  s.files         = Dir["LICENSE", "README.md", "lib/**/*"]
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 

--- a/shoes-package/shoes-package.gemspec
+++ b/shoes-package/shoes-package.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version     = Shoes::Package::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Team Shoes"]
-  s.email       = ["shoes@librelist.com"]
+  s.email       = ["shoes@lists.mvmanila.com"]
   s.homepage    = "https://github.com/shoes/shoes4"
   s.summary     = 'Application packaging for Shoes, the best little GUI toolkit for Ruby.'
   s.description = 'Application packaging for Shoes, the best little GUI toolkit for Ruby. Shoes makes building for Mac, Windows, and Linux super simple.'

--- a/shoes-swt/shoes-swt.gemspec
+++ b/shoes-swt/shoes-swt.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version     = Shoes::Swt::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Team Shoes"]
-  s.email       = ["shoes@librelist.com"]
+  s.email       = ["shoes@lists.mvmanila.com"]
   s.homepage    = "https://github.com/shoes/shoes4"
   s.summary     = 'A JRuby and Swt backend for Shoes, the best little GUI toolkit for Ruby.'
   s.description = 'A JRuby and Swt backend for Shoes, the best little GUI toolkit for Ruby. Shoes makes building for Mac, Windows, and Linux super simple.'

--- a/shoes-swt/shoes-swt.gemspec
+++ b/shoes-swt/shoes-swt.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = 'A JRuby and Swt backend for Shoes, the best little GUI toolkit for Ruby. Shoes makes building for Mac, Windows, and Linux super simple.'
   s.license     = 'MIT'
 
-  s.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  s.files         = Dir["LICENSE", "README.md", "lib/**/*"]
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 

--- a/shoes.gemspec
+++ b/shoes.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version     = version
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Team Shoes"]
-  s.email       = ["shoes@librelist.com"]
+  s.email       = ["shoes@lists.mvmanila.com"]
   s.homepage    = "https://github.com/shoes/shoes4"
   s.summary     = 'Shoes is the best little GUI toolkit for Ruby. Shoes runs on JRuby only for now.'
   s.description = 'Shoes is the best little GUI toolkit for Ruby. Shoes makes building for Mac, Windows, and Linux super simple. Shoes runs on JRuby only for now.'


### PR DESCRIPTION
Fixes #1226 and related to https://github.com/shoes/furoshiki/pull/22

This goes with option 2) I presented there--using `Dir` to list files instead of relying on git.

I've done a fair amount of comparison work locally, and [here's a snapshot](http://jasonrclark.com/shoes-compare.html) from my favorite diffing program (Beyond Compare) showing the diffs. Purple stuff is "orphaned" so you can see what we're dropping on the right. Empty + red + gray just has file diffs potentially, but no mismatched files.

I've chosen to drop the `spec` folder from the projects, as it's not required and just bulks things up.

Also updates some other bits of the gemspec I noticed were out of date.

I'll be doing some thorough testing of the generated gems before merging this, but don't have the time at the moment.

![image](https://cloud.githubusercontent.com/assets/130504/21279967/05c32cda-c398-11e6-9c9a-15b8b0b3d7f1.png)

## TODO

* [x] Check gem installation and samples on:
  * [x] Mac
  * [x] Linux (Ubuntu)
  * [x] Windows
* [x] Check packaging with hacked install on Mac (still pending work to get it working properly out-of-the-box)