### PR TITLE
Fix good_vjot sample

### DIFF
--- a/samples/good_vjot.rb
+++ b/samples/good_vjot.rb
@@ -16,7 +16,8 @@ There is no save button, the jot is saved as you edit.
 END
 
 Shoes.app title: "vJot", width: 420, height: 560, resizable: false do
-  @note = NOTES.first
+  @notes = NOTES.dup
+  @note = @notes.first
   background "#C7EAFB"
   stack width: 400, margin: 20 do
     background "#eee", curve: 12
@@ -37,7 +38,7 @@ Shoes.app title: "vJot", width: 420, height: 560, resizable: false do
   end
 
   def load_list
-    note_list = NOTES.map do |note|
+    note_list = @notes.map do |note|
       [
         link(note.first) do
           @note = load_note(note)
@@ -46,7 +47,7 @@ Shoes.app title: "vJot", width: 420, height: 560, resizable: false do
         "\n"
       ]
     end.flatten + [link("+ Add a new Note") do
-      NOTES << (@note = load_note)
+      @notes << (@note = load_note)
       load_list
     end]
     @list.replace(*note_list)


### PR DESCRIPTION
Frozen 'constant' array failing on adding items.

Busted in [this commit](https://github.com/shoes/shoes4/commit/8af1e4186473453492ed12de4cc58d2310b4ca4f#diff-b7697dc18827e4c188df0bbfc65896beR1) but requires a click to show its wrong so I've missed it in prior sample run-throughs. :man_shrugging: 