### PR TITLE
Apply rotate consistently to all art elements

### DIFF
--- a/shoes-core/lib/shoes/arc.rb
+++ b/shoes-core/lib/shoes/arc.rb
@@ -1,6 +1,6 @@
 class Shoes
   class Arc
-    include Common::UIElement
+    include Common::ArtElement
     include Common::Clickable
     include Common::Hover
     include Common::Fill

--- a/shoes-core/lib/shoes/arrow.rb
+++ b/shoes-core/lib/shoes/arrow.rb
@@ -1,6 +1,6 @@
 class Shoes
   class Arrow
-    include Common::UIElement
+    include Common::ArtElement
     include Common::Clickable
     include Common::Fill
     include Common::Hover
@@ -17,10 +17,6 @@ class Shoes
       width  ||= @style[:width] || 0
 
       @dimensions = AbsoluteDimensions.new left, top, width, width, @style
-    end
-
-    def needs_rotate?
-      rotate && rotate.nonzero?
     end
 
     def width=(*_)

--- a/shoes-core/lib/shoes/common/art_element.rb
+++ b/shoes-core/lib/shoes/common/art_element.rb
@@ -1,0 +1,8 @@
+class Shoes
+  module Common
+    module ArtElement
+      include Common::UIElement
+      include Common::Rotate
+    end
+  end
+end

--- a/shoes-core/lib/shoes/common/rotate.rb
+++ b/shoes-core/lib/shoes/common/rotate.rb
@@ -1,9 +1,8 @@
 class Shoes
   module Common
     module Rotate
-      # By default no one can rotate. Have to enable in particular classes.
       def needs_rotate?
-        false
+        rotate && rotate.nonzero?
       end
     end
   end

--- a/shoes-core/lib/shoes/common/ui_element.rb
+++ b/shoes-core/lib/shoes/common/ui_element.rb
@@ -7,8 +7,12 @@ class Shoes
       include Common::Visibility
       include Common::Positioning
       include Common::Remove
-      include Common::Rotate
       include DimensionsDelegations
+
+      # Nobody rotates by default, but we need to let you check
+      def needs_rotate?
+        false
+      end
 
       # Expected to be overridden by pulling in Common::Fill or Common::Stroke
       # if element needs to actually notify GUI classes of colors changes.

--- a/shoes-core/lib/shoes/dsl.rb
+++ b/shoes-core/lib/shoes/dsl.rb
@@ -94,6 +94,7 @@ require 'shoes/common/translate'
 require 'shoes/common/visibility'
 
 require 'shoes/common/ui_element'
+require 'shoes/common/art_element'
 
 require 'shoes/builtin_methods'
 require 'shoes/check_button'

--- a/shoes-core/lib/shoes/line.rb
+++ b/shoes-core/lib/shoes/line.rb
@@ -2,7 +2,7 @@ require 'matrix'
 
 class Shoes
   class Line
-    include Common::UIElement
+    include Common::ArtElement
     include Common::Clickable
     include Common::Hover
     include Common::Stroke

--- a/shoes-core/lib/shoes/oval.rb
+++ b/shoes-core/lib/shoes/oval.rb
@@ -1,6 +1,6 @@
 class Shoes
   class Oval
-    include Common::UIElement
+    include Common::ArtElement
     include Common::Clickable
     include Common::Fill
     include Common::Hover
@@ -18,10 +18,6 @@ class Shoes
       height ||= @style[:height] || width
 
       @dimensions = AbsoluteDimensions.new left, top, width, height, @style
-    end
-
-    def needs_rotate?
-      rotate && rotate.nonzero?
     end
   end
 end

--- a/shoes-core/lib/shoes/rect.rb
+++ b/shoes-core/lib/shoes/rect.rb
@@ -1,6 +1,6 @@
 class Shoes
   class Rect
-    include Common::UIElement
+    include Common::ArtElement
     include Common::Fill
     include Common::Stroke
     include Common::Clickable
@@ -18,10 +18,6 @@ class Shoes
       height ||= @style[:height] || width
 
       @dimensions = AbsoluteDimensions.new left, top, width, height, @style
-    end
-
-    def needs_rotate?
-      rotate && rotate.nonzero?
     end
   end
 end

--- a/shoes-core/lib/shoes/shape.rb
+++ b/shoes-core/lib/shoes/shape.rb
@@ -1,6 +1,6 @@
 class Shoes
   class Shape
-    include Common::UIElement
+    include Common::ArtElement
     include Common::Clickable
     include Common::Fill
     include Common::Stroke
