### PR TITLE
Emit a meaningful error if JRuby runs shoes

### DIFF
--- a/bin/shoes-stub
+++ b/bin/shoes-stub
@@ -3,6 +3,14 @@
 # This script is symlinked to be present as both bin/shoes and bin/shoes-stub
 # See ext/install/Rakefile for the full explanation of why we do that.
 
+
+# What's this noise? For folks who don't have proper paths set up (i.e. not
+# using a version manager), they might try to run `jruby -S shoes ...` but then
+# Ruby tries to execute this file. This line gives a Ruby syntax error which
+# shows our message here, pointing them how to fix things, while still being a
+# no-op when run via shell.
+: Oops... Try shoes-swt instead of shoes.
+
 # Don't try to cd on an empty $NEXT_DIR (link in same directory)
 mac_move_to_link_dir () {
   # Skip if already in link directory


### PR DESCRIPTION
Fixes #1432

For folks that don't have a version manager for Ruby and the right paths set, it's pretty easy to try something like `jruby -S shoes ...` and get a bizarre syntax error in response:

```
SyntaxError: bin/shoes-stub:9: `$(' is not allowed as a global variable name
  NEXT_DIR=$(dirname $1)
```

This because our `shoes` executable is a shell script (for ["good reasons"](https://github.com/shoes/shoes4/blob/master/ext/install/Rakefile#L5-L17)) and running shell script through the Ruby interpreter yields, well, interesting results.

With this change we embrace that oddity, which yields:

```
SyntaxError: bin/shoes-stub:12: syntax error, unexpected ':'
: Oops... Try shoes-swt instead of shoes.
```

This works because evaluating `:` in shell effectively is a no-op, while in Ruby it causes a `SyntaxError` that prints the line. I tried a lot of other combos, but finding something that's a no-op in bash and prints an error in Ruby is a little finicky to say the least.

Open to improvements to the wording in the error message, but it has to be a single line to work with this scheme and I didn't want it to get too long.