### PR TITLE
Factor parent visibility in

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -100,6 +100,8 @@ Metrics/BlockLength:
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
   Max: 250
+  Exclude:
+    - 'shoes-core/lib/shoes/slot.rb'
 
 # Offense count: 10
 Metrics/CyclomaticComplexity:

--- a/shoes-core/lib/shoes/common/visibility.rb
+++ b/shoes-core/lib/shoes/common/visibility.rb
@@ -8,8 +8,10 @@ class Shoes
         self
       end
 
+      # Root method for determining whether we're visible or not, taking into
+      # account our parent chain's visibility.
       def hidden?
-        style[:hidden]
+        @parent&.hidden? || style[:hidden]
       end
 
       alias hidden hidden?
@@ -33,6 +35,11 @@ class Shoes
 
       private
 
+      # Backend elements are expected to respond to update_visibility, and use
+      # the hidden? or visible? accessors to assess their proper display state.
+      #
+      # These take into account parent visibility, versus styling which applies
+      # only to the element itself.
       def update_visibility
         gui.update_visibility
         self

--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -144,9 +144,7 @@ class Shoes
       scroll_height - height
     end
 
-    attr_reader :scroll_top
-
-    attr_writer :scroll_top
+    attr_accessor :scroll_top
 
     def app
       @app.app # return the Shoes::App not the internal app
@@ -325,6 +323,21 @@ class Shoes
       else
         0
       end
+    end
+
+    def update_visibility
+      # Only alter contents on a visibility change
+      if @last_hidden_state != hidden?
+        @last_hidden_state = hidden?
+
+        # Let the common visibility implementation update the backend
+        super
+
+        # Pass it along to all our children that they should update
+        contents.each(&:update_visibility)
+      end
+
+      self
     end
   end
 

--- a/shoes-core/spec/shoes/common/visibility_spec.rb
+++ b/shoes-core/spec/shoes/common/visibility_spec.rb
@@ -7,16 +7,19 @@ describe Shoes::Common::Visibility do
     include Shoes::Common::Style
 
     attr_reader :gui
+    attr_accessor :parent
 
-    def initialize(gui)
+    def initialize(gui, parent)
       @style = {}
       @gui = gui
+      @parent = parent
     end
   end
 
-  subject { VisibilityTester.new(gui) }
+  subject { VisibilityTester.new(gui, parent) }
 
-  let(:gui) { double("gui", update_visibility: nil) }
+  let(:gui)    { double("gui", update_visibility: nil) }
+  let(:parent) { double("parent", hidden?: false) }
 
   it "hides" do
     subject.hide
@@ -51,6 +54,22 @@ describe Shoes::Common::Visibility do
 
   it "is visible?" do
     subject.show
+    expect(subject).to be_visible
+  end
+
+  it "hides when parent hides" do
+    allow(parent).to receive(:hidden?).and_return(true)
+    expect(subject).to be_hidden
+  end
+
+  it "doesn't change local hidden state because of parent" do
+    allow(parent).to receive(:hidden?).and_return(true)
+    expect(subject.style[:hidden]).to be_falsey
+  end
+
+  it "allows parent to be missing" do
+    allow(parent).to receive(:hidden?).and_return(true)
+    subject.parent = nil
     expect(subject).to be_visible
   end
 end

--- a/shoes-core/spec/shoes/slot_spec.rb
+++ b/shoes-core/spec/shoes/slot_spec.rb
@@ -175,4 +175,23 @@ describe Shoes::Slot do
       subject.send(:compute_content_height)
     end
   end
+
+  describe '#update_visibility' do
+    let(:child_element) { Shoes::Para.new app, subject, ['text'] }
+
+    it 'does not update visibility on gui unless visible state changd' do
+      expect(subject.gui).not_to receive(:update_visibility)
+      subject.send(:update_visibility)
+    end
+
+    it 'updates visibility on gui when changed' do
+      expect(subject.gui).to receive(:update_visibility)
+      subject.toggle
+    end
+
+    it 'updates visibility on children' do
+      expect(child_element).to receive(:update_visibility)
+      subject.toggle
+    end
+  end
 end

--- a/shoes-swt/lib/shoes/swt/slot.rb
+++ b/shoes-swt/lib/shoes/swt/slot.rb
@@ -20,22 +20,9 @@ class Shoes
       def update_position
       end
 
-      # This is more like a temporary work around until slots have a real
-      # backend representations that can just hide their contents all together
-      # I decided to put this logic in the backend since the hiding is a backend
-      # responsibility, although this is more DSL code
-      # #904 #905
       def update_visibility
-        # Only alter contents on a visibility change
-        return if @last_hidden_state == dsl.hidden?
-
-        @last_hidden_state = dsl.hidden?
-
-        if @last_hidden_state
-          dsl.contents.each(&:hide)
-        else
-          dsl.contents.each(&:show)
-        end
+        # No-op since we aren't a real backend, but need to prevent the
+        # shared visibility behavior of tweaking @real's visibility
       end
 
       def redraw_target

--- a/shoes-swt/spec/shoes/swt/shared_examples/swt_app_context.rb
+++ b/shoes-swt/spec/shoes/swt/shared_examples/swt_app_context.rb
@@ -29,13 +29,14 @@ shared_context "swt app" do
   let(:shoes_app) { double('shoes app', gui: swt_app, rotate: 0, style: {}, element_styles: {}) }
 
   let(:parent) do
-    double('parent', app: swt_app, add_child: true, real: true,
+    double('parent', app: swt_app, add_child: true, real: true, hidden?: false,
                      absolute_left: 0, absolute_top: 0,
                      width: 200, height: 100, fixed_height?: true)
   end
 
   let(:parent_dsl) do
     double("parent dsl", add_child: true, contents: [], gui: parent,
+                         hidden?: false,
                          x_dimension: double.as_null_object,
                          y_dimension: double.as_null_object)
   end

--- a/shoes-swt/spec/shoes/swt/slot_spec.rb
+++ b/shoes-swt/spec/shoes/swt/slot_spec.rb
@@ -13,26 +13,6 @@ describe Shoes::Swt::Slot do
 
   subject { Shoes::Swt::Slot.new dsl, swt_app }
 
-  describe '#update_visibility' do
-    it 'does not set visibility on the parent #904' do
-      subject.update_visibility
-      expect(swt_app.real).not_to have_received(:set_visible)
-    end
-
-    # spec may be deleted if we can hide entire rather than their contents
-    it 'tries to hide the content' do
-      subject.update_visibility
-      expect(content).to have_received :hide
-    end
-
-    # spec may be deleted if we can hide entire rather than their contents
-    it 'only hides on visibility changes' do
-      subject.update_visibility
-      subject.update_visibility
-      expect(content).to have_received(:hide).once
-    end
-  end
-
   describe '#remove' do
     it 'cleans up click listeners' do
       expect(swt_app.click_listener).to receive(:remove_listeners_for).with(dsl)


### PR DESCRIPTION
Fixes #905 (or at least what's gonna get fixed there)

When visibility changes happen, we use `update_visibility` to notify the
elements that might need to directly change their current visibility
state. This was only abiding by the direct visible styling for the
element, so when a parent container got hidden we had to hack around
with tromping visibility at the lower levels.

Instead we now take advantage of our `hidden?` method and have that factor
in the parent visibility. If direct visibility access is still needed,
it should go through the styling, but that's almost never what you want.

Note that this works without need a new backend element for the slots,
which is good because I'm convinced none of the SWT elements will
actually work since they don't support transparency. :sob: I'll put more about
where I'm at with that over on #853 in the near future.