### PR TITLE
Pick up gems from Bundler

### DIFF
--- a/shoes-core/lib/shoes/mock/packager.rb
+++ b/shoes-core/lib/shoes/mock/packager.rb
@@ -2,6 +2,8 @@
 class Shoes
   module Mock
     class Packager
+      attr_accessor :gems
+
       def initialize(_dsl)
         @packages = []
       end

--- a/shoes-core/lib/shoes/packager.rb
+++ b/shoes-core/lib/shoes/packager.rb
@@ -6,6 +6,7 @@ class Shoes
     def initialize
       begin
         @backend = Shoes.backend_for(self)
+        configure_gems
       rescue ArgumentError
         # Packaging unsupported by this backend
       end
@@ -23,6 +24,17 @@ class Shoes
     def run(path)
       raise "Packaging unsupported by this backend" if @backend.nil?
       @backend.run(path)
+    end
+
+    def configure_gems
+      @backend.gems = []
+      return unless defined?(::Bundler)
+
+      @backend.gems = ::Bundler.environment.specs.map(&:name) - ["shoes"]
+    rescue Bundler::GemfileNotFound
+      # Ok to be quiet since we didn't even have a Gemfile
+    rescue => e
+      puts "Looking up gems for packaging failed:\n#{e.message}"
     end
 
     def help(program_name)

--- a/shoes-core/spec/shoes/packager_spec.rb
+++ b/shoes-core/spec/shoes/packager_spec.rb
@@ -9,6 +9,18 @@ describe Shoes::Packager do
     subject.create_package("program", "swt:app")
   end
 
+  if defined?(::Bundler)
+    it "detects Bundler and includes gems" do
+      expect(subject.backend.gems).to_not be_empty
+      expect(subject.backend.gems).to include("shoes-core")
+    end
+
+    it "detects Bundler and includes gems" do
+      allow(::Bundler).to receive(:environment).and_return(nil)
+      expect(subject.backend.gems).to be_empty
+    end
+  end
+
   it "knows to run packaging if it created one" do
     subject.create_package("program", "swt:app")
     expect(subject.should_package?).to eq(true)

--- a/shoes-core/spec/shoes/packager_spec.rb
+++ b/shoes-core/spec/shoes/packager_spec.rb
@@ -15,10 +15,13 @@ describe Shoes::Packager do
       expect(subject.backend.gems).to include("shoes-core")
     end
 
-    it "detects Bundler and includes gems" do
-      allow(::Bundler).to receive(:environment).and_return(nil)
+    it "works fine when missing Gemfile" do
+      allow(::Bundler).to receive(:environment).and_raise(::Bundler::GemfileNotFound)
       expect(subject.backend.gems).to be_empty
     end
+  else
+    puts
+    puts "Skipping part of shoes-core/spec/shoes/packager_spec.rb because missing Bundler"
   end
 
   it "knows to run packaging if it created one" do

--- a/shoes-swt/lib/shoes/swt/packager.rb
+++ b/shoes-swt/lib/shoes/swt/packager.rb
@@ -2,8 +2,11 @@
 class Shoes
   module Swt
     class Packager
+      attr_accessor :gems
+
       def initialize(dsl)
-        @dsl = dsl
+        @dsl  = dsl
+        @gems = []
       end
 
       def create_package(program_name, package)
@@ -65,7 +68,9 @@ class Shoes
       # packaging for more than one backend
       def create_config(master_config, backend)
         config = master_config.clone
+        config.gems.concat(@gems)
         config.gems << "shoes-#{backend}"
+        config.gems.uniq!
         config
       end
 


### PR DESCRIPTION
Fixes #1245 

If we detect the presence of Bundler when packaging, we'll try to use
its list of gems (minus `shoes` which causes us problems and isn't
necessary to install). This allows Rubyists to use the typical means of
declaring their dependencies in a Ruby app, but works nicely even
without a Gemfile around too.

So what's up with that conditional test? Ewww, right? Well, it got even
worse when I tried to stub in Bundler's business if it was missing...
three times the code, super-tight binding. I think I'm willing to just let
the non-Bundler case go here but I'm open to discussion.