### PR TITLE
Allow for skipping coverage via ENV

### DIFF
--- a/spec/code_coverage.rb
+++ b/spec/code_coverage.rb
@@ -1,4 +1,7 @@
 require 'simplecov'
-SimpleCov.start do
-  add_filter '/spec/'
+
+unless ENV["SHOES_SKIP_COVERAGE"]
+  SimpleCov.start do
+    add_filter '/spec/'
+  end
 end


### PR DESCRIPTION
I noticed that in running individual specs, I was spending 2-3 seconds each time running coverage that I never actually look at.

This provides a way to opt out of running coverage. It's not default to avoid breaking CI and/or removing coverage for folks less familiar, but it will keep my feedback cycles shorter.

🏃 💨 👌 