### PR TITLE
Line element compatibility with Shoes 3

### DIFF
--- a/shoes-core/lib/shoes/dsl.rb
+++ b/shoes-core/lib/shoes/dsl.rb
@@ -364,8 +364,35 @@ EOS
     # @param [Integer] x2 The x-value of point B
     # @param [Integer] y2 The y-value of point B
     # @param [Hash] opts Style options
-    def line(x1, y1, x2, y2, styles = {}, &blk)
-      create Shoes::Line, Shoes::Point.new(x1, y1), Shoes::Point.new(x2, y2), styles, blk
+    def line(*args, &blk)
+      opts = style_normalizer.normalize pop_style(args)
+
+      x1, y1, x2, y2, *leftovers = args
+
+      x1 ||= opts[:left] || 0
+      y1 ||= opts[:top]  || 0
+
+      x2 ||= opts[:right]
+      if x2
+        # With 3 arguments, draws horizontal line, so fallback to y1
+        y2 ||= opts[:bottom] || y1
+      else
+        # If didn't get needed arguments, set start to end which draws nothing
+        x2 = x1
+        y2 = y1
+      end
+
+      message = <<EOS
+Too many arguments. Must be one of:
+  - line(x1, y1, x2, y2, [opts])
+  - line(x1, y1, x2, [opts])
+  - line(x1, y1, [opts])
+  - line(x1, [opts])
+  - line([opts])
+EOS
+      raise ArgumentError, message if leftovers.any?
+
+      create Shoes::Line, Shoes::Point.new(x1, y1), Shoes::Point.new(x2, y2), opts, blk
     end
 
     # Creates an oval at (left, top)

--- a/shoes-core/lib/shoes/dsl.rb
+++ b/shoes-core/lib/shoes/dsl.rb
@@ -369,19 +369,6 @@ EOS
 
       x1, y1, x2, y2, *leftovers = args
 
-      x1 ||= opts[:left] || 0
-      y1 ||= opts[:top]  || 0
-
-      x2 ||= opts[:right]
-      if x2
-        # With 3 arguments, draws horizontal line, so fallback to y1
-        y2 ||= opts[:bottom] || y1
-      else
-        # If didn't get needed arguments, set start to end which draws nothing
-        x2 = x1
-        y2 = y1
-      end
-
       message = <<EOS
 Too many arguments. Must be one of:
   - line(x1, y1, x2, y2, [opts])
@@ -392,7 +379,7 @@ Too many arguments. Must be one of:
 EOS
       raise ArgumentError, message if leftovers.any?
 
-      create Shoes::Line, Shoes::Point.new(x1, y1), Shoes::Point.new(x2, y2), opts, blk
+      create Shoes::Line, x1, y1, x2, y2, opts, blk
     end
 
     # Creates an oval at (left, top)

--- a/shoes-core/lib/shoes/line.rb
+++ b/shoes-core/lib/shoes/line.rb
@@ -9,14 +9,33 @@ class Shoes
     style_with :angle, :art_styles, :dimensions, :x2, :y2
     STYLES = { angle: 0, fill: Shoes::COLORS[:black] }.freeze
 
-    def create_dimensions(point_a, point_b)
-      @point_a = point_a
-      @point_b = point_b
+    def create_dimensions(x1, y1, x2, y2)
+      x1, y1, x2, y2 = default_coordinates(x1, y1, x2, y2)
+
+      @point_a = Shoes::Point.new(x1, y1)
+      @point_b = Shoes::Point.new(x2, y2)
 
       enclosing_box_of_line
 
-      style[:x2] = point_b.x
-      style[:y2] = point_b.y
+      style[:x2] = @point_b.x
+      style[:y2] = @point_b.y
+    end
+
+    def default_coordinates(x1, y1, x2, y2)
+      x1 ||= @style[:left] || 0
+      y1 ||= @style[:top]  || 0
+
+      x2 ||= @style[:right]
+      if x2
+        # With 3 arguments, draws horizontal line, so fallback to y1
+        y2 ||= @style[:bottom] || y1
+      else
+        # If didn't get needed arguments, set start to end which draws nothing
+        x2 = x1
+        y2 = y1
+      end
+
+      [x1, y1, x2, y2]
     end
 
     # Check out http://math.stackexchange.com/questions/60070/checking-whether-a-point-lies-on-a-wide-line-segment

--- a/shoes-core/spec/shoes/line_spec.rb
+++ b/shoes-core/spec/shoes/line_spec.rb
@@ -114,4 +114,102 @@ describe Shoes::Line do
       expect(line.in_bounds?(70, 50)).to be true
     end
   end
