### PR TITLE
Fix order dependency in SWT font specs

### DIFF
--- a/shoes-swt/spec/shoes/swt/font_spec.rb
+++ b/shoes-swt/spec/shoes/swt/font_spec.rb
@@ -3,7 +3,15 @@ require 'spec_helper'
 describe Shoes::Swt::Font do
   subject { Shoes::Swt::Font }
 
+  before do
+    Shoes::FONTS.clear
+  end
+
   describe 'Shoes::FONTS' do
+    before do
+      Shoes::Swt::Font.setup_fonts
+    end
+
     it 'has the FONTS array initially populared' do
       expect(Shoes::FONTS).not_to be_empty
     end


### PR DESCRIPTION
Got a failure on Travis which was from order dependencies in the font testing after we changed things around. Bummer that earlier testing didn't catch it, but ¯\_(ツ)_/¯ 

Seed values which gave us problems: 38504, 24610

EDIT: Also, first branch after I changed Travis to not build on pushes, but only on PRs. I noticed that I was spending a lot of waiting time on duplicate builds against branches I pushed up that would then rebuild for the PRs. Lighten the load for Travis, shorten my waiting 🕐 👍 