### PR TITLE
Make arrow API compatible with Shoes 3

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -66,6 +66,8 @@ Metrics/MethodLength:
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
   Max: 267
+  Exclude:
+    - shoes-core/lib/shoes/dsl.rb
 
 # Offense count: 13
 # Configuration parameters: CountKeywordArgs.

--- a/shoes-core/lib/shoes/dsl.rb
+++ b/shoes-core/lib/shoes/dsl.rb
@@ -308,15 +308,37 @@ class Shoes
       Shoes::Sound.new @__app__, soundfile, opts, &blk
     end
 
-    # Creates an arrow centered at (left, top)
+    # Creates an arrow
     #
-    # @param [Integer] left the x-coordinate of the element center
-    # @param [Integer] top the y-coordinate of the element center
-    # @param [Integer] width width of the arrow
-    # @param [Hash] opts Arrow style options
-    # @option opts [Integer] rotate (false)
-    def arrow(left, top, width, styles = {}, &blk)
-      create Shoes::Arrow, left, top, width, styles, blk
+    # @overload arrow(left, top, width, opts)
+    #   Creates an arrow centered at (left, top)
+    #   @param [Integer] left the x-coordinate of the element center
+    #   @param [Integer] top the y-coordinate of the element center
+    #   @param [Integer] width width of the arrow
+    #   @param [Hash] opts Arrow style options
+    #   @option opts [Integer] rotate (false)
+    # @overload arrow(opts)
+    #   Creates an arrow using values from the opts Hash.
+    #   @param [Hash] opts
+    #   @option styles [Integer] left (0) the x-coordinate of the top-left corner
+    #   @option styles [Integer] top (0) the y-coordinate of the top-left corner
+    #   @option styles [Integer] width (0) the width
+    #   @option styles [Integer] rotate (false)
+    def arrow(*args, &blk)
+      opts = style_normalizer.normalize pop_style(args)
+
+      left, top, width, *leftovers = args
+
+      message = <<EOS
+Too many arguments. Must be one of:
+  - arrow(left, top, width, [opts])
+  - arrow(left, top, [opts])
+  - arrow(left, [opts])
+  - arrow([opts])
+EOS
+      raise ArgumentError, message if leftovers.any?
+
+      create Shoes::Arrow, left, top, width, opts, blk
     end
 
     # Creates an arc at (left, top)

--- a/shoes-core/lib/shoes/dsl.rb
+++ b/shoes-core/lib/shoes/dsl.rb
@@ -314,7 +314,7 @@ class Shoes
     #   Creates an arrow centered at (left, top)
     #   @param [Integer] left the x-coordinate of the element center
     #   @param [Integer] top the y-coordinate of the element center
-    #   @param [Integer] width width of the arrow
+    #   @param [Integer] width the width of the arrow
     #   @param [Hash] opts Arrow style options
     #   @option opts [Integer] rotate (false)
     # @overload arrow(opts)

