### PR TITLE
Clean up some Cop values, exclusions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,7 +33,6 @@ Style/CollectionMethods:
 # Shoes internals
 Style/MutableConstant:
   Exclude:
-    - shoes-core/lib/shoes/dsl.rb
     - shoes-core/lib/shoes/font.rb
     - shoes-core/lib/shoes/color/dsl.rb
     - shoes-core/lib/shoes/common/style.rb
@@ -70,9 +69,3 @@ Style/TrivialAccessors:
 # We don't care if you use %w or literal string arrays
 Style/WordArray:
   Enabled: false
-
-# app.rb contains variables triggering a false positive for this cop such as @___app__
-# This can be removed when rubocop fixes this bug: https://github.com/bbatsov/rubocop/issues/3699
-Style/VariableNumber:
-  Exclude:
-    - shoes-core/lib/shoes/app.rb

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -57,16 +57,15 @@ Metrics/LineLength:
 #
 # Excludes long central SWT require file since they're long and that's fine!
 Metrics/MethodLength:
-  Max: 86
+  Max: 35
   Exclude:
+    - benchmark/clear.rb
     - shoes-swt/lib/shoes/swt.rb
 
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 267
-  Exclude:
-    - shoes-core/lib/shoes/dsl.rb
+  Max: 160
 
 # Offense count: 13
 # Configuration parameters: CountKeywordArgs.


### PR DESCRIPTION
Thanks to @OrthoDex's fine work on #1341, I was able to remove a couple of direct references to excluding our `dsl.rb` file from Rubocop rules. ✨ 

Along the way cranked down a couple max values closer to where they are, and removed an exclusion that was around for a Rubocop bug.