### PR TITLE
Get samples/simple_accordion.rb working again

### DIFF
--- a/samples/README
+++ b/samples/README
@@ -7,6 +7,7 @@
 # Curious to know more? See https://github.com/shoes/shoes4/wiki/Samples-Guide
 # for more information about writing samples!
 
+simple_accordion.rb
 simple_alert.rb
 simple_altered_para.rb
 simple_anim_shapes.rb

--- a/samples/simple_accordion.rb
+++ b/samples/simple_accordion.rb
@@ -1,50 +1,68 @@
 # frozen_string_literal: true
-#
-# Broken until https://github.com/shoes/shoes4/issues/1440
-#
 module Accordion
+  OPEN_HEIGHT = 240
+
   def open_page(stack)
-    active = app.slot.contents.map { |x| x.contents[1] }
-                .detect { |x| x.height.positive? }
-    return if active == stack
+    if stack.height >= OPEN_HEIGHT
+      zero_other_pages(stack)
+      return
+    end
+
     a = animate 60 do
       stack.height += 20
-      active&.height = 240 - stack.height
-      a.stop if stack.height == 240
+      decrement_other_pages(stack)
+      a.stop if stack.height >= OPEN_HEIGHT
     end
   end
 
-  def page(title, text)
+  def other_pages(stack)
+    @pages.reject { |page| page == stack }
+          .reject { |page| page.height <= 0 }
+  end
+
+  def zero_other_pages(stack)
+    other_pages(stack).each do |page|
+      page.height = 0
+    end
+  end
+
+  def decrement_other_pages(stack)
+    other_pages(stack).each do |page|
+      page.height -= [page.height, 20].min
+    end
+  end
+
+  def page(title, active, text)
     @pages ||= []
-    @pages <<
-      stack do
-        page_text = nil
-        stack width: "100%" do
-          background "#fff".."#eed"
-          hi = background "#ddd".."#ba9", hidden: true
-          para link(title) {}, size: 26
-          hover { hi.show }
-          leave { hi.hide }
-          click { open_page page_text }
-        end
-        page_text =
-          stack width: "100%", height: (@pages.empty? ? 240 : 0) do
-            stack margin: 10 do
-              text.split(/\n{2,}/).each do |pg|
-                para pg
-              end
-            end
-          end
+    stack do
+      page_text = nil
+      header = stack width: "100%" do
+        background "#fff".."#eed"
+        hi = background "#ddd".."#ba9", hidden: true
+        para link(title) {}, size: 26
+        hover { hi.show }
+        leave { hi.hide }
       end
+
+      height = active ? OPEN_HEIGHT : 0
+      page_text = stack width: "100%", height: height do
+        para text
+      end
+      @pages << page_text
+
+      header.click do
+        open_page(page_text)
+      end
+    end
   end
 end
 
 Shoes.app do
   extend Accordion
-  style(Link, stroke: black, underline: nil, weight: "strong")
-  style(LinkHover, stroke: black, fill: nil, underline: nil)
+  style(Shoes::Link, stroke: black, underline: nil, weight: "strong")
+  style(Shoes::LinkHover, stroke: black, fill: nil, underline: nil)
 
-  page "0.0", <<-'END'
+  page "0.0", true, <<-'END'
 There is a thought
 I have just had
 Which I don’t care to pass to
@@ -55,7 +73,7 @@ But kept only the pleasures
 Of my property
 And of my controlled mental slippage.
 END
-  page "0.1", <<-'END'
+  page "0.1", false, <<-'END'
 My eyes have blinked again
 And I have just realized
 This upright world
@@ -66,7 +84,7 @@ My eyes hundreds of times
 Reseting and renovating
 The scenery.
 END
-  page "0.2", <<-'END'
+  page "0.2", false, <<-'END'
 Sister, without you,
 The universe would
 Have such a hole through it,

--- a/shoes-swt/lib/shoes/swt/redrawing_aspect.rb
+++ b/shoes-swt/lib/shoes/swt/redrawing_aspect.rb
@@ -35,8 +35,9 @@ class Shoes
                                                        :mouse_left],
                            ::Shoes::TextBlock      => [:replace] }.freeze
 
-      CHANGED_POSITION = { ::Shoes::Common::Positioning => [:_position, :displace],
-                           ::Shoes::Common::Hover       => [:eval_hover_block] }.freeze
+      CHANGED_POSITION = { ::Shoes::DimensionsDelegations => [:adjust_current_position],
+                           ::Shoes::Common::Positioning   => [:_position, :displace],
+                           ::Shoes::Common::Hover         => [:eval_hover_block] }.freeze
 
       attr_reader :app
 


### PR DESCRIPTION
Fixes #1440 

Sample was busted on both Shoes 3 and 4, so this gets it back into working order on both.

Noticed that we weren't getting proper redraws after the flush when expanding the bottom element on the screen. Will keep a close eye in testing that this doesn't regress anything, but definitely appears to be the correct thing to do at this moment.