### PR TITLE
Report right/bottom if possible

### DIFF
--- a/shoes-core/lib/shoes/dimension.rb
+++ b/shoes-core/lib/shoes/dimension.rb
@@ -27,7 +27,7 @@ class Shoes
     end
 
     def end
-      @end || report_relative_to_parent_end
+      @end || report_relative_to_parent_end || element_end
     end
 
     def extent

--- a/shoes-core/spec/shoes/dimension_spec.rb
+++ b/shoes-core/spec/shoes/dimension_spec.rb
@@ -190,7 +190,7 @@ describe Shoes::Dimension do
       subject.extent = 45
     end
 
-    its(:end) { should be_nil }
+    its(:end) { should eq(67) }
     its(:start) { should be_nil }
   end
 


### PR DESCRIPTION
Fixes #889 

That issue raises the question of breaking compatibility with Shoes 3 over the calculation of right (and as it turns out bottom) on elements that don't explicitly set it. This seems like a totally reasonable thing to me, and easy enough to accomplish as you can see with this change.

From a user's standpoint, this is clearly the behavior I'd expect so I'm good with making it that way. Only a single test broke, and it didn't provide rationale as to _why_ this behavior was good--just documented that we do it.

Will keep an eye out for broken samples in later testing, but almost nothing actually refers to `right` so I'm not tromping through them all just yet.