### PR TITLE
Include packaged rb location in LOAD_PATH

### DIFF
--- a/shoes-package/lib/warbler/traits/shoes.rb
+++ b/shoes-package/lib/warbler/traits/shoes.rb
@@ -33,6 +33,9 @@ module Warbler
         require 'shoes'
         require 'shoes/swt'
 
+        app_dir = File.join(__FILE__, "..", "..", "shoes-app")
+        $LOAD_PATH.unshift(app_dir)
+
         Shoes::Swt.initialize_backend
       EOS
 


### PR DESCRIPTION
Otherwise, you can't require files that we have packaged up alongside your target Ruby script

Using the `shoes` executable accomplishes this via similar means [at this location](https://github.com/shoes/shoes4/blob/master/shoes-core/lib/shoes/ui/cli.rb#L25) although I suspect I see a problem with that now which I'll PR shortly.

Fixes #924