@@ -38,6 +38,16 @@ class Shoes
 
     def height
       @app.height
+    end
+
+    def element_width
+      return super unless @right_bound && @left_bound
+      @right_bound - @left_bound
+    end
+
+    def element_height
+      return super unless @bottom_bound && @top_bound
+      @bottom_bound - @top_bound
     end
 
     def fixed_height?

--- a/shoes-core/lib/shoes/star.rb
+++ b/shoes-core/lib/shoes/star.rb
@@ -1,6 +1,6 @@
 class Shoes
   class Star
-    include Common::UIElement
+    include Common::ArtElement
     include Common::Clickable
     include Common::Fill
     include Common::Hover

--- a/shoes-core/spec/shoes/arc_spec.rb
+++ b/shoes-core/spec/shoes/arc_spec.rb
@@ -23,6 +23,7 @@ describe Shoes::Arc do
     it_behaves_like "left, top as center", :start_angle, :end_angle
     it_behaves_like "object with parent"
     it_behaves_like "object with hover"
+    it_behaves_like "object with rotate"
 
     # it_styles_with :art_styles, :center, :dimensions, :radius
 

--- a/shoes-core/spec/shoes/arrow_spec.rb
+++ b/shoes-core/spec/shoes/arrow_spec.rb
@@ -26,4 +26,5 @@ describe Shoes::Arrow do
   it_behaves_like "movable object"
   it_behaves_like 'object with parent'
   it_behaves_like "object with hover"
+  it_behaves_like "object with rotate"
 end

--- a/shoes-core/spec/shoes/common/rotate_spec.rb
+++ b/shoes-core/spec/shoes/common/rotate_spec.rb
@@ -1,13 +1,21 @@
 require 'spec_helper'
 
 describe Shoes::Common::Rotate do
-  let(:test_class) { Class.new { include Shoes::Common::Rotate } }
-
   subject { test_class.new }
 
   describe '#needs_rotate?' do
-    it 'defaults to falsey value' do
-      expect(subject.needs_rotate?).to be_falsey
+    let(:test_class) do
+      Class.new do
+        include Shoes::Common::Rotate
+
+        def rotate
+          45
+        end
+      end
+    end
+
+    it 'defaults to truthy value' do
+      expect(subject.needs_rotate?).to be_truthy
     end
   end
 end

--- a/shoes-core/spec/shoes/common/rotate_spec.rb
+++ b/shoes-core/spec/shoes/common/rotate_spec.rb
@@ -6,15 +6,23 @@ describe Shoes::Common::Rotate do
   describe '#needs_rotate?' do
     let(:test_class) do
       Class.new do
+        attr_accessor :rotate
         include Shoes::Common::Rotate
-
-        def rotate
-          45
-        end
       end
     end
 
-    it 'defaults to truthy value' do
+    it 'is falsey if nil' do
+      subject.rotate = nil
+      expect(subject.needs_rotate?).to be_falsey
+    end
+
+    it 'is falsey if 0' do
+      subject.rotate = 0
+      expect(subject.needs_rotate?).to be_falsey
+    end
+
+    it 'is truthy if anything else' do
+      subject.rotate = 42
       expect(subject.needs_rotate?).to be_truthy
     end
   end

--- a/shoes-core/spec/shoes/common/ui_element_spec.rb
+++ b/shoes-core/spec/shoes/common/ui_element_spec.rb
@@ -21,19 +21,12 @@ describe Shoes::Common::UIElement do
   end
 
   describe "#needs_rotate?" do
-    before do
-      # Add faux rotate accessor to prove it really doesn't support rotation
-      class << subject
-        attr_accessor :rotate
-      end
-    end
-
     it "doesn't rotate by default" do
       expect(subject.needs_rotate?).to be_falsey
     end
 
     it "still won't rotate even with a value" do
-      subject.rotate = 25
+      allow(subject).to receive(:rotate).and_return(25)
       expect(subject.needs_rotate?).to be_falsey
     end
   end

