### PR TITLE
Helper scripts to run samples faster

### DIFF
--- a/bin/run-sample
+++ b/bin/run-sample
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+puts "STARTED"
+puts "Child process #{$$} started"
+
+sample = ARGV[0]
+parent = ARGV[1].to_i
+ready  = ARGV[2] == "true"
+
+require 'bundler/setup'
+require 'shoes'
+
+# Signal we expect from parent when we're set to go
+Signal.trap("HUP") do
+  ready = true
+end
+
+# Let parent know we're ready
+Process.kill("HUP", parent)
+
+# Wait until we're signaled
+until ready
+end
+
+puts "Running #{sample} in #{$$}"
+load sample

--- a/bin/run-sample
+++ b/bin/run-sample
@@ -1,14 +1,20 @@
 #!/usr/bin/env ruby
-
-puts "STARTED"
-puts "Child process #{$$} started"
+# frozen_string_literal: true
 
 sample = ARGV[0]
 parent = ARGV[1].to_i
-ready  = ARGV[2] == "true"
+index  = ARGV[2].to_i
+total  = ARGV[3].to_i
+ready  = false
 
 require 'bundler/setup'
 require 'shoes'
+
+# A few samples tamper with things so we need to force backend loading early
+$LOAD_PATH.unshift(File.dirname(sample))
+
+require 'shoes/swt'
+Shoes::Swt.initialize_backend
 
 # Signal we expect from parent when we're set to go
 Signal.trap("HUP") do
@@ -19,8 +25,7 @@ end
 Process.kill("HUP", parent)
 
 # Wait until we're signaled
-until ready
-end
+sleep 0.2 until ready
 
-puts "Running #{sample} in #{$$}"
+puts "Running #{sample} (#{index} of #{total})...quit to run next sample"
 load sample

--- a/bin/run-samples
+++ b/bin/run-samples
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+
+require 'open3'
+require 'thread'
+
+$signals = Queue.new
+
+Signal.trap("HUP") do
+  $signals << true
+end
+
+puts "Parent process #{$$}"
+
+def start(sample, ready = false)
+  return nil unless sample
+
+  Process.spawn("bin/run-sample #{sample} #{$$}")
+end
+
+def run(pid)
+  # Make sure child has signaled back before we tell it to proceed...
+  $signals.pop
+  Process.kill("HUP", pid)
+  Process.wait(pid)
+end
+
+samples = ARGV.dup
+
+current_child = start(samples.shift)
+next_child    = start(samples.shift)
+run(current_child)
+
+until next_child.nil?
+  current_child = next_child
+  next_child = start(samples.shift)
+  run(current_child)
+end

--- a/bin/run-samples
+++ b/bin/run-samples
@@ -1,6 +1,14 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# Because of JRuby startup time, it can be a drag running all 100+ samples.
+# This helper alleviates some of the pain.
+#
+# The basic idea is to just have two processes running at all times--one
+# current, the other in a pending state waiting to be signaled to start up.
+# While you're using the current sample, the next process is getting through
+# the JRuby load-time... winning!
+#
 require 'thread'
 
 class SampleRunner

--- a/bin/run-samples
+++ b/bin/run-samples
@@ -1,37 +1,68 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-require 'open3'
 require 'thread'
 
-$signals = Queue.new
+class SampleRunner
+  def initialize(samples)
+    @samples = samples
+    @run_count = 0
+    @total_count = samples.count
 
-Signal.trap("HUP") do
-  $signals << true
+    @ready_signals = Queue.new
+    Signal.trap("HUP") do
+      @ready_signals << true
+    end
+  end
+
+  def start_child_process(sample)
+    return nil unless sample
+
+    @run_count += 1
+    Process.spawn("bin/run-sample #{sample} #{Process.pid} #{@run_count} #{@total_count}")
+  end
+
+  def run_process(pid)
+    # When we're done, you'll get a nil pid so bail
+    return unless pid
+
+    wait_for_child_to_signal_readiness
+
+    signal_child_to_proceed(pid)
+    wait_for_child_to_finish(pid)
+  end
+
+  def run
+    current_child = next_child = start_first_process
+
+    while current_child
+      current_child = next_child
+      next_child    = start_child_process(@samples.shift)
+      run_process(current_child)
+    end
+  end
+
+  # Because #1 and #2 start together, we must ensure we actually got #1's
+  # signal before starting #2. Wait on signal and restore it before going on.
+  def start_first_process
+    start_child_process(@samples.shift).tap do
+      @ready_signals.pop
+      @ready_signals << true
+    end
+  end
+
+  def wait_for_child_to_signal_readiness
+    @ready_signals.pop
+  end
+
+  def signal_child_to_proceed(pid)
+    Process.kill("HUP", pid)
+  end
+
+  def wait_for_child_to_finish(pid)
+    Process.wait(pid)
+  end
 end
 
-puts "Parent process #{$$}"
-
-def start(sample, ready = false)
-  return nil unless sample
-
-  Process.spawn("bin/run-sample #{sample} #{$$}")
-end
-
-def run(pid)
-  # Make sure child has signaled back before we tell it to proceed...
-  $signals.pop
-  Process.kill("HUP", pid)
-  Process.wait(pid)
-end
-
-samples = ARGV.dup
-
-current_child = start(samples.shift)
-next_child    = start(samples.shift)
-run(current_child)
-
-until next_child.nil?
-  current_child = next_child
-  next_child = start(samples.shift)
-  run(current_child)
-end
+runner = SampleRunner.new(ARGV.dup)
+runner.run

--- a/tasks/sample.rb
+++ b/tasks/sample.rb
@@ -22,14 +22,17 @@ namespace :samples do
 
   def run_sample(sample_name, index, total)
     puts "Running #{sample_name} (#{index + 1} of #{total})...quit to run next sample"
-    shoes_executable = ENV["SHOES_USE_INSTALLED"] ? "shoes" : "bin/shoes"
-    system "#{shoes_executable} #{sample_name}"
+    system "shoes #{sample_name}"
   end
 
   def run_samples(samples, start_with = 0)
-    samples.each_with_index do |sample, index|
-      next unless index >= start_with
-      run_sample(sample, index, samples.size)
+    if ENV["SHOES_USE_INSTALLED"]
+      samples.each_with_index do |sample, index|
+        next unless index >= start_with
+        run_sample(sample, index, samples.size)
+      end
+    else
+      system "bin/run-samples #{samples[start_with..-1].join(' ')}"
     end
   end
 


### PR DESCRIPTION
As noted over in #1015, startup time on samples is a drag.

I'd fiddled before with [my own suggestion in the issue](https://github.com/shoes/shoes4/issues/1015#issuecomment-262448017), but multiple samples coexisting and reloading into the same process has some gnarly side-effects. It just isn't the same as launching the apps by themselves per the normal process.

Fortunately, I found a way to get around it 🎉. The basic approach is to just keep two processes running at all times (until we're done): the current one, and the next one. The next one is held in a pending state until the current completes, then we signal next to proceed and spawn a new "next" process. Each process is fully independent, but the next one can hit JRuby boot-time while we're busy interacting with the preceding sample!

Marked as WIP because I don't have it hooked up to the Rake tasks and will give it a thorough run-through to get my first pass of `pre10` testing done. So far it's gotten things down to just 1 second or so between sample apps showing up vs 5-7 seconds previously.

TODO:
* [x] Testing
* [x] Rakefile hookup
* [x] Make Rubocop happy
