### PR TITLE
Put actual script dir into $LOAD_PATH

### DIFF
--- a/samples/README
+++ b/samples/README
@@ -60,6 +60,7 @@ simple_polygon_line.rb
 simple_position_as_we_go.rb
 simple_progress_bar.rb
 simple_random_bubbles.rb
+simple_require.rb
 simple_sample_executor.rb
 simple_sesame_street_shoes.rb
 simple_shoes_intro.rb

--- a/samples/require_me.rb
+++ b/samples/require_me.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class RequireMe
   def self.message
     "This came from another file we required"

--- a/samples/require_me.rb
+++ b/samples/require_me.rb
@@ -1,0 +1,5 @@
+class RequireMe
+  def self.message
+    "This came from another file we required"
+  end
+end

--- a/samples/simple_require.rb
+++ b/samples/simple_require.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+#
 # This app tests that we are correctly setting load paths so files in the
 # executing directory can be required withour require_relative shenanigans.
 require 'require_me'

--- a/samples/simple_require.rb
+++ b/samples/simple_require.rb
@@ -1,0 +1,7 @@
+# This app tests that we are correctly setting load paths so files in the
+# executing directory can be required withour require_relative shenanigans.
+require 'require_me'
+
+Shoes.app do
+  para RequireMe.message
+end

--- a/shoes-core/lib/shoes/ui/cli/default_command.rb
+++ b/shoes-core/lib/shoes/ui/cli/default_command.rb
@@ -6,7 +6,12 @@ class Shoes
         def run
           if parse!(args)
             warn_on_unexpected_parameters
-            load args.first
+
+            path = args.first
+            if path
+              $LOAD_PATH.unshift(File.dirname(path))
+              load path
+            end
           end
         end
 


### PR DESCRIPTION
As alluded to in #1425, when we're loading from the `shoes` executable, if we point to a subdirectory and that does a `require` for a file that's alongside it, that doesn't work. If you're in the directory with the script, then it does work.

Examples, placed in `testing` directory:

```
# testing/requires.rb
require 'required'

Shoes.app do
  para Required.message
end
```

```
# testing/required.rb
class Required
  def self.message
    "This is from that other file"
  end
end
```

When run, you get the following:

```
$ bin/shoes testing/requires.rb
LoadError: no such file to load -- required
  require at org/jruby/RubyKernel.java:961
   <main> at /Users/jason/source/shoes4/testing/requires.rb:1
     load at org/jruby/RubyKernel.java:979
   (root) at /Users/jason/source/shoes4/shoes-core/lib/shoes/ui/cli/default_command.rb:1
      run at /Users/jason/source/shoes4/shoes-core/lib/shoes/ui/cli/default_command.rb:9
   <main> at /Users/jason/source/shoes4/shoes-core/lib/shoes/ui/cli.rb:37
     load at org/jruby/RubyKernel.java:979
   <main> at /Users/jason/source/shoes4/shoes-swt/bin/shoes-swt:12
```

This change now places the directory where we're actually finding our root script into the `$LOAD_PATH` so things get found as expected. This aligns too with #1425 where that directory will be in the `$LOAD_PATH` for packaged apps too (which don't use the executable)