### PR TITLE
Chain off click and release methods

### DIFF
--- a/shoes-core/lib/shoes/button.rb
+++ b/shoes-core/lib/shoes/button.rb
@@ -1,9 +1,13 @@
 class Shoes
   class Button
     include Common::UIElement
-    include Common::Style
     include Common::Clickable
+    include Common::Style
     include Common::State
+
+    # We don't actually support release from buttons, but want to use the
+    # shared infrastructure for clicking. So just get rid of release post def.
+    undef release
 
     style_with :click, :common_styles, :dimensions, :state, :text
 

--- a/shoes-core/lib/shoes/common/clickable.rb
+++ b/shoes-core/lib/shoes/common/clickable.rb
@@ -5,10 +5,12 @@ class Shoes
 
       def click(&blk)
         @gui.click blk
+        self
       end
 
       def release(&blk)
         @gui.release blk
+        self
       end
 
       def register_click(blk = nil)

--- a/shoes-core/lib/shoes/link.rb
+++ b/shoes-core/lib/shoes/link.rb
@@ -14,12 +14,12 @@ class Shoes
       style_init styles
       @gui = Shoes.backend_for self
 
-      setup_click blk
+      register_click blk
       super texts, @style
     end
 
     # Doesn't use Common::Clickable because of URL flavor option clicks
-    def setup_click(blk)
+    def register_click(blk)
       if blk.nil?
         blk = if @style[:click].respond_to? :call
                 @style[:click]
@@ -35,6 +35,12 @@ class Shoes
     def click(&blk)
       @gui.click blk if blk
       @blk = blk
+      self
+    end
+
+    def release(&blk)
+      @gui.release blk if blk
+      self
     end
 
     def pass_coordinates?

--- a/shoes-core/lib/shoes/mock/app.rb
+++ b/shoes-core/lib/shoes/mock/app.rb
@@ -44,6 +44,12 @@ class Shoes
 
       def wait_until_closed
       end
+
+      def click(_blk)
+      end
+
+      def release(_blk)
+      end
     end
   end
 end

--- a/shoes-core/lib/shoes/mock/clickable.rb
+++ b/shoes-core/lib/shoes/mock/clickable.rb
@@ -3,6 +3,9 @@ class Shoes
     module Clickable
       def click(_blk)
       end
+
+      def release(_blk)
+      end
     end
   end
 end

--- a/shoes-core/spec/shoes/arc_spec.rb
+++ b/shoes-core/spec/shoes/arc_spec.rb
@@ -18,6 +18,7 @@ describe Shoes::Arc do
       let(:subject_without_style) { Shoes::Arc.new(app, parent, left, top, width, height, start_angle, end_angle) }
       let(:subject_with_style) { Shoes::Arc.new(app, parent, left, top, width, height, start_angle, end_angle, arg_styles) }
     end
+    it_behaves_like "clickable object"
     it_behaves_like "object with dimensions"
     it_behaves_like "left, top as center", :start_angle, :end_angle
     it_behaves_like "object with parent"

--- a/shoes-core/spec/shoes/arrow_spec.rb
+++ b/shoes-core/spec/shoes/arrow_spec.rb
@@ -21,6 +21,7 @@ describe Shoes::Arrow do
     let(:subject_without_style) { Shoes::Arrow.new(app, parent, left, top, width) }
     let(:subject_with_style) { Shoes::Arrow.new(app, parent, left, top, width, arg_styles) }
   end
+  it_behaves_like "clickable object"
   it_behaves_like "object with dimensions"
   it_behaves_like "movable object"
   it_behaves_like 'object with parent'

--- a/shoes-core/spec/shoes/button_spec.rb
+++ b/shoes-core/spec/shoes/button_spec.rb
@@ -55,7 +55,7 @@ describe Shoes::Button do
 
   describe "no release" do
     it "doesn't allow releasing despite allowing clicks" do
-      expect { subject.release {} }.to raise_error(NoMethodError)
+      expect(subject).not_to respond_to(:release)
     end
   end
 end

--- a/shoes-core/spec/shoes/button_spec.rb
+++ b/shoes-core/spec/shoes/button_spec.rb
@@ -52,4 +52,10 @@ describe Shoes::Button do
     subject { Shoes::Button.new(app, parent, "text", negative_opts, input_block) }
     it_behaves_like "object with negative dimensions"
   end
+
+  describe "no release" do
+    it "doesn't allow releasing despite allowing clicks" do
+      expect { subject.release {} }.to raise_error(NoMethodError)
+    end
+  end
 end

--- a/shoes-core/spec/shoes/image_spec.rb
+++ b/shoes-core/spec/shoes/image_spec.rb
@@ -24,6 +24,7 @@ describe Shoes::Image do
     it_behaves_like "movable object"
     it_behaves_like "object with dimensions"
     it_behaves_like "object with hover"
+    it_behaves_like "clickable object"
 
     it_behaves_like "object with style" do
       let(:subject_without_style) { Shoes::Image.new(app, parent, filename) }

