### PR TITLE
Fix widgets without doing manual allocate

### DIFF
--- a/samples/simple_guess_game.rb
+++ b/samples/simple_guess_game.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 class Answer < Shoes::Widget
   attr_reader :mark
-  def initialize(word)
+
+  def initialize_widget(word)
     mark = nil
     flow do
       flow(width: 70, height: 20) { para word }

--- a/samples/simple_menu.rb
+++ b/samples/simple_menu.rb
@@ -1,15 +1,5 @@
 # frozen_string_literal: true
 class MenuPanel < Shoes::Widget
-  # Handling width against internal stack until widget widths are fixed
-  # https://github.com/shoes/shoes4/issues/641
-  def width
-    @stack.width
-  end
-
-  def width=(value)
-    @stack.width = value
-  end
-
   def self.boxes
     @boxes ||= []
   end
@@ -18,14 +8,12 @@ class MenuPanel < Shoes::Widget
     self.class.boxes
   end
 
-  def initialize(color, args)
+  def initialize_widget(color, _args)
     boxes << self
-    @stack = stack(args) do
-      background color
-      para link("Box #{boxes.length}", fg: white, fill: nil, click: "/"),
-           margin: 18, align: "center", size: 20
-      hover { expand }
-    end
+    background color
+    para link("Box #{boxes.length}", fg: white, fill: nil, click: "/"),
+         margin: 18, align: "center", size: 20
+    hover { expand }
   end
 
   def expand

--- a/shoes-core/lib/shoes/app.rb
+++ b/shoes-core/lib/shoes/app.rb
@@ -123,16 +123,19 @@ class Shoes
       inspect_details
     end
 
-    DELEGATE_BLACKLIST = [:parent, :app].freeze
-
     # class definitions are evaluated top to bottom, want to have all of them
     # so define at bottom
     DELEGATE_METHODS = ((Shoes::App.public_instance_methods(false) +
-                         Shoes::DSL.public_instance_methods) - DELEGATE_BLACKLIST).freeze
+                         Shoes::DSL.public_instance_methods)).freeze
 
     def self.subscribe_to_dsl_methods(klazz)
+      # Delegate anything in the app/dsl public list that DOESN'T have a method
+      # already defined on the class in question
+      methods_to_delegate = DELEGATE_METHODS - klazz.public_instance_methods
+
       klazz.extend Forwardable unless klazz.is_a? Forwardable
-      klazz.def_delegators :app, *DELEGATE_METHODS
+      klazz.def_delegators :app, *methods_to_delegate
+
       @method_subscribers ||= []
       @method_subscribers << klazz
     end

--- a/shoes-core/lib/shoes/common/hover.rb
+++ b/shoes-core/lib/shoes/common/hover.rb
@@ -5,6 +5,10 @@ class Shoes
       attr_reader :hover_blk, :leave_blk
 
       def self.included(base)
+        create_hover_class(base)
+      end
+
+      def self.create_hover_class(base)
         clazz = Class.new {}
         name = base.name.split("::").last
         Shoes.const_set("#{name}Hover", clazz)

--- a/shoes-core/lib/shoes/common/ui_element.rb
+++ b/shoes-core/lib/shoes/common/ui_element.rb
@@ -14,16 +14,6 @@ class Shoes
       attr_reader :app, :parent, :dimensions, :gui
 
       def initialize(app, parent, *args)
-        actual_initialize(app, parent, *args)
-      end
-
-      # Why is this separate? With Widgets, we need to invoke this base
-      # initialize, but ALSO a user-define initialize that historically didn't
-      # require calling super!
-      #
-      # Extracted like this, we can call actual_initialize to get base work
-      # done, and then initialize on the class ourselves to get the widget set.
-      def actual_initialize(app, parent, *args)
         blk    = args.pop if args.last.is_a?(Proc) || args.last.nil?
         styles = args.last.is_a?(Hash) ? args.pop : {}
 

--- a/shoes-core/lib/shoes/common/ui_element.rb
+++ b/shoes-core/lib/shoes/common/ui_element.rb
@@ -14,6 +14,16 @@ class Shoes
       attr_reader :app, :parent, :dimensions, :gui
 
       def initialize(app, parent, *args)
