### PR TITLE
Support start block method in app

### DIFF
--- a/shoes-core/lib/shoes/app.rb
+++ b/shoes-core/lib/shoes/app.rb
@@ -62,6 +62,11 @@ class Shoes
       self.class.new(options, &block)
     end
 
+    # Remember startup block for execution later
+    def start(&blk)
+      @__app__.start_block = blk
+    end
+
     def quit
       Shoes.unregister self
       @__app__.quit

--- a/shoes-core/lib/shoes/internal_app.rb
+++ b/shoes-core/lib/shoes/internal_app.rb
@@ -35,7 +35,9 @@ class Shoes
 
       self.current_slot = create_top_slot
       execution_blk = create_execution_block(blk)
+
       eval_block execution_blk
+      eval_block start_block if start_block
 
       setup_global_keypresses
       register_console_keypress
@@ -52,7 +54,8 @@ class Shoes
                 :mouse_motion, :owner, :element_styles, :resize_callbacks
     attr_accessor :elements, :current_slot, :opts, :blk, :mouse_button,
                   :mouse_pos, :mouse_hover_controls, :resizable, :app_title,
-                  :width, :height, :start_as_fullscreen, :location
+                  :width, :height, :start_as_fullscreen, :location,
+                  :start_block
 
     def_delegators :@app, :eval_with_additional_context
 

--- a/shoes-core/spec/shoes/app_spec.rb
+++ b/shoes-core/spec/shoes/app_spec.rb
@@ -103,6 +103,38 @@ describe Shoes::App do
     end
   end
 
+  describe "start block" do
+    describe "basic" do
+      let(:input_blk) do
+        proc do
+          app.style(value: "")
+          start { app.style[:value] += "2" }
+          app.style[:value] += "1"
+        end
+      end
+
+      it "after main block" do
+        expect(app.style[:value]).to eq("12")
+      end
+    end
+
+    describe "only one" do
+      let(:input_blk) do
+        proc do
+          app.style(value: "")
+          start { app.style[:value] += "2" }
+          start { app.style[:value] += "3" }
+          app.style[:value] += "1"
+        end
+      end
+
+      # Behavior here based on Shoes 3 compat
+      it "only sees last start block" do
+        expect(app.style[:value]).to eq("13")
+      end
+    end
+  end
+
   describe "style with defaults" do
     let(:default_styles) { Shoes::Common::Style::DEFAULT_STYLES }
 


### PR DESCRIPTION
Runs after main block processing has concluded for app.

For example this app:

```
Shoes.app do
  para "before?"

  start do
    para "in the start!"
  end

  para "after!?"
end
```

Looks like this (not `"in the start!"` is after even the `para` that follows the `start` call):

![image](https://cloud.githubusercontent.com/assets/130504/22859947/fcb919aa-f0a2-11e6-8cce-f00380bf9355.png)


First of the things in #1200.