### PR TITLE
refactor: Move DSL Text methods to DSL::Text

### DIFF
--- a/shoes-core/lib/shoes/dsl.rb
+++ b/shoes-core/lib/shoes/dsl.rb
@@ -76,6 +76,8 @@ require 'shoes/text_block_dimensions'
 
 require 'shoes/color'
 
+require 'shoes/dsl/text'
+
 require 'shoes/common/attachable'
 require 'shoes/common/changeable'
 require 'shoes/common/clickable'
@@ -151,7 +153,7 @@ class Shoes
   #                      a hash of default styles for elements of Class,
   module DSL
     include Color::DSLHelpers
-
+    include DSL::Text
     # Set default style for elements of a particular class, or for all
     # elements, or return the current defaults for all elements
     #
@@ -601,50 +603,6 @@ EOS
 
     def nofill
       @__app__.style[:fill] = nil
-    end
-
-    %w(banner title subtitle tagline caption para inscription).each do |method|
-      define_method method do |*texts|
-        styles = pop_style(texts)
-        klass = Shoes.const_get(method.capitalize)
-        create klass, texts, styles
-      end
-    end
-
-    TEXT_STYLES = {
-      code: { font: "Lucida Console" },
-      del: { strikethrough: true },
-      em: { emphasis: true },
-      ins: { underline: true },
-      sub: { rise: -10, size_modifier: 0.8 },
-      sup: { rise: 10, size_modifier: 0.8 },
-      strong: { weight: true },
-    }.freeze
-
-    TEXT_STYLES.keys.each do |method|
-      define_method method do |*texts|
-        styles = style_normalizer.normalize(pop_style(texts))
-        styles = TEXT_STYLES[method].merge(styles)
-        Shoes::Span.new texts, styles
-      end
-    end
-
-    def fg(*texts, color)
-      Shoes::Span.new texts,  stroke: pattern(color)
-    end
-
-    def bg(*texts, color)
-      Shoes::Span.new texts,  fill: pattern(color)
-    end
-
-    def link(*texts, &blk)
-      opts = normalize_style_for_element(Shoes::Link, texts)
-      Shoes::Link.new @__app__, texts, opts, blk
-    end
-
-    def span(*texts)
-      opts = normalize_style_for_element(Shoes::Span, texts)
-      Shoes::Span.new texts, opts
     end
 
     def mouse

--- a/shoes-core/lib/shoes/dsl/text.rb
+++ b/shoes-core/lib/shoes/dsl/text.rb
@@ -1,0 +1,50 @@
+class Shoes
+  module DSL
+    module Text
+      %w(banner title subtitle tagline caption para inscription).each do |method|
+        define_method method do |*texts|
+          styles = pop_style(texts)
+          klass = Shoes.const_get(method.capitalize)
+          create klass, texts, styles
+        end
+      end
+
+      TEXT_STYLES = {
+        code: { font: "Lucida Console" },
+        del: { strikethrough: true },
+        em: { emphasis: true },
+        ins: { underline: true },
+        sub: { rise: -10, size_modifier: 0.8 },
+        sup: { rise: 10, size_modifier: 0.8 },
+        strong: { weight: true },
+      }.freeze
+
+      TEXT_STYLES.keys.each do |method|
+        define_method method do |*texts|
+          styles = style_normalizer.normalize(pop_style(texts))
+          styles = TEXT_STYLES[method].merge(styles)
+          Shoes::Span.new texts, styles
+        end
+      end
+
+      def fg(*texts, color)
+        Shoes::Span.new texts,  stroke: pattern(color)
+      end
+
+      def bg(*texts, color)
+        Shoes::Span.new texts,  fill: pattern(color)
+      end
+
+      def link(*texts, &blk)
+        opts = normalize_style_for_element(Shoes::Link, texts)
+        Shoes::Link.new @__app__, texts, opts, blk
+      end
+
+      def span(*texts)
+        opts = normalize_style_for_element(Shoes::Span, texts)
+        Shoes::Span.new texts, opts
+      end
+
+    end
+  end
+end

--- a/shoes-core/lib/shoes/dsl/text.rb
+++ b/shoes-core/lib/shoes/dsl/text.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Shoes
   module DSL
     module Text
@@ -44,7 +45,6 @@ class Shoes
         opts = normalize_style_for_element(Shoes::Span, texts)
         Shoes::Span.new texts, opts
       end
-
     end
   end
 end


### PR DESCRIPTION
Shifted the text methods to another file within a new directory 'dsl'.

How does this look @PragTob @jasonrclark ?

