### PR TITLE
Apply radius to oval at initialization

### DIFF
--- a/samples/simple_oval.rb
+++ b/samples/simple_oval.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 Shoes.app do
-  oval 100, 100, 100
+  oval 100, 100, 100, 50
+  oval 200, 200, radius: 50
+  oval 300, 300, diameter: 100
 end

--- a/shoes-core/lib/shoes/oval.rb
+++ b/shoes-core/lib/shoes/oval.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 class Shoes
   class Oval < Common::ArtElement
-    style_with :art_styles, :center, :common_styles, :dimensions, :radius
+    style_with :art_styles, :center, :common_styles, :dimensions
     STYLES = { fill: Shoes::COLORS[:black] }.freeze
 
     def create_dimensions(left, top, width, height)
       left   ||= @style[:left] || 0
       top    ||= @style[:top] || 0
-      width  ||= @style[:diameter] || @style[:width] || (@style[:radius] || 0) * 2
+      width  ||= @style[:width] || @style[:diameter] || (@style[:radius] || 0) * 2
       height ||= @style[:height] || width
 
       @dimensions = AbsoluteDimensions.new left, top, width, height, @style

--- a/shoes-core/spec/shoes/oval_spec.rb
+++ b/shoes-core/spec/shoes/oval_spec.rb
@@ -108,6 +108,26 @@ describe Shoes::Oval do
                                       height: 40)
     end
 
+    it "favors width over radius" do
+      oval = dsl.oval 10, 20, width: 30, radius: 40
+      expect(oval.width).to eq(30)
+    end
+
+    it "favors width over diameter" do
+      oval = dsl.oval 10, 20, width: 30, diameter: 40
+      expect(oval.width).to eq(30)
+    end
+
+    it "supports radius" do
+      oval = dsl.oval 10, 20, radius: 40
+      expect(oval.width).to eq(80)
+    end
+
+    it "supports diameter" do
+      oval = dsl.oval 10, 20, diameter: 40
+      expect(oval.width).to eq(40)
+    end
+
     it "doesn't like too many arguments" do
       expect { dsl.oval 10, 20, 30, 40, 666 }.to raise_error(ArgumentError)
     end


### PR DESCRIPTION
Fixes #753

Testing things out against Shoes 3, from what I can tell `radius` is only respected at initialization-time, so I'm going to stick with that. `width` if passed is respected before `radius`.

Shoes 4 added `diameter`, and I made that come behind `width` in consideration.

Removed the accessor for `radius` from the object directly since it wasn't there in Shoes 3. Also updated `samples/simple_oval.rb` to show the other forms.