### PR TITLE
Travis: CI against jruby-9.1.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ script:
   - bundle exec rake
 rvm:
   - jruby-head
-  - jruby-9.1.8.0
+  - jruby-9.1.10.0
 jdk:
   - openjdk7
   - oraclejdk8


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.