--- a/shoes-core/spec/shoes/internal_app_spec.rb
+++ b/shoes-core/spec/shoes/internal_app_spec.rb
@@ -5,6 +5,8 @@ describe Shoes::InternalApp do
 
   subject { app }
 
+  it_behaves_like "clickable object"
+
   describe "#initialize" do
     context "with defaults" do
       let(:defaults) { Shoes::InternalApp::DEFAULT_OPTIONS }

--- a/shoes-core/spec/shoes/line_spec.rb
+++ b/shoes-core/spec/shoes/line_spec.rb
@@ -18,6 +18,7 @@ describe Shoes::Line do
     it_behaves_like "object with dimensions"
     it_behaves_like "object with parent"
     it_behaves_like "object with hover"
+    it_behaves_like "clickable object"
   end
 
   describe "line with point a at leftmost, topmost" do

--- a/shoes-core/spec/shoes/link_spec.rb
+++ b/shoes-core/spec/shoes/link_spec.rb
@@ -33,6 +33,7 @@ describe Shoes::Link do
   end
 
   it_behaves_like "object with hover"
+  it_behaves_like "clickable object"
 
   context "initialize" do
     it "should set up text" do

--- a/shoes-core/spec/shoes/oval_spec.rb
+++ b/shoes-core/spec/shoes/oval_spec.rb
@@ -19,6 +19,7 @@ describe Shoes::Oval do
     it_behaves_like "left, top as center"
     it_behaves_like "object with parent"
     it_behaves_like "object with hover"
+    it_behaves_like "clickable object"
 
     # it_styles_with :art_styles, :center, :dimensions, :radius
   end

--- a/shoes-core/spec/shoes/rect_spec.rb
+++ b/shoes-core/spec/shoes/rect_spec.rb
@@ -37,4 +37,5 @@ describe Shoes::Rect do
   it_behaves_like "left, top as center"
   it_behaves_like 'object with parent'
   it_behaves_like "object with hover"
+  it_behaves_like "clickable object"
 end

--- a/shoes-core/spec/shoes/shared_examples/clickable.rb
+++ b/shoes-core/spec/shoes/shared_examples/clickable.rb
@@ -2,4 +2,18 @@ shared_examples "clickable object" do
   it { is_expected.to respond_to :click }
   it { is_expected.to respond_to :release }
   it { is_expected.to respond_to :register_click }
+
+  it "can chain click" do
+    result = subject.click do
+    end
+
+    expect(result).to eq(subject)
+  end
+
+  it "can chain release" do
+    result = subject.release do
+    end
+
+    expect(result).to eq(subject)
+  end
 end

--- a/shoes-core/spec/shoes/shared_examples/clickable.rb
+++ b/shoes-core/spec/shoes/shared_examples/clickable.rb
@@ -4,16 +4,12 @@ shared_examples "clickable object" do
   it { is_expected.to respond_to :register_click }
 
   it "can chain click" do
-    result = subject.click do
-    end
-
+    result = subject.click {}
     expect(result).to eq(subject)
   end
 
   it "can chain release" do
-    result = subject.release do
-    end
-
+    result = subject.release {}
     expect(result).to eq(subject)
   end
 end

--- a/shoes-core/spec/shoes/slot_spec.rb
+++ b/shoes-core/spec/shoes/slot_spec.rb
@@ -22,6 +22,7 @@ describe Shoes::Slot do
 
   it_behaves_like "object with dimensions"
   it_behaves_like "object with hover"
+  it_behaves_like "clickable object"
 
   it_behaves_like "object with style" do
     let(:subject_without_style) { Shoes::Slot.new(app, parent) }

--- a/shoes-core/spec/shoes/star_spec.rb
+++ b/shoes-core/spec/shoes/star_spec.rb
@@ -30,6 +30,7 @@ describe Shoes::Star do
   it_behaves_like "movable object"
   it_behaves_like 'object with parent'
   it_behaves_like "object with hover"
+  it_behaves_like "clickable object"
 
   describe "in_bounds?" do
     before do

--- a/shoes-core/spec/shoes/text_block_spec.rb
+++ b/shoes-core/spec/shoes/text_block_spec.rb
@@ -14,6 +14,7 @@ describe Shoes::TextBlock do
   end
 
   it_behaves_like "object with hover"
+  it_behaves_like "clickable object"
 
   describe "initialize" do
     it "creates gui object" do


### PR DESCRIPTION
Another fine tutorial find from @snood1205. This PR fixes #1334.

Turns out that back in Shoes 3, the `click` and `release` methods returned their target element so you could chain them. Sensible enough, but we weren't doing it.

Updated the common module for clicking to handle this and slapped the shared example for it on more elements that actually have it.

Two special cases emerged. First was `link`, which despite being the actual source of the bug in the first place doesn't use `Common::Clickable` (for fairly plausible reasons) and didn't get picked up.

Second odd turn was noticing that `Shoes::Button` used `Common::Clickable` but didn't actually support `release`. Turns out Shoes 3 didn't either on buttons (which makes good enough since... with buttons there's really just clicking them, right?) so I removed it at the DSL level so prevent you from calling things that aren't allowed.