### PR TITLE
Sniff around for Gemfiles

### DIFF
--- a/shoes-swt/bin/shoes-swt
+++ b/shoes-swt/bin/shoes-swt
@@ -8,7 +8,7 @@ $LOAD_PATH << lib_directory
 # and packaging apps that have their own Gemfiles, even if we run `shoes` from
 # another location.
 candidates = (ARGV + ["."]).map do |candidate|
-  File.join(File.dirname(candidate), "Gemfile")
+  File.expand_path(File.join(File.dirname(candidate), "Gemfile"))
 end
 
 gemfile = candidates.uniq.find do |candidate|
@@ -16,12 +16,12 @@ gemfile = candidates.uniq.find do |candidate|
 end
 
 if gemfile
-  if defined?(Bundler) && gemfile != Bundler.default_gemfile
+  if defined?(Bundler) && gemfile != Bundler.default_gemfile.to_s
     puts <<~EOS
-Shoes wants to load the Gemfile from '#{gemfile}'
-But you've already loaded Gemfile at '#{Bundler.default_gemfile}'
+      Shoes wants to load the Gemfile from '#{gemfile}'
+      But you've already loaded Gemfile at '#{Bundler.default_gemfile}'
 
-Instead of `bundle exec shoes`, try just `shoes` instead. We'll load Bundler for you.
+      Instead of `bundle exec shoes`, try just `shoes` instead. We'll load Bundler for you.
 
     EOS
   end

--- a/shoes-swt/bin/shoes-swt
+++ b/shoes-swt/bin/shoes-swt
@@ -3,7 +3,31 @@
 lib_directory = File.expand_path('../../lib', __FILE__)
 $LOAD_PATH << lib_directory
 
-if File.exist?("Gemfile")
+# We want the Gemfile alongside the Shoes code that we're executing, not
+# necessarily the Gemfile in our current directory. This helps in both running
+# and packaging apps that have their own Gemfiles, even if we run `shoes` from
+# another location.
+candidates = (ARGV + ["."]).map do |candidate|
+  File.join(File.dirname(candidate), "Gemfile")
+end
+
+gemfile = candidates.uniq.find do |candidate|
+  File.exist?(candidate)
+end
+
+if gemfile
+  if defined?(Bundler) && gemfile != Bundler.default_gemfile
+    puts <<~EOS
+Shoes wants to load the Gemfile from '#{gemfile}'
+But you've already loaded Gemfile at '#{Bundler.default_gemfile}'
+
+Instead of `bundle exec shoes`, try just `shoes` instead. We'll load Bundler for you.
+
+    EOS
+  end
+
+  # Thanks Bundler for the ENV vars! <3
+  ENV["BUNDLE_GEMFILE"] = gemfile
   require "bundler/setup"
   Bundler.require
 end


### PR DESCRIPTION
Fixes #1452

Our problem with packaging (and sometimes running!) apps from outside their directories boils down to the fact that Bundler by default will load `Gemfile` from your current directory. In the case where we're executing a file in a subdirectory (say `samples/packaging/actively_supported`), that isn't what we want.

This commit adds some sniffing logic before we actually call to Bundler in our main executable. This will:

* Look at our args to figure out which of them might point to a file that has a `Gemfile` alongside it
* Check whether we've already loaded Bundler (via `bundle exec`) and warn about it
* Reset `ENV["BUNDLE_GEMFILE"]` before we do the `Bundle.require` so we get the desired bundle loaded

Unfortunately since this is so early in our loading, it's a little problematic to put the code in another file that we load, which hampers testing, but I've done a reasonable amount with it locally and will pay special attention to this case in my cross-platform testing for the upcoming release.