### PR TITLE
Change images blocks to clicks

### DIFF
--- a/samples/good_bounce.rb
+++ b/samples/good_bounce.rb
@@ -11,9 +11,8 @@ Shoes.app width: 300, height: 300 do
   button('stop') { a.stop }
   button('start') { a.start }
   button('remove') { a.remove }
-  img = image File.join(Shoes::DIR, 'static/shoes-icon.png') do
-    alert "You're soooo quick!"
-  end
+  img = image File.join(Shoes::DIR, 'static/shoes-icon.png'),
+              click: ->() { alert "You're soooo quick!" }
 
   x = 150
   y = 150

--- a/samples/simple_bounce.rb
+++ b/samples/simple_bounce.rb
@@ -9,9 +9,8 @@ Shoes.app do
   border black, strokewidth: 6
 
   nostroke
-  @icon = image "#{Shoes::DIR}/static/shoes-icon.png", left: 100, top: 100 do
-    alert "You're soooo quick."
-  end
+  @icon = image "#{Shoes::DIR}/static/shoes-icon.png",
+                left: 100, top: 100, click: ->() { alert "You're soooo quick." }
 
   x = width / 2
   y = height / 2

--- a/samples/simple_shoes_intro.rb
+++ b/samples/simple_shoes_intro.rb
@@ -3,9 +3,8 @@ Shoes.app width: 700, height: 600 do
   title "Shoes is a ", link("tiny") { alert "Cool!" }, " graphics toolkit. "
 
   flow width: 0.4 do
-    image File.join(Shoes::DIR, 'static/shoes-icon.png') do
-      alert "You're soooo quick!"
-    end
+    image File.join(Shoes::DIR, 'static/shoes-icon.png'),
+          click: ->() { alert "You're soooo quick!" }
   end
 
   flow width: 0.6 do


### PR DESCRIPTION
Back in https://github.com/shoes/shoes4/pull/1388 we made passing a block to images show a deprecation message as it didn't do what it used to in Shoes 3 (and we aren't supporting it just now).

Shoes 4 had already picked up the behavior of supporting default click action, though, if you passed one of those blocks and a few samples were using it. D'oh!

I've changed those samples to simply pass the `click:` explicitly.