### PR TITLE
Synchronize opacity change in sample with size change

### DIFF
--- a/samples/good_psychidelic_circles.rb
+++ b/samples/good_psychidelic_circles.rb
@@ -21,10 +21,15 @@ Shoes.app width: 537, height: 500 do
     nostroke
     # Update some variables
     degree += 1
-    size += 1
     degree = 0 if degree >= 360
-    size = 0 if size >= 100
-    color = 0.0 if color >= 1.0
+
+    size += 1
+    if size >= 100
+      size = 0
+      # Synchronize opacity change with size change because floating points
+      color = 0.0 if color >= 0.75
+    end
+
     color += 0.05 if (degree % 10).zero?
 
     # Draw inner circle


### PR DESCRIPTION
Fixes #578

The jitter that was reported in that bug wasn't a redrawing issue, it was simply that we ended up switching the size one frame before we changed the opacity (on the second round when we go back to transparent).