### PR TITLE
Revisions to packaging arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,13 +148,13 @@ That's Warbler talking. Actually, we sneak the Shoes gem in anyway, but don't te
 
 Okay, now for real. The simplest thing is to put your script in a directory by itself and then:
 
-    $ bin/shoes package -p swt:app path/to/directory-of/your-shoes-app.rb
+    $ bin/shoes package --mac path/to/directory-of/your-shoes-app.rb
 
 This will produce a Mac app, which you can then find at `path/to/directory-of/pkg/your-shoes-app.app`.
 
 You can also package a shoes app up as a jar through:
 
-    $ bin/shoes package -p swt:jar path/to/directory-of/your-shoes-app.rb
+    $ bin/shoes package --jar path/to/directory-of/your-shoes-app.rb
 
 You can find the jar in the same directory as above, i.e. path/to/directory-of/pkg/your-shoes-app.jar
 
@@ -164,9 +164,9 @@ If you want more control (like you want to name your app something besides "Shoe
 
 When you have an `app.yaml` file right next to your script, you have three options:
 
-    $ bin/shoes package -p swt:app path/to/directory-of/your-shoes-app.rb
-    $ bin/shoes package -p swt:app path/to/directory-of/app.yaml
-    $ bin/shoes package -p swt:app path/to/directory-of
+    $ bin/shoes package --mac path/to/directory-of/your-shoes-app.rb
+    $ bin/shoes package --mac path/to/directory-of/app.yaml
+    $ bin/shoes package --mac path/to/directory-of
 
 The packager will find your instructions using any of those commands. Again, you'll find your app in the `pkg` directory inside your project's directory. Find out more at `bin/shoes --help`.
 

--- a/shoes-core/lib/shoes/mock/packager.rb
+++ b/shoes-core/lib/shoes/mock/packager.rb
@@ -4,12 +4,14 @@ class Shoes
     class Packager
       attr_accessor :gems
 
-      def initialize(_dsl)
-        @packages = []
+      def initialize(*_)
       end
 
-      def create_package(_, package)
-        @packages << package
+      def options
+        OptionParser.new
+      end
+
+      def create_package(*_)
       end
     end
   end

--- a/shoes-core/lib/shoes/packager.rb
+++ b/shoes-core/lib/shoes/packager.rb
@@ -44,10 +44,5 @@ class Shoes
     rescue => e
       Shoes.logger.error "Looking up gems for packaging failed:\n#{e.message}"
     end
-
-    def help(program_name)
-      return "" if @backend.nil?
-      @backend.help(program_name)
-    end
   end
 end

--- a/shoes-core/lib/shoes/packager.rb
+++ b/shoes-core/lib/shoes/packager.rb
@@ -1,32 +1,21 @@
 # frozen_string_literal: true
 class Shoes
   class Packager
-    attr_reader :packages, :backend
+    attr_reader :backend
 
     def initialize
-      begin
-        @backend = Shoes.backend_for(self)
-        configure_gems
-      rescue ArgumentError
-        # Packaging unsupported by this backend
-      end
-      @packages = []
+      @backend = Shoes.backend_for(self)
+      configure_gems
+    rescue ArgumentError
+      # Packaging unsupported by this backend
     end
 
     def options
-      OptionParser.new do |opts|
-        opts.on('-p', '--package PACKAGE_TYPE', 'Package as BACKEND:PACKAGE') do |package|
-          create_package("shoes", package)
-        end
-      end
+      @backend.options
     end
 
     def parse!(args)
       options.parse!(args)
-    end
-
-    def create_package(program_name, package)
-      @packages << @backend.create_package(program_name, package)
     end
 
     def run(path)

--- a/shoes-core/lib/shoes/ui/cli/package_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/package_command.rb
@@ -11,6 +11,12 @@ class Shoes
 
           path = args[1]
           @packager.run(path)
+        rescue OptionParser::InvalidOption => e
+          puts "Whoops! #{e.message}"
+          puts
+          puts self.class.help
+
+          false
         end
 
         def self.help

--- a/shoes-core/spec/shoes/packager_spec.rb
+++ b/shoes-core/spec/shoes/packager_spec.rb
@@ -28,9 +28,4 @@ describe Shoes::Packager do
     expect(subject.backend).to receive(:run)
     subject.run("path/to/shoes/app.rb")
   end
-
-  it "delegates help" do
-    expect(subject.backend).to receive(:help)
-    subject.help("program")
-  end
 end

--- a/shoes-core/spec/shoes/packager_spec.rb
+++ b/shoes-core/spec/shoes/packager_spec.rb
@@ -4,11 +4,6 @@ require 'spec_helper'
 describe Shoes::Packager do
   subject { Shoes::Packager.new }
 
-  it "creates packages" do
-    expect(subject.backend).to receive(:create_package).and_call_original
-    subject.create_package("program", "swt:app")
-  end
-
   if defined?(::Bundler)
     it "detects Bundler and includes gems" do
       expect(subject.backend.gems).to_not be_empty

--- a/shoes-core/spec/shoes/ui/cli/package_command_spec.rb
+++ b/shoes-core/spec/shoes/ui/cli/package_command_spec.rb
@@ -4,9 +4,11 @@ require 'spec_helper'
 describe Shoes::UI::CLI::PackageCommand do
   subject(:command) { Shoes::UI::CLI::PackageCommand.new([]) }
 
-  let(:packager) { double("packager", parse!: nil, run: nil) }
+  let(:packager) { double("packager", parse!: nil, options: options, run: nil) }
+  let(:options)  { double("options", summarize: ["summary"]) }
 
   before do
+    allow(command).to receive(:puts)
     allow(Shoes::Packager).to receive(:new).and_return(packager)
   end
 
@@ -14,6 +16,14 @@ describe Shoes::UI::CLI::PackageCommand do
     expect(packager).to receive(:run).with("app.rb")
 
     command.args << "package" << "app.rb"
+    command.run
+  end
+
+  it "fails with error message" do
+    expect(command).to receive(:puts).with(/Whoops/)
+    expect(command).to_not receive(:load)
+
+    allow(packager).to receive(:parse!).and_raise(OptionParser::InvalidOption)
     command.run
   end
 

--- a/shoes-package/lib/shoes/package.rb
+++ b/shoes-package/lib/shoes/package.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 class Shoes
   module Package
-    def self.create_packager(config, wrapper)
+    def self.create_packager(config, package_type)
       require 'furoshiki/jar'
       require 'furoshiki/jar_app'
 
-      case wrapper
-      when 'jar'
+      case package_type
+      when :jar
         ::Furoshiki::Jar.new(config)
-      when 'app'
+      when :mac
         ::Furoshiki::JarApp.new(config)
       else
-        abort "shoes: Don't know how to make #{config.backend}:#{wrapper} packages"
+        abort "shoes: Don't know how to make #{package_type} packages"
       end
     end
   end

--- a/shoes-swt/lib/shoes/swt/packager.rb
+++ b/shoes-swt/lib/shoes/swt/packager.rb
@@ -12,17 +12,14 @@ class Shoes
 
       def options
         OptionParser.new do |opts|
-          opts.on('-p', '--package PACKAGE_TYPE', 'Package as BACKEND:PACKAGE') do |package|
-            @packages << create_package("shoes", package)
+          opts.on('--jar', 'Package as executable JAR file') do
+            @packages << :jar
+          end
+
+          opts.on('--mac', 'Package as OS X application') do
+            @packages << :mac
           end
         end
-      end
-
-      def create_package(program_name, package)
-        unless package =~ /^(swt):(app|jar)$/
-          abort("#{program_name}: Can't package as '#{package}'. See '#{program_name} --help'")
-        end
-        package.split(':')
       end
 
       def run(path)
@@ -35,9 +32,9 @@ class Shoes
           abort "shoes: #{e.message}"
         end
 
-        @packages.each do |backend, wrapper|
-          puts "Packaging #{backend}:#{wrapper}..."
-          packager = ::Shoes::Package.create_packager(config, wrapper)
+        @packages.each do |package_type|
+          puts "Packaging #{package_type}..."
+          packager = ::Shoes::Package.create_packager(config, package_type)
           packager.package
         end
       end

--- a/shoes-swt/lib/shoes/swt/packager.rb
+++ b/shoes-swt/lib/shoes/swt/packager.rb
@@ -7,6 +7,15 @@ class Shoes
       def initialize(dsl)
         @dsl  = dsl
         @gems = []
+        @packages = []
+      end
+
+      def options
+        OptionParser.new do |opts|
+          opts.on('-p', '--package PACKAGE_TYPE', 'Package as BACKEND:PACKAGE') do |package|
+            @packages << create_package("shoes", package)
+          end
+        end
       end
 
       def create_package(program_name, package)
@@ -26,7 +35,7 @@ class Shoes
           abort "shoes: #{e.message}"
         end
 
-        @dsl.packages.each do |backend, wrapper|
+        @packages.each do |backend, wrapper|
           puts "Packaging #{backend}:#{wrapper}..."
           packager = ::Shoes::Package.create_packager(config, wrapper)
           packager.package

--- a/shoes-swt/lib/shoes/swt/packager.rb
+++ b/shoes-swt/lib/shoes/swt/packager.rb
@@ -32,34 +32,6 @@ class Shoes
           packager.package
         end
       end
-
-      def help(program_name)
-        <<-EOS
-
-    Package types:
-#{package_types}
-    Examples:
-#{examples(program_name)}
-        EOS
-      end
-
-      def package_types
-        <<-EOS
-    swt:app     A standalone OS X executable with the Swt backend
-    swt:jar     An executable JAR with the Swt backend
-        EOS
-      end
-
-      def examples(program_name)
-        <<-EOS
-    To run a Shoes app:
-      #{program_name} path/to/shoes-app.rb
-
-    Two ways to package a Shoes app as an APP and a JAR, using the Swt backend:
-      #{program_name} -p swt:app -p swt:jar path/to/app.yaml
-      #{program_name} -p swt:app -p swt:jar path/to/shoes-app.rb
-          EOS
-      end
     end
   end
 end

--- a/shoes-swt/spec/shoes/cli_spec.rb
+++ b/shoes-swt/spec/shoes/cli_spec.rb
@@ -10,7 +10,7 @@ describe Shoes::UI::CLI do
 
   it 'does not raise an error for a normal packaging command #624' do
     expect do
-      subject.run ['package', '-p', 'swt:app', 'samples/simple_sound.rb']
+      subject.run ['package', '--jar', 'samples/simple_sound.rb']
     end.not_to raise_error
   end
 end


### PR DESCRIPTION
Tidies up our handling around packaging command-line arguments and changes them around a bit. Now a command looks like this:

```
shoes --jar --mac path-to-package.rb
```

Obviously, [more platform flags will be coming soon](https://github.com/shoes/shoes4/issues/1415#issuecomment-289256990)!

Additionally this pushes the specific options allowed down to the current backend which is being used. This avoids some of the backend awkwardness we had before... if we ever allow one backend to package for another, we can re-address how that'd work at that point in time.