### PR TITLE
Fixes for YAML.safe_load from new Rubocop

### DIFF
--- a/samples/good_reminder.rb
+++ b/samples/good_reminder.rb
@@ -143,7 +143,7 @@ Shoes.app title: "A Gentle Reminder",
 
   def load
     if File.exist?(data_path)
-      @todo, @completed = YAML.load(File.open(data_path, 'r'))
+      @todo, @completed = YAML.safe_load(File.open(data_path, 'r'), [Date])
     else
       @todo = []
       @completed = {}

--- a/shoes-package/lib/shoes/package/configuration.rb
+++ b/shoes-package/lib/shoes/package/configuration.rb
@@ -71,7 +71,7 @@ class Shoes
           file, dir = config_for_single_file_app(pathname)
         end
 
-        config = YAML.load(file.read)
+        config = YAML.safe_load(file.read, [Symbol])
         config[:working_dir] = dir
         config[:gems] = merge_gems(base_config, config)
         create(config)


### PR DESCRIPTION
https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0470-2017-01-16

Since we don't check in `Gemfile.lock` (appropriately for a gem), we get all the latest Rubocop changes whenever they post (hurray?) since we don't bother with a version range in the `Gemfile` (which seems fine... when will we ever remember to update otherwise?)

This was the only breakage, and will fix #1370 on a rebase once this is merged.