### PR TITLE
Turn UIElement, ArtElement, BackgroundElement to classes

### DIFF
--- a/shoes-core/lib/shoes/arc.rb
+++ b/shoes-core/lib/shoes/arc.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 class Shoes
-  class Arc
-    include Common::ArtElement
-
+  class Arc < Common::ArtElement
     style_with :angle1, :angle2, :art_styles, :center, :common_styles, :dimensions, :radius, :wedge
     STYLES = { wedge: false, fill: Shoes::COLORS[:black] }.freeze
 

--- a/shoes-core/lib/shoes/arrow.rb
+++ b/shoes-core/lib/shoes/arrow.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 class Shoes
-  class Arrow
-    include Common::ArtElement
-
+  class Arrow < Common::ArtElement
     style_with :angle, :art_styles, :curve, :common_styles, :dimensions
     STYLES = { angle: 0, fill: Shoes::COLORS[:black] }.freeze
 

--- a/shoes-core/lib/shoes/background.rb
+++ b/shoes-core/lib/shoes/background.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class Shoes
-  class Background
-    include Common::BackgroundElement
+  class Background < Common::BackgroundElement
     include Common::Fill
 
     style_with :angle, :common_styles, :curve, :dimensions, :fill

--- a/shoes-core/lib/shoes/border.rb
+++ b/shoes-core/lib/shoes/border.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class Shoes
-  class Border
-    include Common::BackgroundElement
+  class Border < Common::BackgroundElement
     include Common::Stroke
 
     style_with :angle, :common_styles, :curve, :dimensions, :stroke, :strokewidth

--- a/shoes-core/lib/shoes/button.rb
+++ b/shoes-core/lib/shoes/button.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class Shoes
-  class Button
-    include Common::UIElement
+  class Button < Common::UIElement
     include Common::Clickable
     include Common::State
 

--- a/shoes-core/lib/shoes/check_button.rb
+++ b/shoes-core/lib/shoes/check_button.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class Shoes
-  class CheckButton
-    include Common::UIElement
+  class CheckButton < Common::UIElement
     include Common::Clickable
     include Common::State
 

--- a/shoes-core/lib/shoes/common/art_element.rb
+++ b/shoes-core/lib/shoes/common/art_element.rb
@@ -1,21 +1,17 @@
 # frozen_string_literal: true
 class Shoes
   module Common
-    module ArtElement
-      include Common::UIElement
+    class ArtElement < UIElement
       include Common::Clickable
       include Common::Fill
       include Common::Rotate
       include Common::Stroke
       include Common::Translate
 
-      # Modules that muck with class methods need to be included like this
-      #
-      # We also can't rely on Common::UIElement providing these, as it gets
-      # ArtElement, not the destination class to add things to!
-      def self.included(base)
-        base.include Common::Hover
-        base.include Common::Style
+      def self.inherited(child)
+        # Hover's inclusion generates a styling class per child class.
+        # We need to include it at inheritance time to get that behavior.
+        child.include Common::Hover
       end
     end
   end

--- a/shoes-core/lib/shoes/common/background_element.rb
+++ b/shoes-core/lib/shoes/common/background_element.rb
@@ -1,17 +1,7 @@
 # frozen_string_literal: true
 class Shoes
   module Common
-    module BackgroundElement
-      include Common::UIElement
-
-      # Modules that muck with class methods need to be included like this
-      #
-      # We also can't rely on Common::UIElement providing these, as it gets
-      # BackgroundElement, not the destination class to add things to!
-      def self.included(base)
-        base.include Common::Style
-      end
-
+    class BackgroundElement < Common::UIElement
       def create_dimensions(*_)
         @dimensions = ParentDimensions.new @parent, @style
       end

--- a/shoes-core/lib/shoes/common/ui_element.rb
+++ b/shoes-core/lib/shoes/common/ui_element.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Shoes
   module Common
-    module UIElement
+    class UIElement
       include Common::Attachable
       include Common::Initialization
       include Common::Inspect
@@ -9,11 +9,7 @@ class Shoes
       include Common::Positioning
       include Common::Remove
       include DimensionsDelegations
-
-      # Modules that muck with class methods need to be included like this
-      def self.included(base)
-        base.include Common::Style
-      end
+      include Common::Style
 
       # Nobody rotates by default, but we need to let you check
       def needs_rotate?

--- a/shoes-core/lib/shoes/image.rb
+++ b/shoes-core/lib/shoes/image.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class Shoes
-  class Image
-    include Common::UIElement
+  class Image < Common::UIElement
     include Common::Clickable
     include Common::Hover
 

--- a/shoes-core/lib/shoes/input_box.rb
+++ b/shoes-core/lib/shoes/input_box.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class Shoes
-  class InputBox
-    include Common::UIElement
+  class InputBox < Common::UIElement
     include Common::Changeable
     include Common::State
 