--- a/shoes-core/spec/shoes/shared_examples/dsl.rb
+++ b/shoes-core/spec/shoes/shared_examples/dsl.rb
@@ -11,6 +11,7 @@ shared_examples "DSL container" do
   %w(
     animate
     arc
+    arrow
     background
     button
     border

--- a/shoes-core/spec/shoes/shared_examples/dsl/arrow.rb
+++ b/shoes-core/spec/shoes/shared_examples/dsl/arrow.rb
@@ -1,96 +1,65 @@
-shared_examples_for "arrow dimensions" do
-  it "makes a Shoes::Arrow" do
-    expect(arrow).to be_an_instance_of(Shoes::Arrow)
-  end
-
-  it "sets proper dimensions" do
-    expect(arrow.left).to eq(left)
-    expect(arrow.top).to eq(top)
-    expect(arrow.width).to eq(width)
-  end
-end
-
 shared_examples_for "arrow DSL method" do
-  let(:left)   { 40 }
-  let(:top)    { 30 }
-  let(:width)  { 12 }
-
-  context "no arguments" do
-    subject(:arrow) { dsl.arrow }
-
-    let(:left)  { 0 }
-    let(:top)   { 0 }
-    let(:width) { 0 }
-
-    include_examples "arrow dimensions"
+  it "takes no arguments" do
+    arrow = dsl.arrow
+    expect(arrow).to have_attributes(left: 0,
+                                     top: 0,
+                                     width: 0)
   end
 
-  context "from 1 argument" do
-    subject(:arrow) { dsl.arrow left }
-
-    let(:top)   { 0 }
-    let(:width) { 0 }
-
-    include_examples "arrow dimensions"
+  it "takes 1 argument" do
+    arrow = dsl.arrow 40
+    expect(arrow).to have_attributes(left: 40,
+                                     top: 0,
+                                     width: 0)
   end
 
-  context "from 1 argument with options" do
-    subject(:arrow) { dsl.arrow left, top: top }
-
-    let(:width) { 0 }
-
-    include_examples "arrow dimensions"
+  it "takes 1 argument with options" do
+    arrow = dsl.arrow 40, top: 50
+    expect(arrow).to have_attributes(left: 40,
+                                     top: 50,
+                                     width: 0)
   end
 
-  context "from 2 argument" do
-    subject(:arrow) { dsl.arrow left, top }
-
-    let(:width) { 0 }
-
-    include_examples "arrow dimensions"
+  it "takes 2 arguments" do
+    arrow = dsl.arrow 40, 50
+    expect(arrow).to have_attributes(left: 40,
+                                     top: 50,
+                                     width: 0)
   end
 
-  context "from 2 argument with options" do
-    subject(:arrow) { dsl.arrow left, top, width: width }
-
-    include_examples "arrow dimensions"
+  it "takes 2 arguments with options" do
+    arrow = dsl.arrow 40, 50, width: 100
+    expect(arrow).to have_attributes(left: 40,
+                                     top: 50,
+                                     width: 100)
   end
 
-  context "from 3 arguments" do
-    subject(:arrow) { dsl.arrow left, top, width }
-
-    include_examples "arrow dimensions"
+  it "takes 3 arguments" do
+    arrow = dsl.arrow 40, 50, 100
+    expect(arrow).to have_attributes(left: 40,
+                                     top: 50,
+                                     width: 100)
   end
 
-  context "from 3 arguments with options" do
-    subject(:arrow) { dsl.arrow left, top, width, left: -1, top: -2, width: -3 }
-
-    include_examples "arrow dimensions"
+  it "takes 3 arguments with options" do
+    arrow = dsl.arrow 40, 50, 100, left: -1, top: -2, width: -3
+    expect(arrow).to have_attributes(left: 40,
+                                     top: 50,
+                                     width: 100)
   end
 
-  context "from style hash" do
-    subject(:arrow) { dsl.arrow left: left, top: top, width: width }
-
-    include_examples "arrow dimensions"
+  it "takes styles hash" do
+    arrow = dsl.arrow left: 40, top: 50, width: 100
+    expect(arrow).to have_attributes(left: 40,
+                                     top: 50,
+                                     width: 100)
   end
 
-  context "too many arguments" do
-    subject(:arrow) { dsl.arrow left, top, width, oops }
-
-    let(:oops) { 42 }
-
-    it "won't accept that" do
-      expect { subject }.to raise_error(ArgumentError)
-    end
+  it "doesn't like too many arguments" do
+    expect { dsl.arrow 40, 50, 100, 666 }.to raise_error(ArgumentError)
   end
 
-  context "too many arguments and options too!" do
-    subject(:arrow) { dsl.arrow left, top, width, oops, left: -1 }
-
-    let(:oops) { 42 }
-
-    it "won't accept that" do
-      expect { subject }.to raise_error(ArgumentError)
-    end
+  it "doesn't like too many arguments and options too!" do
+    expect { dsl.arrow 40, 50, 100, 666, left: -1 }.to raise_error(ArgumentError)
   end
 end

--- a/shoes-core/spec/shoes/shared_examples/dsl/arrow.rb
+++ b/shoes-core/spec/shoes/shared_examples/dsl/arrow.rb
@@ -1,0 +1,96 @@
+shared_examples_for "arrow dimensions" do
+  it "makes a Shoes::Arrow" do
+    expect(arrow).to be_an_instance_of(Shoes::Arrow)
+  end
+
+  it "sets proper dimensions" do
+    expect(arrow.left).to eq(left)
+    expect(arrow.top).to eq(top)
+    expect(arrow.width).to eq(width)
+  end
+end
+
+shared_examples_for "arrow DSL method" do
+  let(:left)   { 40 }
+  let(:top)    { 30 }
+  let(:width)  { 12 }
+
+  context "no arguments" do
+    subject(:arrow) { dsl.arrow }
+
+    let(:left)  { 0 }
+    let(:top)   { 0 }
+    let(:width) { 0 }
+
+    include_examples "arrow dimensions"
+  end
+
+  context "from 1 argument" do
+    subject(:arrow) { dsl.arrow left }
+
+    let(:top)   { 0 }
+    let(:width) { 0 }
+
+    include_examples "arrow dimensions"
+  end
+
+  context "from 1 argument with options" do
+    subject(:arrow) { dsl.arrow left, top: top }
+
+    let(:width) { 0 }
+
+    include_examples "arrow dimensions"
+  end
+
+  context "from 2 argument" do
+    subject(:arrow) { dsl.arrow left, top }
+
+    let(:width) { 0 }
+
+    include_examples "arrow dimensions"
+  end
+
+  context "from 2 argument with options" do
+    subject(:arrow) { dsl.arrow left, top, width: width }
+
+    include_examples "arrow dimensions"
+  end
+
+  context "from 3 arguments" do
+    subject(:arrow) { dsl.arrow left, top, width }
+
+    include_examples "arrow dimensions"
+  end
+
+  context "from 3 arguments with options" do
+    subject(:arrow) { dsl.arrow left, top, width, left: -1, top: -2, width: -3 }
+
+    include_examples "arrow dimensions"
+  end
+
+  context "from style hash" do
+    subject(:arrow) { dsl.arrow left: left, top: top, width: width }
+
+    include_examples "arrow dimensions"
+  end
+
+  context "too many arguments" do
+    subject(:arrow) { dsl.arrow left, top, width, oops }
+
+    let(:oops) { 42 }
+
+    it "won't accept that" do
+      expect { subject }.to raise_error(ArgumentError)
+    end
+  end
+
+  context "too many arguments and options too!" do
+    subject(:arrow) { dsl.arrow left, top, width, oops, left: -1 }
+
+    let(:oops) { 42 }
+
+    it "won't accept that" do
+      expect { subject }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1332 

As reported in that issue, we had some incompatibilities with the Shoes 3 API on `arrow`. In particular, tutorials called it with just an options hash which Shoes 4 wasn't allowing. ⬇️ 

Turns out on further testing Shoes 3 allows any number of arguments you want! Values that aren't provided explicitly are defaulted to what's in the options hash (and treated as 0/false if missing from there). :zero: 

I've allowed some of that flexibility, but deviated in one spot from precisely matching Shoes 3. If you provide *too many* explicit arguments, I'll give you an `ArgumentError`. It seems kinder than allowing blatantly bad data. 🔪 

I also chose in the method docs not to individually call out every variation that's actually supported, but just the full and options-only flavors. 📚 

Note that the behavior I saw when not giving enough args (where the arrow was "invisible") is just a consequence of the `width` being 0. I didn't even need to code anything explicitly to get Shoes 4 behaving the same--it just fell out of the implementation. 🎉 

This was partially missed because I neglected to add DSL specs for `arrow` (d'oh!) which I've added in all their spec-ish glory. 👼 

Based on @snood1205's fine footwork on the tutorial, I suspect that even the DSL methods we've got covered by specs have gaps though. Before `pre8` I'm going to do a comprehensive survey of all of them and get our 🏠 in order once and for all.