### PR TITLE
Switch ask dialog from quit to close

### DIFF
--- a/shoes-core/lib/shoes/dialog.rb
+++ b/shoes-core/lib/shoes/dialog.rb
@@ -31,12 +31,12 @@ class Shoes
           flow margin_top: 10 do
             button "OK", margin_left: 150 do
               @result = @e.text
-              quit
+              close
             end
 
             button "Cancel" do
               @result = nil
-              quit
+              close
             end
           end
         end


### PR DESCRIPTION
Changes from #1474 broke the `ask` method because it was shutting down our shoes-based dialog with `quit` instead of `close` like it should have.