### PR TITLE
Fix widgets to behave like real elements

### DIFF
--- a/samples/simple_menu.rb
+++ b/samples/simple_menu.rb
@@ -1,15 +1,5 @@
 # frozen_string_literal: true
 class MenuPanel < Shoes::Widget
-  # Handling width against internal stack until widget widths are fixed
-  # https://github.com/shoes/shoes4/issues/641
-  def width
-    @stack.width
-  end
-
-  def width=(value)
-    @stack.width = value
-  end
-
   def self.boxes
     @boxes ||= []
   end
@@ -18,14 +8,12 @@ class MenuPanel < Shoes::Widget
     self.class.boxes
   end
 
-  def initialize(color, args)
+  def initialize(color, _args)
     boxes << self
-    @stack = stack(args) do
-      background color
-      para link("Box #{boxes.length}", fg: white, fill: nil, click: "/"),
-           margin: 18, align: "center", size: 20
-      hover { expand }
-    end
+    background color
+    para link("Box #{boxes.length}", fg: white, fill: nil, click: "/"),
+         margin: 18, align: "center", size: 20
+    hover { expand }
   end
 
   def expand

--- a/shoes-core/lib/shoes/app.rb
+++ b/shoes-core/lib/shoes/app.rb
@@ -123,16 +123,19 @@ class Shoes
       inspect_details
     end
 
-    DELEGATE_BLACKLIST = [:parent, :app].freeze
-
     # class definitions are evaluated top to bottom, want to have all of them
     # so define at bottom
     DELEGATE_METHODS = ((Shoes::App.public_instance_methods(false) +
-                         Shoes::DSL.public_instance_methods) - DELEGATE_BLACKLIST).freeze
+                         Shoes::DSL.public_instance_methods)).freeze
 
     def self.subscribe_to_dsl_methods(klazz)
+      # Delegate anything in the app/dsl public list that DOESN'T have a method
+      # already defined on the class in question
+      methods_to_delegate = DELEGATE_METHODS - klazz.public_instance_methods
+
       klazz.extend Forwardable unless klazz.is_a? Forwardable
-      klazz.def_delegators :app, *DELEGATE_METHODS
+      klazz.def_delegators :app, *methods_to_delegate
+
       @method_subscribers ||= []
       @method_subscribers << klazz
     end

--- a/shoes-core/lib/shoes/common/hover.rb
+++ b/shoes-core/lib/shoes/common/hover.rb
@@ -5,6 +5,10 @@ class Shoes
       attr_reader :hover_blk, :leave_blk
 
       def self.included(base)
+        create_hover_class(base)
+      end
+
+      def self.create_hover_class(base)
         clazz = Class.new {}
         name = base.name.split("::").last
         Shoes.const_set("#{name}Hover", clazz)

--- a/shoes-core/lib/shoes/common/ui_element.rb
+++ b/shoes-core/lib/shoes/common/ui_element.rb
@@ -14,6 +14,16 @@ class Shoes
       attr_reader :app, :parent, :dimensions, :gui
 
       def initialize(app, parent, *args)
+        actual_initialize(app, parent, *args)
+      end
+
+      # Why is this separate? With Widgets, we need to invoke this base
+      # initialize, but ALSO a user-define initialize that historically didn't
+      # require calling super!
+      #
+      # Extracted like this, we can call actual_initialize to get base work
+      # done, and then initialize on the class ourselves to get the widget set.
+      def actual_initialize(app, parent, *args)
         blk    = args.pop if args.last.is_a?(Proc) || args.last.nil?
         styles = args.last.is_a?(Hash) ? args.pop : {}
 

--- a/shoes-core/lib/shoes/configuration.rb
+++ b/shoes-core/lib/shoes/configuration.rb
@@ -47,12 +47,17 @@ class Shoes
       # @example
       #   Shoes.configuration.backend_class(shoes_button) # => Shoes::Swt::Button
       def backend_class(object)