+        actual_initialize(app, parent, *args)
+      end
+
+      # Why is this separate? With Widgets, we need to invoke this base
+      # initialize, but ALSO a user-define initialize that historically didn't
+      # require calling super!
+      #
+      # Extracted like this, we can call actual_initialize to get base work
+      # done, and then initialize on the class ourselves to get the widget set.
+      def actual_initialize(app, parent, *args)
         blk    = args.pop if args.last.is_a?(Proc) || args.last.nil?
         styles = args.last.is_a?(Hash) ? args.pop : {}
 

--- a/shoes-core/lib/shoes/configuration.rb
+++ b/shoes-core/lib/shoes/configuration.rb
@@ -47,12 +47,17 @@ class Shoes
       # @example
       #   Shoes.configuration.backend_class(shoes_button) # => Shoes::Swt::Button
       def backend_class(object)
-        klazz = object.is_a?(Class) ? object : object.class
+        klazz = object.is_a?(Class) ? object : find_shoes_base_class(object)
         class_name = klazz.name.split("::").last
         # Lookup with false to not consult modules higher in the chain Object
         # because Shoes::Swt.const_defined? 'Range' => true
         raise ArgumentError, "#{object} does not have a backend class defined for #{backend}" unless backend.const_defined?(class_name, false)
         backend.const_get(class_name, false)
+      end
+
+      def find_shoes_base_class(object)
+        return object.shoes_base_class if object.respond_to?(:shoes_base_class)
+        object.class
       end
 
       # Creates an appropriate backend object, passing along additional

--- a/shoes-core/lib/shoes/mock/slot.rb
+++ b/shoes-core/lib/shoes/mock/slot.rb
@@ -18,5 +18,6 @@ class Shoes
 
     class Stack < Slot; end
     class Flow < Slot; end
+    class Widget < Slot; end
   end
 end

--- a/shoes-core/lib/shoes/widget.rb
+++ b/shoes-core/lib/shoes/widget.rb
@@ -2,17 +2,22 @@
 class Shoes
   # This is the superclass for creating custom Shoes widgets.
   #
-  # To use, inherit from {Shoes::Widget}. You get a few magical effects:
+  # To use, inherit from {Shoes::Widget} and implement a initialize_widget
+  # method. You get a few magical effects:
   #
   # * When you inherit from {Shoes::Widget}, you get a method in your Apps to
   #   create your widgets. The method is lower- and snake-cased. It returns
   #   an instance of your widget class.
+  #
   # * Your widgets delegate missing methods to their app object. This
   #   allows you to use the Shoes DSL within your widgets.
   #
+  # * Your widget otherwise behaves like a flow. If the final parameter to
+  #   the widget method is a Hash, that will initialize the flow as well.
+  #
   # @example
   #   class SayHello < Shoes::Widget
-  #     def initialize word
+  #     def initialize_widget word
   #       para "Hello #{word}", stroke: green, size: 80
   #     end
   #   end
@@ -21,22 +26,23 @@ class Shoes
   #     say_hello 'Shoes'
   #   end
   #
-  class Widget
-    include Common::Inspect
-
+  class Widget < Shoes::Flow
     Shoes::App.subscribe_to_dsl_methods self
 
-    attr_accessor :parent
-    attr_writer :app
+    attr_accessor :original_args
 
-    class << self
-      attr_accessor :app
+    # Having Widget define initialize makes it easier for us to detect whether
+    # subclasses have inappropriately overridden it or not.
+    def initialize(*_)
+      super
     end
 
-    # lookup a bit more complicated as during initialize we do
-    # not have @app yet...
-    def app
-      @app || self.class.app
+    def initialize_widget
+      # Expected to be overridden by children but not guaranteed
+    end
+
+    def shoes_base_class
+      Shoes::Widget
     end
 
     def self.inherited(klass, &_blk)
@@ -44,20 +50,22 @@ class Shoes
       Shoes::Common::Hover.create_hover_class(klass)
 
       dsl_method = dsl_method_name(klass)
