### PR TITLE
Properly dispose of ArrowPainter

### DIFF
--- a/shoes-swt/lib/shoes/swt/arrow_painter.rb
+++ b/shoes-swt/lib/shoes/swt/arrow_painter.rb
@@ -52,7 +52,12 @@ class Shoes
         end
       end
 
+      def dispose
+        clear_path
+      end
+
       def clear_path
+        @path.dispose unless @path.nil? || @path.disposed?
         @path = nil
       end
     end

--- a/shoes-swt/spec/shoes/swt/arrow_painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/arrow_painter_spec.rb
@@ -35,4 +35,9 @@ describe Shoes::Swt::ArrowPainter do
     expect(gc).to receive(:fill_path).with(subject.path)
     subject.paint_control(event)
   end
+
+  it "disposes when clearing path" do
+    expect(subject.path).to receive(:dispose)
+    subject.clear_path
+  end
 end


### PR DESCRIPTION
Fixes #1454 

Got things half right... the `Shoes::Swt::ArrowPainter` uses `::Swt::Path` which does in fact deserve to be disposed (hence the half-baked attempt to clean up). However, the painter never got the right `dispose` definition, hence the reported failure.

Now tidies up after itself nice and cleanly.

Test app:

```
# frozen_string_literal: true
class ArrowFail < Shoes
  url '/',     :index
  url '/away', :away

  def index
    rect 100, 100, 100, 100
    para link("away", click: "/away")
  end

  def away
    arrow 100, top: 100, width: 100, fill: green
    para link("back", click: "/")
  end
end

Shoes.app width: 200, height: 200
```