--- a/shoes-core/spec/shoes/common/ui_element_spec.rb
+++ b/shoes-core/spec/shoes/common/ui_element_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Shoes::Common::UIElement do
+  include_context "dsl app"
+
+  subject { test_class.new }
+
+  let(:test_class) do
+    Class.new do
+      include Shoes::Common::UIElement
+
+      # Override UIElement's Initialization include for simpler testing
+      def initialize
+      end
+    end
+  end
+
+  describe "stubbed updates" do
+    it { is_expected.to respond_to(:update_fill) }
+    it { is_expected.to respond_to(:update_stroke) }
+  end
+
+  describe "#needs_rotate?" do
+    before do
+      # Add faux rotate accessor to prove it really doesn't support rotation
+      class << subject
+        attr_accessor :rotate
+      end
+    end
+
+    it "doesn't rotate by default" do
+      expect(subject.needs_rotate?).to be_falsey
+    end
+
+    it "still won't rotate even with a value" do
+      subject.rotate = 25
+      expect(subject.needs_rotate?).to be_falsey
+    end
+  end
+end

--- a/shoes-core/spec/shoes/line_spec.rb
+++ b/shoes-core/spec/shoes/line_spec.rb
@@ -18,6 +18,7 @@ describe Shoes::Line do
     it_behaves_like "object with dimensions"
     it_behaves_like "object with parent"
     it_behaves_like "object with hover"
+    it_behaves_like "object with rotate"
     it_behaves_like "clickable object"
   end
 

--- a/shoes-core/spec/shoes/oval_spec.rb
+++ b/shoes-core/spec/shoes/oval_spec.rb
@@ -19,6 +19,7 @@ describe Shoes::Oval do
     it_behaves_like "left, top as center"
     it_behaves_like "object with parent"
     it_behaves_like "object with hover"
+    it_behaves_like "object with rotate"
     it_behaves_like "clickable object"
 
     # it_styles_with :art_styles, :center, :dimensions, :radius

--- a/shoes-core/spec/shoes/rect_spec.rb
+++ b/shoes-core/spec/shoes/rect_spec.rb
@@ -37,5 +37,6 @@ describe Shoes::Rect do
   it_behaves_like "left, top as center"
   it_behaves_like 'object with parent'
   it_behaves_like "object with hover"
+  it_behaves_like "object with rotate"
   it_behaves_like "clickable object"
 end

--- a/shoes-core/spec/shoes/shape_spec.rb
+++ b/shoes-core/spec/shoes/shape_spec.rb
@@ -17,6 +17,7 @@ describe Shoes::Shape do
 
   it_behaves_like "movable object"
   it_behaves_like "clickable object"
+  it_behaves_like "object with rotate"
 
   describe "octagon" do
     let(:draw) do

--- a/shoes-core/spec/shoes/shared_examples/rotate.rb
+++ b/shoes-core/spec/shoes/shared_examples/rotate.rb
@@ -1,6 +1,11 @@
 shared_examples "object with rotate" do
-  it "only rotates when necessary" do
+  it "doesn't rotate on nil" do
     subject.rotate = nil
+    expect(subject.needs_rotate?).to be_falsey
+  end
+
+  it "doesn't rotate on zero" do
+    subject.rotate = 0
     expect(subject.needs_rotate?).to be_falsey
   end
 

--- a/shoes-core/spec/shoes/shared_examples/rotate.rb
+++ b/shoes-core/spec/shoes/shared_examples/rotate.rb
@@ -1,0 +1,11 @@
+shared_examples "object with rotate" do
+  it "only rotates when necessary" do
+    subject.rotate = nil
+    expect(subject.needs_rotate?).to be_falsey
+  end
+
+  it "needs to rotate" do
+    subject.rotate = 10
+    expect(subject.needs_rotate?).to be_truthy
+  end
+end

--- a/shoes-core/spec/shoes/star_spec.rb
+++ b/shoes-core/spec/shoes/star_spec.rb
@@ -30,6 +30,7 @@ describe Shoes::Star do
   it_behaves_like "movable object"
   it_behaves_like 'object with parent'
   it_behaves_like "object with hover"
+  it_behaves_like "object with rotate"
   it_behaves_like "clickable object"
 
   describe "in_bounds?" do


### PR DESCRIPTION
Fixes #699

Previously the kind of odd `Shoes::Common::Rotate` module would give you the required method `needs_rotate?`, but only to return false. You had to re-plumb that method yourself to actually rotate (which `rect`, `oval` and `arrow` did, but other art elements did not).

I've flipped that now so `Shoes::Common::Rotate` actually supports real rotation, and we have a stubbed `needs_rotate?` that returns false on `UIElement` as the fallback instead.

As part of this, I also did something I'd wanted to for a while--started a new `ArtElement` module which can apply common across, not-surprisingly, the art elements :)  Follow-on work will be coming to make better use of this, but for now it lets us easily plumb rotation across the elements.