-      Shoes::App.new_dsl_method(dsl_method) do |*args, &blk|
-        # we set app 2 times because widgets execute most of their code
-        # straight in initialize. I dunno if there is a good way of setting
-        # an @app instance variable before initialize is executed. We could
-        # hand it over in #initialize but that would break the interface
-        # and people would have to set it themselves or make sure to call
-        # super so for not it's like this.
-        # Setting the ref on the instance is important as we might have
-        # instances of the same widget in different Shoes::Apps so each one
-        # needs to save the reference to the one it was started with
-        klass.app              = self
-        widget_instance        = klass.new(*args, &blk)
-        widget_instance.app    = self
-        widget_instance.parent = @__app__.current_slot
+      Shoes::App.new_dsl_method(dsl_method) do |*args|
+        # ***TODO: Validate that our Widget class abides by initialize_widget
+        # and not initialize contract, and warn if not!***
+
+        # If last arg is a Hash, pass that to the underlying Flow
+        container_args = args.last.is_a?(Hash) ? args.last : {}
+
+        # Expected to call through to initialize our underlying slot behavior
+        widget_instance = klass.new(@__app__, @__app__.current_slot, container_args)
+
+        # Call the user's widget initialization, with proper slot context
+        old_current_slot = @__app__.current_slot
+        @__app__.current_slot = widget_instance
+        widget_instance.initialize_widget(*args)
+        @__app__.current_slot = old_current_slot
+
         widget_instance
       end
     end

--- a/shoes-core/lib/shoes/widget.rb
+++ b/shoes-core/lib/shoes/widget.rb
@@ -40,6 +40,9 @@ class Shoes
     end
 
     def self.inherited(klass, &_blk)
+      # Ensure Hover styling class exists, but Widget gets hover behavior from parents
+      Shoes::Common::Hover.create_hover_class(klass)
+
       dsl_method = dsl_method_name(klass)
       Shoes::App.new_dsl_method(dsl_method) do |*args, &blk|
         # we set app 2 times because widgets execute most of their code

--- a/shoes-core/spec/shoes/app_spec.rb
+++ b/shoes-core/spec/shoes/app_spec.rb
@@ -435,10 +435,6 @@ describe Shoes::App do
       describe 'it does not have access to private methods' do
         it { is_expected.not_to include :pop_style, :style_normalizer, :create }
       end
-
-      describe 'there are blacklisted methods that wreck havoc' do
-        it { is_expected.not_to include :parent, :app }
-      end
     end
   end
 end

--- a/shoes-core/spec/shoes/widget_spec.rb
+++ b/shoes-core/spec/shoes/widget_spec.rb
@@ -18,6 +18,12 @@ class Face < Shoes::Widget
   end
 end
 
+class InvalidWidget < Shoes::Widget
+  def initialize
+    # This form is no longer supported...
+  end
+end
+
 describe Shoes::Widget do
   let(:app) { Shoes::App.new }
 
@@ -74,6 +80,21 @@ describe Shoes::Widget do
     it 'really smiles' do
       expect_any_instance_of(Smile).to receive(:smile_magic)
       Shoes.app { visit '/smile' }
+    end
+  end
+
+  describe 'initialization' do
+    it 'warns about invalid old-school initialize' do
+      Shoes.configuration.fail_fast = true
+
+      expect(Shoes.logger).to receive(:warn).with(/initialize.*initialize_widget/m)
+      expect(Shoes.logger).to receive(:error)
+
+      expect do
+        Shoes.app do
+          invalid_widget
+        end
+      end.to raise_error(ArgumentError)
     end
   end
 end

--- a/shoes-core/spec/shoes/widget_spec.rb
+++ b/shoes-core/spec/shoes/widget_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 class Smile < Shoes::Widget
-  def initialize(caption)
+  def initialize_widget(caption)
     smile_magic caption
   end
 
@@ -12,7 +12,7 @@ class Smile < Shoes::Widget
 end
 
 class Face < Shoes::Widget
-  def initialize
+  def initialize_widget
     para  "Hair"
     smile "Toothsome"
   end

--- a/shoes-swt/lib/shoes/swt/slot.rb
+++ b/shoes-swt/lib/shoes/swt/slot.rb
@@ -49,5 +49,6 @@ class Shoes
 
     class Flow < Slot; end
     class Stack < Slot; end
+    class Widget < Slot; end
   end
 end


### PR DESCRIPTION
Per @PragTob's suggestion on https://github.com/shoes/shoes4/pull/1475 here's an alternate PR that changes our contract with child classes to expect a `initialize_widget` instead of `initialize`.

TODOs
* [x] When the widget method is called, warn on whether the class disobeys our new rules for `initialize`. This is the best time to do it, since our `inherited` hooks happen too early to ensure everything's right.
* [x] Ahem, fix the tests so they pass 😓 
* [x] Also will want some docs/wiki updates about the change, probably on https://github.com/shoes/shoes4/wiki/Compatibility-with-Shoes-3