### PR TITLE
Get clipboard working again

### DIFF
--- a/samples/simple_clipboard.rb
+++ b/samples/simple_clipboard.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+Shoes.app do
+  stack do
+    @line = edit_line "Put text here"
+    flow do
+      button "Copy" do
+        self.clipboard = @line.text
+        @buffer.text = "Now click Paste"
+      end
+      button "Paste" do
+        @buffer.text = clipboard
+      end
+    end
+
+    @buffer = para ""
+  end
+end

--- a/shoes-swt/lib/shoes/swt/app.rb
+++ b/shoes-swt/lib/shoes/swt/app.rb
@@ -129,7 +129,8 @@ EOS
       def clipboard=(str)
         ::Swt::Clipboard.new(Shoes.display).setContents(
           [str].to_java,
-          [::Swt::TextTransfer.getInstance].to_java(::Swt::TextTransfer)
+          [::Swt::TextTransfer.getInstance].to_java(::Swt::TextTransfer),
+          ::Swt::DND::DND::CLIPBOARD
         )
       end
 


### PR DESCRIPTION
Another day, another compatibility regression over in #1200!

This time, it appears from my testing that this was only failing on the Mac. When I tried the 3 parameter version instead of 2 parameter, it happily works now. Tested on VMs for Windows and Ubuntu, and those went swimmingly.

This is a bit in the weeds testing-wise. Could maybe try to wire something in new that actually round-trips text through the clipboard, but what's there right now is just mocking out that we get the call to the `clipboard` methods. If we do want tests, that'll be a task for another night, as it's time for 💤 