### PR TITLE
Changelog dates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-v4.0.0.pre7 (192 commits)
+v4.0.0.pre7 (192 commits) (Dec 10, 2016)
 -------------------------------
 
 Improvements (3)
@@ -26,7 +26,7 @@ Jared Moody, Jason R. Clark, Tobias Pfeiffer
 
 
 
-v4.0.0.pre6 (33 commits)
+v4.0.0.pre6 (33 commits) (Nov 6, 2016)
 ------------------------------
 
 Improvements (3)
@@ -55,7 +55,7 @@ Fidelis, Roden Monte, Tobias Pfeiffer, Wayne Vucenic
 
 
 
-v4.0.0.pre5 (125 commits)
+v4.0.0.pre5 (125 commits) (Dec 13, 2015)
 ------------------------------
 
 Improvements (10)
@@ -96,7 +96,7 @@ McCormack, Rin Raeuber
 
 
 
-4.0.0.pre4 (170 commits)
+4.0.0.pre4 (170 commits) (May 15, 2015)
 -------------------------------
 
 This release saw a lot of bug fixing, but no big structural changes (hurray!).
@@ -151,7 +151,7 @@ Thomas Graves, David English, Emily Bookstein, bx10000, matugm, Tyler Lemburg
 
 
 
-4.0.0.pre3 (199 commits)
+4.0.0.pre3 (199 commits) (Jan 6, 2015)
 ------------------------
 
 New features (1)
@@ -207,7 +207,7 @@ Jake Gordon, Neil Northrop
 
 
 
-4.0.0.pre2 (438 commits)
+4.0.0.pre2 (438 commits) (Oct 14, 2014)
 ----------------
 
 New features (1)

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -21,7 +21,10 @@ class Changelog
   private
 
   def changelog_header(commit_range)
-    heading = "SINCE #{last_release} (#{commit_count(commit_range)} commits)\n"
+    date = Time.now.strftime("%b %-d, %Y")
+    count = commit_count(commit_range)
+
+    heading = "SINCE #{last_release} (#{count} commits) (#{date})\n"
     heading += "-" * (heading.length - 1)
 
     [heading]


### PR DESCRIPTION
Fixes #1359

Backdates all the old releases, adds auto-generation to the changelog task.