+
+  describe "dsl" do
+    it "takes no arguments" do
+      line = dsl.line
+      expect(line).to have_attributes(left: 0,
+                                      top: 0,
+                                      right: 0,
+                                      bottom: 0)
+    end
+
+    it "takes 1 argument" do
+      line = dsl.line 10
+      expect(line).to have_attributes(left: 10,
+                                      top: 0,
+                                      right: 10,
+                                      bottom: 0)
+    end
+
+    it "takes 1 argument with hash" do
+      line = dsl.line 10, top: 20, right: 30, bottom: 40
+      expect(line).to have_attributes(left: 10,
+                                      top: 20,
+                                      right: 30,
+                                      bottom: 40)
+    end
+
+    it "takes 2 arguments" do
+      line = dsl.line 10, 20
+      expect(line).to have_attributes(left: 10,
+                                      top: 20,
+                                      right: 10,
+                                      bottom: 20)
+    end
+
+    it "takes 2 arguments with hash" do
+      line = dsl.line 10, 20, right: 30, bottom: 40
+      expect(line).to have_attributes(left: 10,
+                                      top: 20,
+                                      right: 30,
+                                      bottom: 40)
+    end
+
+    it "takes 2 arguments with hash side" do
+      line = dsl.line 10, 20, right: 30
+      expect(line).to have_attributes(left: 10,
+                                      top: 20,
+                                      right: 30,
+                                      bottom: 20)
+    end
+
+    it "takes 3 arguments" do
+      line = dsl.line 10, 20, 30
+      expect(line).to have_attributes(left: 10,
+                                      top: 20,
+                                      right: 30,
+                                      bottom: 20)
+    end
+
+    it "takes 3 arguments with hash" do
+      line = dsl.line 10, 20, 30, bottom: 40
+      expect(line).to have_attributes(left: 10,
+                                      top: 20,
+                                      right: 30,
+                                      bottom: 40)
+    end
+
+    it "takes 4 arguments" do
+      line = dsl.line 10, 20, 30, 40
+      expect(line).to have_attributes(left: 10,
+                                      top: 20,
+                                      right: 30,
+                                      bottom: 40)
+    end
+
+    it "takes 4 arguments with hash" do
+      line = dsl.line 10, 20, 30, 40, left: -1, top: -2, right: -3, bottom: -4
+      expect(line).to have_attributes(left: 10,
+                                      top: 20,
+                                      right: 30,
+                                      bottom: 40)
+    end
+
+    it "takes styles hash" do
+      line = dsl.line left: 10, top: 20, right: 30, bottom: 40
+      expect(line).to have_attributes(left: 10,
+                                      top: 20,
+                                      right: 30,
+                                      bottom: 40)
+    end
+
+    it "doesn't like too many arguments" do
+      expect { dsl.line 10, 20, 30, 40, 666 }.to raise_error(ArgumentError)
+    end
+
+    it "doesn't like too many arguments and options too!" do
+      expect { dsl.line 10, 20, 30, 40, 666, left: -1 }.to raise_error(ArgumentError)
+    end
+  end
 end

--- a/shoes-core/spec/shoes/line_spec.rb
+++ b/shoes-core/spec/shoes/line_spec.rb
@@ -9,16 +9,16 @@ describe Shoes::Line do
     let(:width) { 280 }
     let(:height) { 407 }
 
-    subject { Shoes::Line.new(app, parent, Shoes::Point.new(left, top), Shoes::Point.new(300, 430), input_opts) }
+    subject { Shoes::Line.new(app, parent, left, top, 300, 430, input_opts) }
 
     it_behaves_like "an art element" do
-      let(:subject_without_style) { Shoes::Line.new(app, parent, Shoes::Point.new(left, top), Shoes::Point.new(300, 430)) }
-      let(:subject_with_style) { Shoes::Line.new(app, parent, Shoes::Point.new(left, top), Shoes::Point.new(300, 430), arg_styles) }
+      let(:subject_without_style) { Shoes::Line.new(app, parent, left, top, 300, 430) }
+      let(:subject_with_style) { Shoes::Line.new(app, parent, left, top, 300, 430, arg_styles) }
     end
   end
 
   describe "line with point a at leftmost, topmost" do
-    subject { Shoes::Line.new(app, app, Shoes::Point.new(10, 15), Shoes::Point.new(100, 60), input_opts) }
+    subject { Shoes::Line.new(app, app, 10, 15, 100, 60, input_opts) }
     its(:left)   { should eq(10) }
     its(:top)    { should eq(15) }
     its(:right)  { should eq(100) }
@@ -28,7 +28,7 @@ describe Shoes::Line do
   end
 
   describe "specified right-to-left, top-to-bottom" do
-    subject { Shoes::Line.new(app, app, Shoes::Point.new(100, 60), Shoes::Point.new(10, 15), input_opts) }
+    subject { Shoes::Line.new(app, app, 100, 60, 10, 15, input_opts) }
     its(:left)   { should eq(100) }
     its(:top)    { should eq(60) }
     its(:right)  { should eq(10) }
@@ -38,7 +38,7 @@ describe Shoes::Line do
   end
 
   describe "setting dimensions" do
