### PR TITLE
Fix setting clicks during initialization

### DIFF
--- a/shoes-core/lib/shoes/common/initialization.rb
+++ b/shoes-core/lib/shoes/common/initialization.rb
@@ -58,8 +58,7 @@ class Shoes
       #
       # Override if DSL element uses that block for something else (i.e. slot)
       def handle_block(blk)
-        return unless blk
-        register_click blk
+        register_click blk if respond_to?(:register_click)
       end
 
       # Final method called in initialize. Intended for any final setup after

--- a/shoes-core/lib/shoes/common/style.rb
+++ b/shoes-core/lib/shoes/common/style.rb
@@ -127,7 +127,7 @@ class Shoes
         set_coloring(new_styles)
         set_hovers(new_styles)
         set_translate(new_styles)
-        click(&new_styles[:click]) if new_styles.key?(:click)
+        set_click(new_styles)
         @style.merge! normalized_style
       end
 
@@ -156,6 +156,10 @@ class Shoes
 
       def set_translate(new_styles)
         clear_translate if new_styles.include?(:translate)
+      end
+
+      def set_click(new_styles)
+        click(&new_styles[:click]) if new_styles.key?(:click)
       end
 
       def update_dimensions # so that @style hash matches actual values

--- a/shoes-core/spec/shoes/common/clickable_spec.rb
+++ b/shoes-core/spec/shoes/common/clickable_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe Shoes::Common::Clickable do
+  include_context "dsl app"
+
+  class ClickTester
+    include Shoes::Common::UIElement
+    include Shoes::Common::Clickable
+
+    style_with :click
+
+    def create_dimensions
+      # Patched to avoid ratholing on shared setup we don't care about here
+      nil
+    end
+  end
+
+  subject { ClickTester.new(app, parent) }
+
+  before do
+    allow(Shoes).to receive(:backend_for).and_return(gui)
+  end
+
+  let(:gui)    { double("gui", update_visibility: nil) }
+  let(:parent) { double("parent", add_child: nil) }
+  let(:block)  { proc {} }
+
+  it "clicks" do
+    expect(gui).to receive(:click).with(block)
+    subject.click(&block)
+  end
+
+  it "clicks with style" do
+    expect(gui).to receive(:click).with(block)
+    subject.style(click: block)
+  end
+
+  it "clicks from styles at initialization" do
+    expect(gui).to receive(:click).with(block)
+    ClickTester.new(app, parent, click: block)
+  end
+
+  it "clicks from initialize block by default" do
+    expect(gui).to receive(:click).with(block)
+    ClickTester.new(app, parent, block)
+  end
+end


### PR DESCRIPTION
While testing around for #1377, I noticed that I didn't seem to be able to set the clicks appropriately during initializing an element. Turned out, if you didn't pass a block to an element, we didn't call `register_click` which was where the style lookup for `:click` happened.

Luckily, if `register_click` exists on a class, it can be called with a `nil` block, so safe enough to call through with a new guard in place.