-        klazz = object.is_a?(Class) ? object : object.class
+        klazz = object.is_a?(Class) ? object : find_shoes_base_class(object)
         class_name = klazz.name.split("::").last
         # Lookup with false to not consult modules higher in the chain Object
         # because Shoes::Swt.const_defined? 'Range' => true
         raise ArgumentError, "#{object} does not have a backend class defined for #{backend}" unless backend.const_defined?(class_name, false)
         backend.const_get(class_name, false)
+      end
+
+      def find_shoes_base_class(object)
+        return object.shoes_base_class if object.respond_to?(:shoes_base_class)
+        object.class
       end
 
       # Creates an appropriate backend object, passing along additional

--- a/shoes-core/lib/shoes/mock/slot.rb
+++ b/shoes-core/lib/shoes/mock/slot.rb
@@ -18,5 +18,6 @@ class Shoes
 
     class Stack < Slot; end
     class Flow < Slot; end
+    class Widget < Slot; end
   end
 end

--- a/shoes-core/lib/shoes/widget.rb
+++ b/shoes-core/lib/shoes/widget.rb
@@ -38,6 +38,9 @@ class Shoes
     end
 
     def self.inherited(klass, &_blk)
+      # Ensure Hover styling class exists, but Widget gets hover behavior from parents
+      Shoes::Common::Hover.create_hover_class(klass)
+
       dsl_method = dsl_method_name(klass)
       Shoes::App.new_dsl_method(dsl_method) do |*args|
         # If last arg is a Hash, pass that to the underlying Flow

--- a/shoes-core/spec/shoes/app_spec.rb
+++ b/shoes-core/spec/shoes/app_spec.rb
@@ -435,10 +435,6 @@ describe Shoes::App do
       describe 'it does not have access to private methods' do
         it { is_expected.not_to include :pop_style, :style_normalizer, :create }
       end
-
-      describe 'there are blacklisted methods that wreck havoc' do
-        it { is_expected.not_to include :parent, :app }
-      end
     end
   end
 end

--- a/shoes-swt/lib/shoes/swt/slot.rb
+++ b/shoes-swt/lib/shoes/swt/slot.rb
@@ -49,5 +49,6 @@ class Shoes
 
     class Flow < Slot; end
     class Stack < Slot; end
+    class Widget < Slot; end
   end
 end


### PR DESCRIPTION
Fixes #641

This PR changes `Widget` to behave essentially as a `Flow` so it gets all the standard dimensions and styling it wasn't obeying before.

This has a big challenge, though, as the contract for `Widget` derived classes in older Shoes didn't for calling `super` from `#initialize`. We must run `UIElement#initialize` (or an equivalent) to get everything wired up, but we also need to run the user-defined `initialize` so the user's code runs.

Ruby's flexibility to the rescue! ✨  We can take the odd step of actually skipping `new` calls for the widgets and just `allocate` and `initialize` (in the order and timing we want, along with our base initialization) directly. 😱 Never thought I'd find a use for that bit of trivia, but here we are!

Other tidbits:

* Widget delegation before was touchy because it tried to delegate EVERYTHING to the app except a small set of methods we'd called out. Turns out, that's a bad plan, so instead now we delegate everything that the widget class doesn't define itself already.
* Added a new way for DSL classes to declare their own backend class directly for cases where the class names don't necessarily line up (ala people's custom-named classes, which need to be backed by `Shoes::Swt::Flow`)

Been using this app, in addition to the two samples with widgets (`samples/simple_menu.rb` and `samples/simple_guess_game.rb`):

```
class MyWidget < Shoes::Widget
  def initialize(color, args)
    background color
    para "thing"
    para "one"
    para "thing"
    para "one"
  end
end

Shoes.app do
  @w = my_widget green, width: 170, height: 120
  click do
    @w.left += 10
    @w.top += 10
  end
end
```