### PR TITLE
Provide support for readonly state

### DIFF
--- a/shoes-core/lib/shoes/common/state.rb
+++ b/shoes-core/lib/shoes/common/state.rb
@@ -5,25 +5,18 @@ class Shoes
 
       def after_initialize(*_)
         super
-        update_enabled
+        update_from_state
       end
 
       def state=(value)
         style(state: value)
-        update_enabled
       end
-
-      def state_options(opts)
-        self.state = opts[:state]
-      end
-
-      private
 
       def enabled?
         !(state.to_s == DISABLED_STATE)
       end
 
-      def update_enabled
+      def update_from_state
         @gui.enabled(enabled?)
       end
     end

--- a/shoes-core/lib/shoes/common/style.rb
+++ b/shoes-core/lib/shoes/common/style.rb
@@ -122,13 +122,15 @@ class Shoes
 
       def update_style(new_styles)
         normalized_style = StyleNormalizer.new.normalize(new_styles)
+        @style.merge! normalized_style
+
         set_dimensions(new_styles)
         set_visibility(new_styles)
         set_coloring(new_styles)
         set_hovers(new_styles)
         set_translate(new_styles)
         set_click(new_styles)
-        @style.merge! normalized_style
+        set_state(new_styles)
       end
 
       # if dimension is set via style, pass info on to the dimensions setter
@@ -140,7 +142,6 @@ class Shoes
 
       def set_visibility(new_styles)
         return unless new_styles.include?(:hidden)
-        @style[:hidden] = new_styles[:hidden]
         update_visibility
       end
 
@@ -160,6 +161,10 @@ class Shoes
 
       def set_click(new_styles)
         click(&new_styles[:click]) if new_styles.key?(:click)
+      end
+
+      def set_state(new_styles)
+        update_from_state if new_styles.include?(:state)
       end
 
       def update_dimensions # so that @style hash matches actual values

--- a/shoes-core/lib/shoes/input_box.rb
+++ b/shoes-core/lib/shoes/input_box.rb
@@ -33,6 +33,15 @@ class Shoes
     def caret_to(index)
       @gui.caret_to(index)
     end
+
+    def readonly?
+      state.to_s == "readonly"
+    end
+
+    def update_from_state
+      super
+      @gui.readonly = readonly?
+    end
   end
 
   class EditBox < InputBox

--- a/shoes-core/lib/shoes/mock/input_box.rb
+++ b/shoes-core/lib/shoes/mock/input_box.rb
@@ -7,6 +7,9 @@ class Shoes
       def enabled(_value)
       end
 
+      def readonly=(_value)
+      end
+
       def highlight_text(_start_index, _finish_index)
       end
 

--- a/shoes-core/spec/shoes/input_box_spec.rb
+++ b/shoes-core/spec/shoes/input_box_spec.rb
@@ -58,7 +58,7 @@ describe Shoes::InputBox do
 
   describe Shoes::EditLine do
     describe "secret" do
-      subject { Shoes::EditLine.new(app, parent, text, secret: true, state: 'disabled') }
+      subject { Shoes::EditLine.new(app, parent, text, secret: true) }
 
       it "gets initialized" do
         expect(subject.secret).to eq(true)
@@ -74,6 +74,26 @@ describe Shoes::InputBox do
       it_behaves_like "object with style" do
         let(:subject_without_style) { Shoes::EditLine.new(app, parent, text) }
         let(:subject_with_style) { Shoes::EditLine.new(app, parent, text, arg_styles) }
+      end
+    end
+
+    describe "readonly" do
+      subject { Shoes::EditLine.new(app, parent, text, state: "readonly") }
+
+      it "gets initialized" do
+        expect(subject.readonly?).to eq(true)
+      end
+
+      it "respects setting" do
+        expect(subject.gui).to receive(:readonly=).with(false)
+        subject.state = ""
+        expect(subject.readonly?).to eq(false)
+      end
+
+      it "respects style setting" do
+        expect(subject.gui).to receive(:readonly=).with(false)
+        subject.style(state: "")
+        expect(subject.readonly?).to eq(false)
       end
     end
   end

--- a/shoes-core/spec/shoes/shared_examples/state.rb
+++ b/shoes-core/spec/shoes/shared_examples/state.rb
@@ -13,6 +13,7 @@ shared_examples_for "object with state" do
   end
 
   it "should disable" do
+    subject.state = ""
     expect(subject.gui).to receive(:enabled).with(false)
     subject.state = "disabled"
     expect(subject.state).to eq("disabled")

--- a/shoes-core/spec/shoes/shared_examples/state.rb
+++ b/shoes-core/spec/shoes/shared_examples/state.rb
@@ -13,7 +13,7 @@ shared_examples_for "object with state" do
   end
 
   it "should disable" do
-    subject.state = ""
+    subject.state = nil
     expect(subject.gui).to receive(:enabled).with(false)
     subject.state = "disabled"
     expect(subject.state).to eq("disabled")

--- a/shoes-swt/lib/shoes/swt/input_box.rb
+++ b/shoes-swt/lib/shoes/swt/input_box.rb
@@ -20,6 +20,10 @@ class Shoes
         @real.add_modify_listener do |event|
           @dsl.call_change_listeners unless nothing_changed?(event)
         end
+
+        @real.add_verify_listener do |event|
+          event.doit = false if @readonly
+        end
       end
 
       def text
@@ -33,6 +37,10 @@ class Shoes
 
       def enabled(value)
         @real.enabled = value
+      end
+
+      def readonly=(value)
+        @readonly = value
       end
 
       def highlight_text(start_index, final_index)

--- a/shoes-swt/lib/shoes/swt/input_box.rb
+++ b/shoes-swt/lib/shoes/swt/input_box.rb
@@ -9,6 +9,7 @@ class Shoes
       include ::Shoes::BackendDimensionsDelegations
 
       attr_reader :real, :dsl, :app
+      attr_writer :readonly
 
       def initialize(dsl, app, text_options)
         @dsl = dsl
@@ -37,10 +38,6 @@ class Shoes
 
       def enabled(value)
         @real.enabled = value
-      end
-
-      def readonly=(value)
-        @readonly = value
       end
 
       def highlight_text(start_index, final_index)


### PR DESCRIPTION
Fixes #1187

Couple things going in this to get it all lined up:

* Obviously had to implement readonly for input boxes (doesn't make sense elsewhere, and Shoes 3 treats it like any other non-disabled state). This was accomplished via an SWT verify listener on keypresses 👌 
* Noted that setting `state` via style wasn't sticking because we weren't triggering the updates from the style module (like all the others). Fixed that up following the same pattern (although I'm trying to figure out a more elegant way to let the modules declare they should get called for certain style changes, but haven't gotten there yet).
* Removed entirely unused `state_options` method (woot!)
* Moved style merging above all the triggers in `Shoes::Common::Style`. A few spots were explicitly setting things in `@style`, and then the merge at the end sets it again. Looks like things are good with just merging first. 