### PR TITLE
Restore selection after list changes

### DIFF
--- a/shoes-swt/lib/shoes/swt/list_box.rb
+++ b/shoes-swt/lib/shoes/swt/list_box.rb
@@ -28,7 +28,11 @@ class Shoes
       end
 
       def update_items
+        # Keep original selection to restore after resetting the list
+        text = @real.text
+
         @real.set_items(*@dsl.items.to_a.map(&:to_s))
+        @real.text = text
       end
 
       def text

--- a/shoes-swt/spec/shoes/swt/list_box_spec.rb
+++ b/shoes-swt/spec/shoes/swt/list_box_spec.rb
@@ -37,6 +37,13 @@ describe Shoes::Swt::ListBox do
     expect(real).to have_received(:set_items).with("hello").twice
   end
 
+  it "resets text after updating" do
+    allow(dsl).to receive(:items).and_return ["hello"]
+    allow(real).to receive(:text).and_return "", "hello"
+    subject.update_items
+    expect(real).to have_received(:text=).with("hello")
+  end
+
   it "should set real text if initialized with choose option" do
     allow(dsl).to receive(:style) { { choose: "Apple" } }
     subject


### PR DESCRIPTION
More compatibility goodness from #1200 

In this case, we found that anything which changed out the items list in a listbox would drop the current selection. To address this, we capture the value immediately before (easiest to just get the `@real.text` selection) and then put it back after the items change.