-    subject { Shoes::Line.new(app, app, Shoes::Point.new(100, 100), Shoes::Point.new(200, 200), input_opts) }
+    subject { Shoes::Line.new(app, app, 100, 100, 200, 200, input_opts) }
 
     it "moves point a with left and top" do
       subject.left -= 100
@@ -84,7 +84,7 @@ describe Shoes::Line do
   end
 
   describe "#in_bounds?" do
-    subject(:line) { Shoes::Line.new(app, app, Shoes::Point.new(100, 100), Shoes::Point.new(50, 50), input_opts) }
+    subject(:line) { Shoes::Line.new(app, app, 100, 100, 50, 50, input_opts) }
 
     it "returns true if a point is in the end of the line" do
       expect(subject.in_bounds?(100, 100)).to be true
@@ -103,7 +103,7 @@ describe Shoes::Line do
     end
 
     it "takes into account :strokewidth style" do
-      line = Shoes::Line.new(app, app, Shoes::Point.new(50, 50), Shoes::Point.new(70, 50), input_opts)
+      line = Shoes::Line.new(app, app, 50, 50, 70, 50, input_opts)
       line.style(strokewidth: 20)
       expect(line.in_bounds?(50, 52)).to be true
       expect(line.in_bounds?(50, 48)).to be true

--- a/shoes-core/spec/shoes/shared_examples/dsl.rb
+++ b/shoes-core/spec/shoes/shared_examples/dsl.rb
@@ -20,7 +20,6 @@ shared_examples "DSL container" do
     flow
     gradient
     image
-    line
     nofill
     nostroke
     pattern

--- a/shoes-core/spec/shoes/shared_examples/dsl/line.rb
+++ b/shoes-core/spec/shoes/shared_examples/dsl/line.rb
@@ -1,9 +1,0 @@
-shared_examples_for "line DSL method" do
-  it "creates a Shoes::Line" do
-    expect(dsl.line(10, 15, 20, 30)).to be_an_instance_of(Shoes::Line)
-  end
-
-  it "raises an ArgumentError" do
-    expect { dsl.line(30) }.to raise_error(ArgumentError)
-  end
-end

--- a/shoes-swt/spec/shoes/swt/line_painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/line_painter_spec.rb
@@ -4,16 +4,16 @@ describe Shoes::Swt::LinePainter do
   include_context "swt app"
   include_context "painter context"
 
-  let(:dsl) { Shoes::Line.new shoes_app, parent, point_a, point_b }
-  let(:point_a) { Shoes::Point.new(10, 100) }
-  let(:point_b) { Shoes::Point.new(300, 10) }
+  let(:dsl)  { Shoes::Line.new shoes_app, parent, left, top, 300, 10 }
+  let(:left) { 10 }
+  let(:top)  { 100 }
 
   let(:shape) { Shoes::Swt::Line.new(dsl, swt_app) }
   subject { Shoes::Swt::LinePainter.new(shape) }
 
   before(:each) do
-    dsl.absolute_left = point_a.x
-    dsl.absolute_top  = point_a.y
+    dsl.absolute_left = left
+    dsl.absolute_top  = top
     allow(dsl).to receive_messages(positioned?: true)
   end
 

--- a/shoes-swt/spec/shoes/swt/line_spec.rb
+++ b/shoes-swt/spec/shoes/swt/line_spec.rb
@@ -3,9 +3,7 @@ require 'spec_helper'
 describe Shoes::Swt::Line do
   include_context "swt app"
 
-  let(:dsl) { Shoes::Line.new shoes_app, parent, point_a, point_b }
-  let(:point_a) { Shoes::Point.new(10, 100) }
-  let(:point_b) { Shoes::Point.new(300, 10) }
+  let(:dsl) { Shoes::Line.new shoes_app, parent, 10, 100, 300, 10 }
 
   subject { Shoes::Swt::Line.new(dsl, swt_app) }
 


### PR DESCRIPTION
Another step toward full compatibility, Specs moved over to new standard form for DSL also. This time with a little extra flavor! 😋 

Specific interesting behavior noted from Shoes 3:

* As with other elements, you're free to provide 0..4 direct arguments
* Styles are allowed to substitute for left/top/right/bottom values provided if you like
* If only x1, y1, x2 are provided, y2 would default to y1 (giving you a horizontal line)
* Failing to provide for x2 would result in the element not showing (accomplished via setting start and end to match)

All this fell out from the following testing app:

```
Shoes.app do
  strokewidth 10

  line 100, 100, 200, 100, stroke: blue
  line 100, 200, 200, stroke: green
  line 100, 300, right: 200, bottom: 300, stroke: yellow
  line 100, top: 400, right: 200, bottom: 400, stroke: red
  line left: 100, top: 500, right: 200, bottom: 500, stroke: orange

  line 300, 100, 400, 100, stroke: teal
  line 300, 200, 400, stroke: gray
  line 300, 300, stroke: black
  line 300, stroke: pink
  line
end
```