### PR TITLE
Bump furoshiki to 0.4.0

### DIFF
--- a/shoes-package/shoes-package.gemspec
+++ b/shoes-package/shoes-package.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "shoes-core", Shoes::Package::VERSION
-  s.add_dependency "furoshiki", "~> 0.3.1"
+  s.add_dependency "furoshiki", "~> 0.4.0"
   s.add_dependency "bundler"
 end


### PR DESCRIPTION
Released the [latest of the `furoshiki` gem](https://rubygems.org/gems/furoshiki/versions/0.4.0), pick that up for use from Shoes!