### PR TITLE
Move to subcommands vs flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,13 +148,13 @@ That's Warbler talking. Actually, we sneak the Shoes gem in anyway, but don't te
 
 Okay, now for real. The simplest thing is to put your script in a directory by itself and then:
 
-    $ bin/shoes -p swt:app path/to/directory-of/your-shoes-app.rb
+    $ bin/shoes package -p swt:app path/to/directory-of/your-shoes-app.rb
 
-This will produce a Mac app, which you can then find at `path/to/directory-of/pkg/Shoes App.app`.
+This will produce a Mac app, which you can then find at `path/to/directory-of/pkg/your-shoes-app.app`.
 
 You can also package a shoes app up as a jar through:
 
-    $ bin/shoes -p swt:jar path/to/directory-of/your-shoes-app.rb
+    $ bin/shoes package -p swt:jar path/to/directory-of/your-shoes-app.rb
 
 You can find the jar in the same directory as above, i.e. path/to/directory-of/pkg/your-shoes-app.jar
 
@@ -164,9 +164,9 @@ If you want more control (like you want to name your app something besides "Shoe
 
 When you have an `app.yaml` file right next to your script, you have three options:
 
-    $ bin/shoes -p swt:app path/to/directory-of/your-shoes-app.rb
-    $ bin/shoes -p swt:app path/to/directory-of/app.yaml
-    $ bin/shoes -p swt:app path/to/directory-of
+    $ bin/shoes package -p swt:app path/to/directory-of/your-shoes-app.rb
+    $ bin/shoes package -p swt:app path/to/directory-of/app.yaml
+    $ bin/shoes package -p swt:app path/to/directory-of
 
 The packager will find your instructions using any of those commands. Again, you'll find your app in the `pkg` directory inside your project's directory. Find out more at `bin/shoes --help`.
 

--- a/shoes-core/lib/shoes/mock.rb
+++ b/shoes-core/lib/shoes/mock.rb
@@ -1,4 +1,12 @@
 # frozen_string_literal: true
+
+class Shoes
+  module Mock
+    def self.initialize_backend(*_)
+    end
+  end
+end
+
 require 'shoes/mock/common_methods'
 require 'shoes/mock/clickable'
 

--- a/shoes-core/lib/shoes/packager.rb
+++ b/shoes-core/lib/shoes/packager.rb
@@ -13,12 +13,18 @@ class Shoes
       @packages = []
     end
 
-    def create_package(program_name, package)
-      @packages << @backend.create_package(program_name, package)
+    def parse!(args)
+      options = OptionParser.new do |opts|
+        opts.on('-p', '--package PACKAGE_TYPE', 'Package as BACKEND:PACKAGE') do |package|
+          create_package("shoes", package)
+        end
+      end
+
+      options.parse!(args)
     end
 
-    def should_package?
-      @packages.any?
+    def create_package(program_name, package)
+      @packages << @backend.create_package(program_name, package)
     end
 
     def run(path)

--- a/shoes-core/lib/shoes/packager.rb
+++ b/shoes-core/lib/shoes/packager.rb
@@ -13,13 +13,15 @@ class Shoes
       @packages = []
     end
 
-    def parse!(args)
-      options = OptionParser.new do |opts|
+    def options
+      OptionParser.new do |opts|
         opts.on('-p', '--package PACKAGE_TYPE', 'Package as BACKEND:PACKAGE') do |package|
           create_package("shoes", package)
         end
       end
+    end
 
+    def parse!(args)
       options.parse!(args)
     end
 

--- a/shoes-core/lib/shoes/ui/cli.rb
+++ b/shoes-core/lib/shoes/ui/cli.rb
@@ -2,79 +2,44 @@
 require 'optparse'
 require 'shoes'
 
+require 'shoes/ui/cli/base_command'
+require 'shoes/ui/cli/default_command'
+require 'shoes/ui/cli/help_command'
+require 'shoes/ui/cli/manual_command'
+require 'shoes/ui/cli/package_command'
+require 'shoes/ui/cli/select_backend_command'
+require 'shoes/ui/cli/version_command'
+
 class Shoes
-  class CLI
-    attr_reader :packager
+  module UI
+    class CLI
+      SUPPORTED_COMMANDS = {
+        help:           HelpCommand,
+        manual:         ManualCommand,
+        package:        PackageCommand,
+        select_backend: SelectBackendCommand,
+        version:        VersionCommand,
+      }.freeze
 
-    def initialize(backend)
-      $LOAD_PATH.unshift(Dir.pwd)
-      backend_const = Shoes.load_backend(backend)
-      backend_const.initialize_backend
-
-      @packager = Shoes::Packager.new
-    end
-
-    def parse!(args)
-      options = OptionParser.new do |opts|
-        opts.program_name = 'shoes'
-        opts.banner = <<-EOS
-Usage: #{opts.program_name} [-h] [-p package] file
-        EOS
-        opts.separator ''
-        opts.separator 'Options:'
-
-        opts.on('-p', '--package PACKAGE_TYPE', 'Package as BACKEND:PACKAGE') do |package|
-          @packager.create_package(opts.program_name, package)
-        end
-
-        opts.on('-v', '--version', 'Shoes version') do
-          puts "Shoes #{Shoes::Core::VERSION}"
-          exit
-        end
-
-        opts.on('-m', '--manual', 'Run the Shoes manual') do
-          require 'shoes/manual'
-          Shoes::Manual.run "English"
-          exit
-        end
-
-        opts.on('-b', '--backend [BACKEND]', 'Select a Shoes backend') do |backend|
-          require 'shoes/ui/picker'
-          Shoes::UI::Picker.new.run(ENV["SHOES_BIN_DIR"], backend)
-          exit
-        end
-
-        opts.on('-f', '--fail-fast', 'Crash on exceptions in Shoes code') do
-          Shoes.configuration.fail_fast = true
-        end
-
-        opts.separator @packager.help(opts.program_name)
+      def initialize(backend)
+        $LOAD_PATH.unshift(Dir.pwd)
+        backend_const = Shoes.load_backend(backend)
+        backend_const.initialize_backend
       end
 
-      options.parse!(args)
-      options
-    end
+      def run(args)
+        if args.empty?
+          Shoes::UI::CLI::HelpCommand.new([]).run
+          exit(1)
+        end
 
-    # Execute a shoes app.
-    #
-    # @param [String] app the location of the app to run
-    # @param [String] backend name of backend to load with the app
-    def execute_app(app)
-      load app
-    end
-
-    def run(args)
-      opts = parse!(args)
-      if args.empty?
-        puts opts.banner
-        puts "Try '#{opts.program_name} --help' for more information"
-        exit(0)
+        command = create_command(*args)
+        command.run
       end
 
-      if @packager.should_package?
-        @packager.run(args.shift)
-      else
-        execute_app(args.first)
+      def create_command(*args)
+        command_class = SUPPORTED_COMMANDS[args.first.to_sym] || DefaultCommand
+        command_class.new(args.dup)
       end
     end
   end

--- a/shoes-core/lib/shoes/ui/cli/base_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/base_command.rb
@@ -9,6 +9,13 @@ class Shoes
           @args = args
         end
 
+        def warn_on_unexpected_parameters
+          return unless args.size > 1
+
+          unexpected = args[1..-1].join(" ")
+          Shoes.logger.warn("Unexpected extra parameters '#{unexpected}'")
+        end
+
         def self.help
           nil
         end

--- a/shoes-core/lib/shoes/ui/cli/base_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/base_command.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class Shoes
+  module UI
+    class CLI
+      class BaseCommand
+        attr_reader :args
+
+        def initialize(args)
+          @args = args
+        end
+      end
+    end
+  end
+end

--- a/shoes-core/lib/shoes/ui/cli/base_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/base_command.rb
@@ -8,6 +8,15 @@ class Shoes
         def initialize(args)
           @args = args
         end
+
+        def self.help
+          nil
+        end
+
+        def self.help_from_options(command, options)
+          lines = ["#{command}\n"] + options.summarize
+          lines.join("")
+        end
       end
     end
   end

--- a/shoes-core/lib/shoes/ui/cli/base_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/base_command.rb
@@ -9,10 +9,10 @@ class Shoes
           @args = args
         end
 
-        def warn_on_unexpected_parameters
-          return unless args.size > 1
+        def warn_on_unexpected_parameters(expected_size = 1)
+          return unless args.size > expected_size
 
-          unexpected = args[1..-1].join(" ")
+          unexpected = args[expected_size..-1].join(" ")
           Shoes.logger.warn("Unexpected extra parameters '#{unexpected}'")
         end
 

--- a/shoes-core/lib/shoes/ui/cli/default_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/default_command.rb
@@ -5,10 +5,8 @@ class Shoes
       class DefaultCommand < BaseCommand
         def run
           if parse!(args)
-            path = args.shift
-            Shoes.logger.warn("Unexpected extra parameters '#{args.join(' ')}'") if args.any?
-
-            load path
+            warn_on_unexpected_parameters
+            load args.first
           end
         end
 

--- a/shoes-core/lib/shoes/ui/cli/default_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/default_command.rb
@@ -8,7 +8,15 @@ class Shoes
           load args.first
         end
 
+        def self.help
+          help_from_options("shoes [options] file", options)
+        end
+
         def options
+          self.class.options
+        end
+
+        def self.options
           OptionParser.new do |opts|
             # Keep around command dashed options
             opts.on('-v', '--version', 'Shoes version') do

--- a/shoes-core/lib/shoes/ui/cli/default_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/default_command.rb
@@ -4,16 +4,23 @@ class Shoes
     class CLI
       class DefaultCommand < BaseCommand
         def run
-          options.parse!(args)
-          load args.first
+          if parse!(args)
+            path = args.shift
+            Shoes.logger.warn("Unexpected extra parameters '#{args.join(' ')}'") if args.any?
+
+            load path
+          end
         end
 
-        def self.help
-          help_from_options("shoes [options] file", options)
-        end
+        def parse!(args)
+          self.class.options.parse!(args)
+          true
+        rescue OptionParser::InvalidOption => e
+          puts "Whoops! #{e.message}"
+          puts
+          puts self.class.help
 
-        def options
-          self.class.options
+          false
         end
 
         def self.options
@@ -34,6 +41,10 @@ class Shoes
               Shoes.configuration.fail_fast = true
             end
           end
+        end
+
+        def self.help
+          help_from_options("shoes [options] file", options)
         end
       end
     end

--- a/shoes-core/lib/shoes/ui/cli/default_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/default_command.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+class Shoes
+  module UI
+    class CLI
+      class DefaultCommand < BaseCommand
+        def run
+          options.parse!(args)
+          load args.first
+        end
+
+        def options
+          OptionParser.new do |opts|
+            # Keep around command dashed options
+            opts.on('-v', '--version', 'Shoes version') do
+              Shoes::UI::CLI::VersionCommand.new([]).run
+              exit
+            end
+
+            opts.on('-h', '--help', 'Shoes help') do
+              Shoes::UI::CLI::HelpCommand.new([]).run
+              exit
+            end
+
+            # Also, we have some real runtime options!
+            opts.on('-f', '--fail-fast', 'Crash on exceptions in Shoes code') do
+              Shoes.configuration.fail_fast = true
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/shoes-core/lib/shoes/ui/cli/help_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/help_command.rb
@@ -4,6 +4,8 @@ class Shoes
     class CLI
       class HelpCommand < BaseCommand
         def run
+          warn_on_unexpected_parameters
+
           puts "Shoes is the best little GUI toolkit for Ruby."
           puts
 
@@ -17,6 +19,13 @@ class Shoes
               puts
             end
           end
+        end
+
+        def warn_on_unexpected_parameters
+          return unless args.size > 1
+
+          unexpected = args[1..-1].join(" ")
+          Shoes.logger.warn("Unexpected extra parameters '#{unexpected}'")
         end
 
         def self.help

--- a/shoes-core/lib/shoes/ui/cli/help_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/help_command.rb
@@ -4,7 +4,26 @@ class Shoes
     class CLI
       class HelpCommand < BaseCommand
         def run
-          puts "halp!"
+          puts "Shoes is the best little GUI toolkit for Ruby."
+          puts
+
+          command_classes = [DefaultCommand]
+          command_classes.concat(SUPPORTED_COMMANDS.map(&:last))
+
+          command_classes.each do |command_class|
+            text = command_class.help.to_s
+            unless text.empty?
+              puts text
+              puts
+            end
+          end
+        end
+
+        def self.help
+          <<-EOS
+shoes help
+    Displays this help text
+EOS
         end
       end
     end

--- a/shoes-core/lib/shoes/ui/cli/help_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/help_command.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class Shoes
+  module UI
+    class CLI
+      class HelpCommand < BaseCommand
+        def run
+          puts "halp!"
+        end
+      end
+    end
+  end
+end

--- a/shoes-core/lib/shoes/ui/cli/help_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/help_command.rb
@@ -21,13 +21,6 @@ class Shoes
           end
         end
 
-        def warn_on_unexpected_parameters
-          return unless args.size > 1
-
-          unexpected = args[1..-1].join(" ")
-          Shoes.logger.warn("Unexpected extra parameters '#{unexpected}'")
-        end
-
         def self.help
           <<-EOS
 shoes help

--- a/shoes-core/lib/shoes/ui/cli/manual_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/manual_command.rb
@@ -7,6 +7,13 @@ class Shoes
           require 'shoes/manual'
           Shoes::Manual.run "English"
         end
+
+        def self.help
+          <<-EOS
+shoes manual
+    Run the interactive Shoes manual
+EOS
+        end
       end
     end
   end

--- a/shoes-core/lib/shoes/ui/cli/manual_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/manual_command.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class Shoes
+  module UI
+    class CLI
+      class ManualCommand < BaseCommand
+        def run
+          require 'shoes/manual'
+          Shoes::Manual.run "English"
+        end
+      end
+    end
+  end
+end

--- a/shoes-core/lib/shoes/ui/cli/package_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/package_command.rb
@@ -10,6 +10,15 @@ class Shoes
           path = args[1]
           @packager.run(path)
         end
+
+        def self.help
+          help_from_options("shoes package [options] file",
+                            Shoes::Packager.new.options) + <<-EOS
+
+    Packages may be built either from a single .rb file, or a .yaml file with
+    more options defined.
+EOS
+        end
       end
     end
   end

--- a/shoes-core/lib/shoes/ui/cli/package_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/package_command.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class Shoes
+  module UI
+    class CLI
+      class PackageCommand < BaseCommand
+        def run
+          @packager = Shoes::Packager.new
+          @packager.parse!(args)
+
+          path = args[1]
+          @packager.run(path)
+        end
+      end
+    end
+  end
+end

--- a/shoes-core/lib/shoes/ui/cli/package_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/package_command.rb
@@ -7,6 +7,8 @@ class Shoes
           @packager = Shoes::Packager.new
           @packager.parse!(args)
 
+          warn_on_unexpected_parameters(2)
+
           path = args[1]
           @packager.run(path)
         end

--- a/shoes-core/lib/shoes/ui/cli/select_backend_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/select_backend_command.rb
@@ -8,6 +8,14 @@ class Shoes
           backend = args[1]
           Shoes::UI::Picker.new.run(ENV["SHOES_BIN_DIR"], backend)
         end
+
+        def self.help
+          <<-EOS
+shoes select_backend [backend]
+    Select a Shoes backend to use. A backend can be specified, or Shoes will
+    attempt to auto-detect available backends to select from.
+EOS
+        end
       end
     end
   end

--- a/shoes-core/lib/shoes/ui/cli/select_backend_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/select_backend_command.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class Shoes
+  module UI
+    class CLI
+      class SelectBackendCommand < BaseCommand
+        def run
+          require 'shoes/ui/picker'
+          backend = args[1]
+          Shoes::UI::Picker.new.run(ENV["SHOES_BIN_DIR"], backend)
+        end
+      end
+    end
+  end
+end

--- a/shoes-core/lib/shoes/ui/cli/version_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/version_command.rb
@@ -6,6 +6,13 @@ class Shoes
         def run
           puts "Shoes #{Shoes::Core::VERSION}"
         end
+
+        def self.help
+          <<-EOS
+shoes version
+    Prints the current Shoes version
+EOS
+        end
       end
     end
   end

--- a/shoes-core/lib/shoes/ui/cli/version_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/version_command.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class Shoes
+  module UI
+    class CLI
+      class VersionCommand < BaseCommand
+        def run
+          puts "Shoes #{Shoes::Core::VERSION}"
+        end
+      end
+    end
+  end
+end

--- a/shoes-core/spec/shoes/packager_spec.rb
+++ b/shoes-core/spec/shoes/packager_spec.rb
@@ -24,11 +24,6 @@ describe Shoes::Packager do
     puts "Skipping part of shoes-core/spec/shoes/packager_spec.rb because missing Bundler"
   end
 
-  it "knows to run packaging if it created one" do
-    subject.create_package("program", "swt:app")
-    expect(subject.should_package?).to eq(true)
-  end
-
   it "delegates run" do
     expect(subject.backend).to receive(:run)
     subject.run("path/to/shoes/app.rb")

--- a/shoes-core/spec/shoes/ui/cli/default_command_spec.rb
+++ b/shoes-core/spec/shoes/ui/cli/default_command_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Shoes::UI::CLI::DefaultCommand do
+  subject(:command) { Shoes::UI::CLI::DefaultCommand.new([]) }
+
+  let(:stubbed_command) { double('stubbed command', run: nil) }
+
+  before do
+    # Keep from trying to run the file
+    allow(command).to receive(:load)
+    allow(command).to receive(:puts)
+
+    allow(command.class).to receive(:exit)
+  end
+
+  it "loads a plain file" do
+    command.args << "thing.rb"
+    command.run
+
+    expect(command).to have_received(:load).with("thing.rb")
+  end
+
+  it "allows known option" do
+    command.args << "--fail-fast" << "thing.rb"
+    command.run
+
+    expect(Shoes.configuration.fail_fast).to eq(true)
+    expect(command).to have_received(:load).with("thing.rb")
+  end
+
+  it "fails with error message" do
+    expect(command).to receive(:puts).with(/Whoops/)
+    expect(command).to_not receive(:load)
+
+    command.args << "--unknown"
+    command.run
+  end
+
+  it "warns on unexpected additional parameters" do
+    expect(Shoes.logger).to receive(:warn).with(/Unexpected.*boo.rb/)
+    expect(command).to receive(:load).with("thing.rb")
+
+    command.args << "thing.rb" << "boo.rb"
+    command.run
+  end
+
+  it "passes version through" do
+    allow(Shoes::UI::CLI::VersionCommand).to receive(:new).and_return(stubbed_command)
+    expect(stubbed_command).to receive(:run)
+    expect(command.class).to receive(:exit)
+
+    command.args << "-v"
+    command.run
+  end
+
+  it "passes help through" do
+    allow(Shoes::UI::CLI::HelpCommand).to receive(:new).and_return(stubbed_command)
+    expect(stubbed_command).to receive(:run)
+    expect(command.class).to receive(:exit)
+
+    command.args << "-h"
+    command.run
+  end
+end

--- a/shoes-core/spec/shoes/ui/cli/help_command_spec.rb
+++ b/shoes-core/spec/shoes/ui/cli/help_command_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Shoes::UI::CLI::HelpCommand do
+  subject(:command) { Shoes::UI::CLI::HelpCommand.new([]) }
+
+  before do
+    allow(command).to receive(:puts)
+  end
+
+  it "includes all subcommands" do
+    Shoes::UI::CLI::SUPPORTED_COMMANDS.keys.each do |key|
+      expect(command).to receive(:puts).with(/shoes.*#{key}/)
+    end
+
+    command.run
+  end
+
+  it "warns on too many parameters" do
+    expect(Shoes.logger).to receive(:warn).with(/Unexpected.*whatever/)
+
+    command.args << "help" << "whatever"
+    command.run
+  end
+end

--- a/shoes-core/spec/shoes/ui/cli/package_command_spec.rb
+++ b/shoes-core/spec/shoes/ui/cli/package_command_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Shoes::UI::CLI::PackageCommand do
+  subject(:command) { Shoes::UI::CLI::PackageCommand.new([]) }
+
+  let(:packager) { double("packager", parse!: nil, run: nil) }
+
+  before do
+    allow(Shoes::Packager).to receive(:new).and_return(packager)
+  end
+
+  it "runs" do
+    expect(packager).to receive(:run).with("app.rb")
+
+    command.args << "package" << "app.rb"
+    command.run
+  end
+
+  it "warns on unexpected stuff" do
+    expect(Shoes.logger).to receive(:warn).with(/Unexpected.*another.rb/)
+
+    command.args << "package" << "app.rb" << "another.rb"
+    command.run
+  end
+end

--- a/shoes-core/spec/shoes/ui/cli_spec.rb
+++ b/shoes-core/spec/shoes/ui/cli_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Shoes::UI::CLI do
+  subject(:cli) { Shoes::UI::CLI.new(:mock) }
+
+  it "recognizes help subcommand" do
+    command = cli.create_command("help")
+    expect(command).to be_an_instance_of(Shoes::UI::CLI::HelpCommand)
+    expect(command.args).to eq(["help"])
+  end
+
+  it "recognizes manual subcommand" do
+    command = cli.create_command("manual")
+    expect(command).to be_an_instance_of(Shoes::UI::CLI::ManualCommand)
+    expect(command.args).to eq(["manual"])
+  end
+
+  it "recognizes package subcommand" do
+    command = cli.create_command("package", "something.rb")
+    expect(command).to be_an_instance_of(Shoes::UI::CLI::PackageCommand)
+    expect(command.args).to eq(["package", "something.rb"])
+  end
+
+  it "recognizes select_backend subcommand" do
+    command = cli.create_command("select_backend", "backitup")
+    expect(command).to be_an_instance_of(Shoes::UI::CLI::SelectBackendCommand)
+    expect(command.args).to eq(["select_backend", "backitup"])
+  end
+
+  it "recognizes version subcommand" do
+    command = cli.create_command("version")
+    expect(command).to be_an_instance_of(Shoes::UI::CLI::VersionCommand)
+    expect(command.args).to eq(["version"])
+  end
+
+  it "falls back to default run command otherwise" do
+    command = cli.create_command("my_app.rb")
+    expect(command).to be_an_instance_of(Shoes::UI::CLI::DefaultCommand)
+    expect(command.args).to eq(["my_app.rb"])
+  end
+end

--- a/shoes-core/spec/shoes/ui/cli_spec.rb
+++ b/shoes-core/spec/shoes/ui/cli_spec.rb
@@ -4,6 +4,9 @@ require 'spec_helper'
 describe Shoes::UI::CLI do
   subject(:cli) { Shoes::UI::CLI.new(:mock) }
 
+  ALL_COMMAND_CLASSES = [Shoes::UI::CLI::DefaultCommand] +
+                        Shoes::UI::CLI::SUPPORTED_COMMANDS.map(&:last)
+
   it "recognizes help subcommand" do
     command = cli.create_command("help")
     expect(command).to be_an_instance_of(Shoes::UI::CLI::HelpCommand)
@@ -38,5 +41,13 @@ describe Shoes::UI::CLI do
     command = cli.create_command("my_app.rb")
     expect(command).to be_an_instance_of(Shoes::UI::CLI::DefaultCommand)
     expect(command.args).to eq(["my_app.rb"])
+  end
+
+  describe "help" do
+    ALL_COMMAND_CLASSES.each do |command_class|
+      it "supports help for #{command_class}" do
+        expect(command_class.help).to_not be_empty
+      end
+    end
   end
 end

--- a/shoes-swt/bin/shoes-swt
+++ b/shoes-swt/bin/shoes-swt
@@ -9,4 +9,4 @@ if File.exist?("Gemfile")
 end
 
 require 'shoes/ui/cli'
-Shoes::CLI.new("swt").run ARGV
+Shoes::UI::CLI.new("swt").run ARGV

--- a/shoes-swt/spec/shoes/cli_spec.rb
+++ b/shoes-swt/spec/shoes/cli_spec.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Shoes::CLI do
-  subject { Shoes::CLI.new("swt") }
+describe Shoes::UI::CLI do
+  subject { Shoes::UI::CLI.new("swt") }
 
   before :each do
-    allow(subject.packager).to receive :run
+    allow_any_instance_of(Shoes::Packager).to receive(:run)
   end
 
   it 'does not raise an error for a normal packaging command #624' do
     expect do
-      subject.run ['-p', 'swt:app', 'samples/simple_sound.rb']
+      subject.run ['package', '-p', 'swt:app', 'samples/simple_sound.rb']
     end.not_to raise_error
   end
 end


### PR DESCRIPTION
As discussed briefly over in https://github.com/shoes/shoes4/issues/1320#issuecomment-265961168, this PR moves us toward using subcommands instead of flags for everything.

It will move people's 🧀 but I'm cool with it for the nice doors it opens. The main revision will be for packaging. I'm proposing that we change the layout to something like this:

```
shoes package --jar --mac the_app.rb
```

Today there's some binding being done in the DSL/core layer around the backend naming on the options. In reality, we're working with a single backend at a time here today (and it'll be big revisions to change that down the line) so I'd rather drop that and let the backend feed these options up to the CLI system. With the new structure, that'll be totally easy to accomplish.

FWIW although there are new `shoes help` and `shoes version` commands, I kept the dashed flag versions of the commands too... principle of least surprise you know 😉 

## Todo

* [x] Rewire help (planning to do just one help dump for all the commands)
* [x] More testing (manual and specs), particularly around passing too many, too few, etc.
* [ ] ~~Revise packaging options (maybe move to separate PR?)~~
