### PR TITLE
Make rotate direction compatible with Shoes 3

### DIFF
--- a/shoes-swt/lib/shoes/swt/common/painter.rb
+++ b/shoes-swt/lib/shoes/swt/common/painter.rb
@@ -80,9 +80,9 @@ class Shoes
           if block_given?
             begin
               transform = ::Swt::Transform.new Shoes.display
-              reset_rotate transform, graphics_context, angle, left, top
-              yield
               reset_rotate transform, graphics_context, -angle, left, top
+              yield
+              reset_rotate transform, graphics_context, angle, left, top
             ensure
               transform.dispose unless transform.nil? || transform.disposed?
             end

--- a/shoes-swt/lib/shoes/swt/common/painter.rb
+++ b/shoes-swt/lib/shoes/swt/common/painter.rb
@@ -80,6 +80,11 @@ class Shoes
           if block_given?
             begin
               transform = ::Swt::Transform.new Shoes.display
+
+              # Why the negative angle? Older shoes rotated from the middle
+              # right running counter clockwise (as seen on this web page:
+              # https://www.mathsisfun.com/geometry/degrees.html). To get the
+              # same effect, we have to negate the value passed in.
               reset_rotate transform, graphics_context, -angle, left, top
               yield
               reset_rotate transform, graphics_context, angle, left, top

--- a/shoes-swt/spec/shoes/swt/common/painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/common/painter_spec.rb
@@ -67,7 +67,7 @@ describe Shoes::Swt::Common::Painter do
       allow(dsl).to receive(:element_top)    { 0 }
       allow(dsl).to receive(:element_height) { 0 }
 
-      expect_transform_for_rotate
+      expect_transform_for_rotate(dsl.rotate)
 
       subject.paint_control event
     end
@@ -83,17 +83,20 @@ describe Shoes::Swt::Common::Painter do
 
   context "set_rotate" do
     it "disposes of transform" do
-      expect_transform_for_rotate
+      rotate_by = 10
+      expect_transform_for_rotate(rotate_by)
 
-      subject.set_rotate graphics_context, 0, 0, 0 do
+      subject.set_rotate graphics_context, rotate_by, 0, 0 do
         # no-op
       end
     end
   end
 
-  def expect_transform_for_rotate
+  def expect_transform_for_rotate(rotate_by)
     expect(transform).to receive(:dispose)
     expect(transform).to receive(:translate).at_least(:once)
-    expect(transform).to receive(:rotate).at_least(:once)
+
+    expect(transform).to receive(:rotate).with(-rotate_by).ordered
+    expect(transform).to receive(:rotate).with(rotate_by).ordered
   end
 end


### PR DESCRIPTION
Fixes #1288

After experimenting further with `rotate`, it's pretty plain to me that we're going the opposite direction that Shoes 3 assumes consistently for every single art element.

Anecdotally, when I googled about "rotating in degrees", the top result was https://www.mathsisfun.com/geometry/degrees.html which shows an animation working precisely how Shoes 3 does (starting from middle-right, rotating counter-clockwise with increase in degrees).

While it may be opposite of what some of us were expecting, this seems like enough of a compatibility issue that I'm willing to flip it.

This fix addresses the 3 art elements that currently support `rotate` (`rect`, `oval`, and `arrow`). Other elements that don't respond yet to `rotate` will just get addressed as they support it.