### PR TITLE
Extract image handling for reuse in pattern

### DIFF
--- a/shoes-swt/lib/shoes/swt.rb
+++ b/shoes-swt/lib/shoes/swt.rb
@@ -59,6 +59,7 @@ class Shoes
       require 'shoes/swt/common/clickable'
       require 'shoes/swt/common/container'
       require 'shoes/swt/common/fill'
+      require 'shoes/swt/common/image_handling'
       require 'shoes/swt/common/resource'
       require 'shoes/swt/common/painter'
       require 'shoes/swt/common/painter_updates_position'

--- a/shoes-swt/lib/shoes/swt/common/image_handling.rb
+++ b/shoes-swt/lib/shoes/swt/common/image_handling.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+class Shoes
+  module Swt
+    module Common
+      module ImageHandling
+        # Why copy the file to a temporary location just to pass a different name
+        # to load? Because SWT doesn't like us when we're packaged!
+        #
+        # Apparently the warbler-style path names we end up with for relative
+        # image paths don't cross nicely to SWT, so we need to resolve the paths
+        # in Ruby-land before handing it over.
+        def load_file_image_data(name)
+          tmpname = File.join(Dir.tmpdir, "__shoes4_#{Time.now.to_f}_#{File.basename(name)}")
+          FileUtils.cp(name, tmpname)
+
+          @cleanup_files ||= []
+          @cleanup_files << tmpname
+          tmpname
+        end
+
+        def cleanup_temporary_files
+          return unless @cleanup_files
+
+          @cleanup_files.each do |file|
+            begin
+              FileUtils.rm(file)
+            rescue => e
+              Shoes.logger.debug("Error during image temp file cleanup.\n#{e.class}: #{e.message}")
+            end
+          end
+          @cleanup_files.clear
+        end
+      end
+    end
+  end
+end

--- a/shoes-swt/lib/shoes/swt/common/image_handling.rb
+++ b/shoes-swt/lib/shoes/swt/common/image_handling.rb
@@ -10,7 +10,7 @@ class Shoes
         # image paths don't cross nicely to SWT, so we need to resolve the paths
         # in Ruby-land before handing it over.
         def load_file_image_data(name)
-          tmpname = File.join(Dir.tmpdir, "__shoes4_#{Time.now.to_f}_#{File.basename(name)}")
+          tmpname = File.join(Dir.tmpdir, "__shoes4_#{Time.now.to_i}_#{File.basename(name)}")
           FileUtils.cp(name, tmpname)
 
           @cleanup_files ||= []

--- a/shoes-swt/lib/shoes/swt/image_pattern.rb
+++ b/shoes-swt/lib/shoes/swt/image_pattern.rb
@@ -3,6 +3,7 @@ class Shoes
   module Swt
     class ImagePattern
       include Common::Remove
+      include Common::ImageHandling
 
       def initialize(dsl)
         @dsl = dsl
@@ -16,8 +17,11 @@ class Shoes
       # Since colors are bound up (at least in specs) with image patterns,
       # we can't safely touch images during initialize, so lazily load them.
       def pattern
-        @image   ||= ::Swt::Image.new(Shoes.display, @dsl.path)
+        @image   ||= ::Swt::Image.new(Shoes.display, load_file_image_data(@dsl.path))
         @pattern ||= ::Swt::Pattern.new(Shoes.display, @image)
+        cleanup_temporary_files
+
+        @pattern
       end
 
       def apply_as_fill(gc, _dsl)

--- a/shoes-swt/spec/shoes/swt/image_pattern_spec.rb
+++ b/shoes-swt/spec/shoes/swt/image_pattern_spec.rb
@@ -14,6 +14,9 @@ describe Shoes::Swt::ImagePattern do
   before do
     allow(::Swt::Image).to receive(:new)   { swt_image }
     allow(::Swt::Pattern).to receive(:new) { swt_pattern }
+
+    allow(::FileUtils).to receive(:cp)
+    allow(::FileUtils).to receive(:rm)
   end
 
   describe "#dispose" do


### PR DESCRIPTION
First part of getting #1428. Second part (relative image paths) will wait until #1429 lands for further extraction.

Basically just pulls the temporary file handling dance out into a module so both `Shoes::Swt::Image` and `Shoes::Swt::ImagePattern` can use it.