### PR TITLE
Fix intermittent failure in integration_spec

### DIFF
--- a/shoes-core/spec/shoes/app_spec.rb
+++ b/shoes-core/spec/shoes/app_spec.rb
@@ -493,8 +493,12 @@ describe "App registry" do
     let(:app_1) { double("app 1") }
     let(:app_2) { double("app 2") }
 
-    before :each do
+    before do
       [app_1, app_2].each { |a| Shoes.register(a) }
+    end
+
+    after do
+      Shoes.unregister_all
     end
 
     its(:length) { should eq(2) }


### PR DESCRIPTION
Leftovers from app_spec.rb fails later on if you run this:

```
rspec   shoes-core/spec/shoes/app_spec.rb:500 shoes-swt/spec/shoes/swt/integration_spec.rb
```

Overall specs for swt failed on seed 46667 with this, which we hit once on an unrelated PR.