--- a/shoes-core/lib/shoes/line.rb
+++ b/shoes-core/lib/shoes/line.rb
@@ -2,9 +2,7 @@
 require 'matrix'
 
 class Shoes
-  class Line
-    include Common::ArtElement
-
+  class Line < Common::ArtElement
     attr_reader :point_a, :point_b
 
     style_with :angle, :art_styles, :dimensions, :x2, :y2

--- a/shoes-core/lib/shoes/list_box.rb
+++ b/shoes-core/lib/shoes/list_box.rb
@@ -25,8 +25,7 @@ class Shoes
     end
   end
 
-  class ListBox
-    include Common::UIElement
+  class ListBox < Common::UIElement
     include Common::Changeable
     include Common::State
 

--- a/shoes-core/lib/shoes/oval.rb
+++ b/shoes-core/lib/shoes/oval.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 class Shoes
-  class Oval
-    include Common::ArtElement
-
+  class Oval < Common::ArtElement
     style_with :art_styles, :center, :common_styles, :dimensions, :radius
     STYLES = { fill: Shoes::COLORS[:black] }.freeze
 

--- a/shoes-core/lib/shoes/progress.rb
+++ b/shoes-core/lib/shoes/progress.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 class Shoes
-  class Progress
-    include Common::UIElement
-
+  class Progress < Common::UIElement
     style_with :common_styles, :dimensions, :fraction
     STYLES = { fraction: 0.0 }.freeze
 

--- a/shoes-core/lib/shoes/rect.rb
+++ b/shoes-core/lib/shoes/rect.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 class Shoes
-  class Rect
-    include Common::ArtElement
-
+  class Rect < Common::ArtElement
     style_with :angle, :art_styles, :curve, :common_styles, :dimensions
     STYLES = { angle: 0, curve: 0, fill: Shoes::COLORS[:black] }.freeze
 

--- a/shoes-core/lib/shoes/shape.rb
+++ b/shoes-core/lib/shoes/shape.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 class Shoes
-  class Shape
-    include Common::ArtElement
-
+  class Shape < Common::ArtElement
     attr_reader :blk, :x, :y, :left_bound, :top_bound, :right_bound, :bottom_bound
 
     style_with :art_styles, :center, :common_styles, :dimensions
-
     STYLES = { fill: Shoes::COLORS[:black] }.freeze
 
     def create_dimensions(left, top)

--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class Shoes
-  class Slot
-    include Common::UIElement
+  class Slot < Common::UIElement
     include Common::Clickable
     include Common::Hover
 

--- a/shoes-core/lib/shoes/star.rb
+++ b/shoes-core/lib/shoes/star.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 class Shoes
-  class Star
-    include Common::ArtElement
-
+  class Star < Common::ArtElement
     style_with :angle, :art_styles, :common_styles, :dimensions, :inner, :outer, :points
     STYLES = { angle: 0, fill: Shoes::COLORS[:black] }.freeze
 

--- a/shoes-core/lib/shoes/text_block.rb
+++ b/shoes-core/lib/shoes/text_block.rb
@@ -3,8 +3,7 @@ class Shoes
   CENTER = "center"
   DEFAULT_TEXTBLOCK_FONT = "Arial"
 
-  class TextBlock
-    include Common::UIElement
+  class TextBlock < Common::UIElement
     include Common::Clickable
     include Common::Hover
     include Common::LinkFinder

--- a/shoes-core/spec/shoes/common/clickable_spec.rb
+++ b/shoes-core/spec/shoes/common/clickable_spec.rb
@@ -4,8 +4,7 @@ require 'spec_helper'
 describe Shoes::Common::Clickable do
   include_context "dsl app"
 
-  class ClickTester
-    include Shoes::Common::UIElement
+  class ClickTester < Shoes::Common::UIElement
     include Shoes::Common::Clickable
 
     style_with :click

--- a/shoes-core/spec/shoes/common/ui_element_spec.rb
+++ b/shoes-core/spec/shoes/common/ui_element_spec.rb
@@ -7,9 +7,7 @@ describe Shoes::Common::UIElement do
   subject { test_class.new }
 
   let(:test_class) do
-    Class.new do
-      include Shoes::Common::UIElement
-
+    Class.new(Shoes::Common::UIElement) do
       # Override UIElement's Initialization include for simpler testing
       def initialize
       end


### PR DESCRIPTION
Spoken of earlier, but a few other things I've been ruminating on would benefit from having the UIElement and others as full classes.

In particular this should yield some fruit around how we do updates after style setting, which currently is 1) ugly 2) has rough edges if you set keys on an unsupporting element and 3) probably inefficient (benchmarks will prove whether this bit is true).

Got a plan for handling the `Hover` weirdness we still have, but can probably apply those in separate PRs.