### PR TITLE
Fix visibility to be set through styles

### DIFF
--- a/shoes-core/lib/shoes/common/visibility.rb
+++ b/shoes-core/lib/shoes/common/visibility.rb
@@ -3,8 +3,7 @@ class Shoes
     module Visibility
       # Hides the element, so that it can't be seen. See also #show and #toggle.
       def hide
-        style[:hidden] = true
-        update_visibility
+        style(hidden: true)
       end
 
       def hidden?
@@ -19,15 +18,13 @@ class Shoes
 
       # Reveals the element, if it is hidden. See also #hide and #toggle.
       def show
-        style[:hidden] = false
-        update_visibility
+        style(hidden: false)
       end
 
       # Hides an element if it is shown. Or shows the element, if it is hidden.
       # See also #hide and #show.
       def toggle
-        style[:hidden] = !style[:hidden]
-        update_visibility
+        style(hidden: !style[:hidden])
       end
 
       private

--- a/shoes-core/spec/shoes/common/visibility_spec.rb
+++ b/shoes-core/spec/shoes/common/visibility_spec.rb
@@ -29,7 +29,7 @@ describe Shoes::Common::Visibility do
     expect(subject.gui).to have_received(:update_visibility)
   end
 
-  it "shows" do
+  it "toggles" do
     subject.show
     expect(subject.style[:hidden]).to eq(false)
 

--- a/shoes-core/spec/shoes/common/visibility_spec.rb
+++ b/shoes-core/spec/shoes/common/visibility_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe Shoes::Common::Visibility do
+  class VisibilityTester
+    include Shoes::Common::Visibility
+    include Shoes::Common::Style
+
+    attr_reader :gui
+
+    def initialize(gui)
+      @style = {}
+      @gui = gui
+    end
+  end
+
+  subject { VisibilityTester.new(gui) }
+
+  let(:gui) { double("gui", update_visibility: nil) }
+
+  it "hides" do
+    subject.hide
+    expect(subject.style[:hidden]).to eq(true)
+    expect(subject.gui).to have_received(:update_visibility)
+  end
+
+  it "shows" do
+    subject.show
+    expect(subject.style[:hidden]).to eq(false)
+    expect(subject.gui).to have_received(:update_visibility)
+  end
+
+  it "shows" do
+    subject.show
+    expect(subject.style[:hidden]).to eq(false)
+
+    subject.toggle
+    expect(subject.style[:hidden]).to eq(true)
+  end
+
+  it "is hidden?" do
+    subject.hide
+    expect(subject).to be_hidden
+  end
+
+  it "is visible?" do
+    subject.show
+    expect(subject).to be_visible
+  end
+end

--- a/shoes-core/spec/shoes/helpers/fake_element.rb
+++ b/shoes-core/spec/shoes/helpers/fake_element.rb
@@ -15,7 +15,7 @@ class Shoes
 
     # Fake this out instead of using Common::Style to avoid things like touching
     # app level styles, etc. that we don't need for testing purposes
-    def style(styles={})
+    def style(styles = {})
       @style ||= {}
       @style.merge!(styles)
       @style

--- a/shoes-core/spec/shoes/helpers/fake_element.rb
+++ b/shoes-core/spec/shoes/helpers/fake_element.rb
@@ -15,8 +15,9 @@ class Shoes
 
     # Fake this out instead of using Common::Style to avoid things like touching
     # app level styles, etc. that we don't need for testing purposes
-    def style
+    def style(styles={})
       @style ||= {}
+      @style.merge!(styles)
       @style
     end
 


### PR DESCRIPTION
Fixes #1176.

Per that issues, `Shoes::Common::Visibility` was writing to the styles hash itself directly, then triggering a visibility update. This ought to be done through the `style` method, which already handles the updates itself.

Hunted for other similar cases that we'd missed, but didn't turn any problematic candidates up, so 🌮 for that.

This also adds a more direct test for the module like I've been doing in other cases for these modules.