### PR TITLE
Pin version of Rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,12 +20,13 @@ group :development do
   gem "rspec-its", "~>1.2.0"
   gem "rake"
 
+  gem "rubocop", "0.47.1"
+
   gem "yard"
   gem "kramdown"
   gem 'simplecov'
   gem "codeclimate-test-reporter", "~> 1.0"
   gem 'webmock'
   gem 'hometown'
-  gem 'rubocop'
   gem 'benchmark-ips'
 end


### PR DESCRIPTION
Will look after releases for updates to the gem and do it manually.

@PragTob this addresses the main pain-point that's been breaking builds when it updates. Do you think we should apply direct versions to all the other gems in the Gemfile too?