### PR TITLE
Fix problem with rake spec:package

### DIFF
--- a/shoes-package/spec/spec_helper.rb
+++ b/shoes-package/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 # Packaging caches files in $HOME/.furoshiki/cache by default.
 # For testing, we override $HOME using $FUROSHIKI_HOME
 FUROSHIKI_SPEC_DIR = Pathname.new(__FILE__).dirname.expand_path.to_s
@@ -9,7 +11,6 @@ $LOAD_PATH << File.expand_path(SHOES_PACKAGE_SPEC_ROOT)
 $LOAD_PATH << File.expand_path('../../lib', __FILE__)
 $LOAD_PATH << File.expand_path('../../../shoes-core/lib', __FILE__)
 
-require 'pathname'
 require 'rspec/its'
 
 Dir["#{SHOES_PACKAGE_SPEC_ROOT}/support/**/*.rb"].each { |f| require f }


### PR DESCRIPTION
Noticed that if I ran `rake spec:package` instead of `bundle exec rake spec:package` we'd get a failure about finding the `Pathname` constant.

Easy enough fix as we were already requiring it later in the spec helper... just not early enough if we're not running through Bundler.