### PR TITLE
Reset alpha on graphics context

### DIFF
--- a/shoes-swt/lib/shoes/swt/common/painter.rb
+++ b/shoes-swt/lib/shoes/swt/common/painter.rb
@@ -98,7 +98,7 @@ class Shoes
           transform.translate left, top
           transform.rotate angle
           transform.translate(-left, -top)
-          graphics_context.setTransform transform
+          graphics_context.set_transform transform
         end
       end
     end

--- a/shoes-swt/lib/shoes/swt/common/resource.rb
+++ b/shoes-swt/lib/shoes/swt/common/resource.rb
@@ -2,6 +2,8 @@ class Shoes
   module Swt
     module Common
       module Resource
+        OPAQUE = 255
+
         def reset_graphics_context(graphics_context)
           dispose_previous_contexts
           set_defaults_on_context(graphics_context)
@@ -15,6 +17,7 @@ class Shoes
         end
 
         def set_defaults_on_context(graphics_context)
+          graphics_context.set_alpha OPAQUE
           graphics_context.set_antialias(::Swt::SWT::ON)
           graphics_context.set_line_cap(::Swt::SWT::CAP_FLAT)
           graphics_context.set_transform(nil)

--- a/shoes-swt/spec/shoes/swt/common/painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/common/painter_spec.rb
@@ -24,8 +24,7 @@ describe Shoes::Swt::Common::Painter do
                                set_clipping: nil,
                                set_antialias: nil,
                                set_line_cap: nil,
-                               set_transform: nil,
-                               setTransform: nil
+                               set_transform: nil
   end
 
   let(:transform) { double 'transform', disposed?: false }

--- a/shoes-swt/spec/shoes/swt/common/painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/common/painter_spec.rb
@@ -20,6 +20,7 @@ describe Shoes::Swt::Common::Painter do
   let(:graphics_context) do
     double 'graphics_context', dispose: nil,
                                clipping: nil,
+                               set_alpha: nil,
                                set_clipping: nil,
                                set_antialias: nil,
                                set_line_cap: nil,

--- a/shoes-swt/spec/shoes/swt/common/resource_spec.rb
+++ b/shoes-swt/spec/shoes/swt/common/resource_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe Shoes::Swt::Common::Resource do
+  let(:clazz) do
+    Class.new do
+      include Shoes::Swt::Common::Resource
+
+      attr_reader :graphic_contexts
+
+      def initialize
+        @graphic_contexts = []
+      end
+    end
+  end
+
+  let(:graphic_context) do
+    double("gc").tap do |gc|
+      expect(gc).to receive(:set_alpha).with(::Shoes::Swt::Common::Resource::OPAQUE)
+      expect(gc).to receive(:set_antialias).with(::Swt::SWT::ON)
+      expect(gc).to receive(:set_line_cap).with(::Swt::SWT::CAP_FLAT)
+      expect(gc).to receive(:set_transform).with(nil)
+    end
+  end
+
+  subject(:resource) { clazz.new }
+
+  it "tracks graphic contexts" do
+    resource.reset_graphics_context(graphic_context)
+    expect(resource.graphic_contexts).to eq([graphic_context])
+  end
+
+  it "disposes prior graphic contexts" do
+    old_context = double("old gc", dispose: nil)
+    resource.track_graphics_context(old_context)
+
+    resource.reset_graphics_context(graphic_context)
+
+    expect(old_context).to have_received(:dispose)
+    expect(resource.graphic_contexts).to eq([graphic_context])
+  end
+
+  describe "clipping" do
+    let(:element) { double("element", absolute_left: 0, absolute_top: 0, height: 100, width: 100) }
+    let(:clipping) { double("clipping", x: 10, y: 10, height: 50, width: 50) }
+    let(:graphic_context) { double("gc", clipping: clipping) }
+
+    it "clips in a block" do
+      expect(graphic_context).to receive(:set_clipping).with(0, 0, 100, 100)
+      expect(graphic_context).to receive(:set_clipping).with(10, 10, 50, 50)
+
+      resource.clip_context_to(graphic_context, element) do
+        @clipped = true
+      end
+
+      expect(@clipped).to eq(true)
+    end
+  end
+end

--- a/shoes-swt/spec/shoes/swt/text_block/painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block/painter_spec.rb
@@ -13,7 +13,7 @@ describe Shoes::Swt::TextBlock::Painter do
   let(:graphics_context) do
     double("graphics context", set_antialias: nil, set_line_cap: nil,
                                set_transform: nil, clipping: nil,
-                               set_clipping: nil)
+                               set_clipping: nil, set_alpha: nil)
   end
 
   subject { Shoes::Swt::TextBlock::Painter.new(dsl) }


### PR DESCRIPTION
Fixes #1190 

As @PragTob suspected, we weren't getting the alpha reset on the graphics context after it was getting modified while painting faded elements.

This had a natural home in the method that sets up graphic context defaults.

Noticed along the way we were still using an old-school, Java-ish `setTransform` call, so tidied that up too.