### PR TITLE
#close closes windows, #quit (and #exit) stops everything

### DIFF
--- a/shoes-core/lib/shoes/app.rb
+++ b/shoes-core/lib/shoes/app.rb
@@ -69,11 +69,13 @@ class Shoes
     end
 
     def quit
+      Shoes.apps.each(&:close)
+    end
+
+    def close
       Shoes.unregister self
       @__app__.quit
     end
-
-    alias close quit
 
     def parent
       @__app__.current_slot.parent

--- a/shoes-core/lib/shoes/app.rb
+++ b/shoes-core/lib/shoes/app.rb
@@ -72,6 +72,8 @@ class Shoes
       Shoes.apps.each(&:close)
     end
 
+    alias exit quit
+
     def close
       Shoes.unregister self
       @__app__.quit

--- a/shoes-core/spec/shoes/app_spec.rb
+++ b/shoes-core/spec/shoes/app_spec.rb
@@ -212,13 +212,30 @@ describe Shoes::App do
     end
 
     describe "quitting" do
-      it "#quit tells the GUI to quit" do
+      let(:another_app) { double('another', close: nil) }
+
+      before do
+        Shoes.register(another_app)
+      end
+
+      it "#quit tells the GUI and other apps to close, shuts down gui" do
+        expect(another_app).to receive :close
+        expect(subject).to receive :close
+        subject.quit
+      end
+
+      it "#quit passes along to GUI to quit" do
         expect(gui).to receive :quit
         subject.quit
       end
 
-      it '#close tells the GUI to quit' do
+      it '#close only tells our GUI to quit' do
         expect(gui).to receive :quit
+        subject.close
+      end
+
+      it '#close does not stop other app windows' do
+        expect(another_app).to_not receive :quit
         subject.close
       end
     end

--- a/shoes-core/spec/shoes/app_spec.rb
+++ b/shoes-core/spec/shoes/app_spec.rb
@@ -229,6 +229,11 @@ describe Shoes::App do
         subject.quit
       end
 
+      it "#exit is same as #quit for us" do
+        expect(gui).to receive :quit
+        subject.exit
+      end
+
       it '#close only tells our GUI to quit' do
         expect(gui).to receive :quit
         subject.close


### PR DESCRIPTION
Fixes #553
Fixes #894

As noted in the issue, `close` and `quit` were aliases in Shoes 4, but weren't in Shoes 3. Specifically, `close` just shuts the current window, while `quit` stops the whole app.

Shoes 4 now plays along with the scheme with one variation. Because we don't support multiple top-level windows in Shoes 4, once the last window `close`s, the app will exit where it hangs around in Shoes 3. I actually didn't like that behavior much anyway, but with our current setup it's really difficult to avoid and doesn't seem worthwhile.

Worth keeping an eye on in sample testing before release, but doesn't seem like worth holding things up for an independent round of testing.