### PR TITLE
Warn if no packaging formats passed

### DIFF
--- a/shoes-swt/lib/shoes/swt/packager.rb
+++ b/shoes-swt/lib/shoes/swt/packager.rb
@@ -31,6 +31,11 @@ class Shoes
       end
 
       def run(path)
+        if @packages.empty?
+          puts "You must select at least one packaging format.\n\n#{::Shoes::UI::CLI::PackageCommand.help}"
+          return
+        end
+
         begin
           require 'shoes/package'
           require 'shoes/package/configuration'

--- a/shoes-swt/spec/shoes/swt/packager_spec.rb
+++ b/shoes-swt/spec/shoes/swt/packager_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+require 'shoes/package'
+require 'shoes/package/configuration'
+
+describe Shoes::Swt::Packager do
+  subject { Shoes::Swt::Packager.new(dsl) }
+
+  let(:dsl)      { double("dsl") }
+  let(:config)   { double("config", gems: []) }
+  let(:packager) { double("packager") }
+  let(:gems)     { [] }
+
+  before do
+    allow(subject).to receive(:puts)
+    allow(Shoes::Package::Configuration).to receive(:load).and_return(config)
+    allow(Shoes::Package).to receive(:create_packager).and_return(packager)
+  end
+
+  it "balks at empty packages" do
+    expect(subject).to receive(:puts).with(/You must select/)
+    subject.run("somewhere.rb")
+  end
+
+  it "runs when given packaging formats" do
+    expect(packager).to receive(:package)
+    subject.options.parse("--jar")
+    subject.run("somewhere")
+  end
+end


### PR DESCRIPTION
Fixes #1449

```
$ bin/shoes package something.rb
You must select at least one packaging format.

shoes package [options] file
        --jar                        Package as executable JAR file
        --mac                        Package as OS X application
        --windows                    Package as Windows application
        --linux                      Package as Linux application

    Packages may be built either from a single .rb file, or a .yaml file with
    more options defined.
```