### PR TITLE
Fix gradient angles across elements

### DIFF
--- a/shoes-core/lib/shoes/arc.rb
+++ b/shoes-core/lib/shoes/arc.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 class Shoes
   class Arc < Common::ArtElement
-    style_with :angle1, :angle2, :art_styles, :center, :common_styles, :dimensions, :radius, :wedge
-    STYLES = { wedge: false, fill: Shoes::COLORS[:black] }.freeze
+    # angle is the gradient angle used across all art elements
+    # angle1/2 are the angles of the arc itself!
+    style_with :angle, :angle1, :angle2, :art_styles, :center, :common_styles, :dimensions, :radius, :wedge
+    STYLES = { angle: 0, wedge: false, fill: Shoes::COLORS[:black] }.freeze
 
     def create_dimensions(left, top, width, height, angle1, angle2)
       @style[:angle1] = angle1 || @style[:angle1] || 0

--- a/shoes-core/lib/shoes/arc.rb
+++ b/shoes-core/lib/shoes/arc.rb
@@ -3,8 +3,8 @@ class Shoes
   class Arc < Common::ArtElement
     # angle is the gradient angle used across all art elements
     # angle1/2 are the angles of the arc itself!
-    style_with :angle, :angle1, :angle2, :art_styles, :center, :common_styles, :dimensions, :radius, :wedge
-    STYLES = { angle: 0, wedge: false, fill: Shoes::COLORS[:black] }.freeze
+    style_with :angle1, :angle2, :art_styles, :center, :common_styles, :dimensions, :radius, :wedge
+    STYLES = { wedge: false, fill: Shoes::COLORS[:black] }.freeze
 
     def create_dimensions(left, top, width, height, angle1, angle2)
       @style[:angle1] = angle1 || @style[:angle1] || 0

--- a/shoes-core/lib/shoes/arrow.rb
+++ b/shoes-core/lib/shoes/arrow.rb
@@ -16,5 +16,32 @@ class Shoes
       super
       gui.update_position
     end
+
+    # Our locations are nonstandard, so let redrawing and gradient know
+    def redraw_left
+      return 0 unless element_left
+      element_left - width * 0.5
+    end
+
+    def redraw_top
+      return 0 unless element_top
+      element_top - width * 0.4
+    end
+
+    def redraw_height
+      width * 0.8
+    end
+
+    def gradient_left
+      redraw_left
+    end
+
+    def gradient_top
+      redraw_top
+    end
+
+    def gradient_height
+      redraw_height
+    end
   end
 end

--- a/shoes-core/lib/shoes/arrow.rb
+++ b/shoes-core/lib/shoes/arrow.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class Shoes
   class Arrow < Common::ArtElement
-    style_with :angle, :art_styles, :curve, :common_styles, :dimensions
-    STYLES = { angle: 0, fill: Shoes::COLORS[:black] }.freeze
+    style_with :art_styles, :curve, :common_styles, :dimensions
+    STYLES = { fill: Shoes::COLORS[:black] }.freeze
 
     def create_dimensions(left, top, width)
       left   ||= @style[:left] || 0

--- a/shoes-core/lib/shoes/arrow.rb
+++ b/shoes-core/lib/shoes/arrow.rb
@@ -20,16 +20,20 @@ class Shoes
     # Our locations are nonstandard, so let redrawing and gradient know
     def redraw_left
       return 0 unless element_left
-      element_left - width * 0.5
+      element_left - width * 0.5 - style[:strokewidth].to_i
     end
 
     def redraw_top
       return 0 unless element_top
-      element_top - width * 0.4
+      element_top - width * 0.4 - style[:strokewidth].to_i
+    end
+
+    def redraw_width
+      width + style[:strokewidth].to_i * 2
     end
 
     def redraw_height
-      width * 0.8
+      width + style[:strokewidth].to_i * 2
     end
 
     def gradient_left

--- a/shoes-core/lib/shoes/common/style.rb
+++ b/shoes-core/lib/shoes/common/style.rb
@@ -15,7 +15,8 @@ class Shoes
       }
 
       STYLE_GROUPS = {
-        art_styles:           [:cap, :click, :fill, :rotate, :stroke, :strokewidth, :transform, :translate],
+        art_styles:           [:angle, :cap, :click, :fill, :rotate, :stroke,
+                               :strokewidth, :transform, :translate],
         common_styles:        [:displace_left, :displace_top, :hidden],
         dimensions:           [:bottom, :height, :left, :margin,
                                :margin_bottom, :margin_left, :margin_right,

--- a/shoes-core/lib/shoes/common/ui_element.rb
+++ b/shoes-core/lib/shoes/common/ui_element.rb
@@ -88,6 +88,25 @@ class Shoes
 
       def update_stroke
       end
+
+      # Some element types (arrows, shapes) don't necessarily track their
+      # element locations in the standard way. Let them inform redrawing about
+      # the actual bounds to redraw within by overriding these methods
+      def redraw_left
+        element_left
+      end
+
+      def redraw_top
+        element_top
+      end
+
+      def redraw_width
+        element_width
+      end
+
+      def redraw_height
+        element_height
+      end
     end
   end
 end

--- a/shoes-core/lib/shoes/line.rb
+++ b/shoes-core/lib/shoes/line.rb
@@ -82,19 +82,19 @@ class Shoes
     alias y2= bottom=
 
     def redraw_left
-      [@point_a.x, @point_b.x].min - 0.5 * strokewidth
+      [@point_a.x, @point_b.x].min - 0.5 * style[:strokewidth].to_i
     end
 
     def redraw_top
-      [@point_a.y, @point_b.y].min - 0.5 * strokewidth
+      [@point_a.y, @point_b.y].min - 0.5 * style[:strokewidth].to_i
     end
 
     def redraw_width
-      (@point_a.x - @point_b.x).abs + strokewidth
+      (@point_a.x - @point_b.x).abs + style[:strokewidth].to_i
     end
 
     def redraw_height
-      (@point_a.y - @point_b.y).abs + strokewidth
+      (@point_a.y - @point_b.y).abs + style[:strokewidth].to_i
     end
 
     def move(x, y, x2 = nil, y2 = nil)

--- a/shoes-core/lib/shoes/line.rb
+++ b/shoes-core/lib/shoes/line.rb
@@ -5,8 +5,8 @@ class Shoes
   class Line < Common::ArtElement
     attr_reader :point_a, :point_b
 
-    style_with :angle, :art_styles, :dimensions, :x2, :y2
-    STYLES = { angle: 0, fill: Shoes::COLORS[:black] }.freeze
+    style_with :art_styles, :dimensions, :x2, :y2
+    STYLES = { fill: Shoes::COLORS[:black] }.freeze
 
     def create_dimensions(x1, y1, x2, y2)
       x1, y1, x2, y2 = default_coordinates(x1, y1, x2, y2)

--- a/shoes-core/lib/shoes/line.rb
+++ b/shoes-core/lib/shoes/line.rb
@@ -81,6 +81,22 @@ class Shoes
     alias x2= right=
     alias y2= bottom=
 
+    def redraw_left
+      [@point_a.x, @point_b.x].min - 0.5 * strokewidth
+    end
+
+    def redraw_top
+      [@point_a.y, @point_b.y].min - 0.5 * strokewidth
+    end
+
+    def redraw_width
+      (@point_a.x - @point_b.x).abs + strokewidth
+    end
+
+    def redraw_height
+      (@point_a.y - @point_b.y).abs + strokewidth
+    end
+
     def move(x, y, x2 = nil, y2 = nil)
       @point_a.x = x
       @point_a.y = y

--- a/shoes-core/lib/shoes/oval.rb
+++ b/shoes-core/lib/shoes/oval.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class Shoes
   class Oval < Common::ArtElement
-    style_with :art_styles, :center, :common_styles, :dimensions
-    STYLES = { fill: Shoes::COLORS[:black] }.freeze
+    style_with :angle, :art_styles, :center, :common_styles, :dimensions
+    STYLES = { angle: 0, fill: Shoes::COLORS[:black] }.freeze
 
     def create_dimensions(left, top, width, height)
       left   ||= @style[:left] || 0

--- a/shoes-core/lib/shoes/oval.rb
+++ b/shoes-core/lib/shoes/oval.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class Shoes
   class Oval < Common::ArtElement
-    style_with :angle, :art_styles, :center, :common_styles, :dimensions
-    STYLES = { angle: 0, fill: Shoes::COLORS[:black] }.freeze
+    style_with :art_styles, :center, :common_styles, :dimensions
+    STYLES = { fill: Shoes::COLORS[:black] }.freeze
 
     def create_dimensions(left, top, width, height)
       left   ||= @style[:left] || 0

--- a/shoes-core/lib/shoes/rect.rb
+++ b/shoes-core/lib/shoes/rect.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class Shoes
   class Rect < Common::ArtElement
-    style_with :angle, :art_styles, :curve, :common_styles, :dimensions
-    STYLES = { angle: 0, curve: 0, fill: Shoes::COLORS[:black] }.freeze
+    style_with :art_styles, :curve, :common_styles, :dimensions
+    STYLES = { curve: 0, fill: Shoes::COLORS[:black] }.freeze
 
     def create_dimensions(left, top, width, height)
       left   ||= @style[:left] || 0

--- a/shoes-core/lib/shoes/shape.rb
+++ b/shoes-core/lib/shoes/shape.rb
@@ -3,8 +3,8 @@ class Shoes
   class Shape < Common::ArtElement
     attr_reader :blk, :x, :y, :left_bound, :top_bound, :right_bound, :bottom_bound
 
-    style_with :art_styles, :center, :common_styles, :dimensions
-    STYLES = { fill: Shoes::COLORS[:black] }.freeze
+    style_with :angle, :art_styles, :center, :common_styles, :dimensions
+    STYLES = { angle: 0, fill: Shoes::COLORS[:black] }.freeze
 
     def create_dimensions(left, top)
       left ||= @style[:left] || 0

--- a/shoes-core/lib/shoes/shape.rb
+++ b/shoes-core/lib/shoes/shape.rb
@@ -3,8 +3,8 @@ class Shoes
   class Shape < Common::ArtElement
     attr_reader :blk, :x, :y, :left_bound, :top_bound, :right_bound, :bottom_bound
 
-    style_with :angle, :art_styles, :center, :common_styles, :dimensions
-    STYLES = { angle: 0, fill: Shoes::COLORS[:black] }.freeze
+    style_with :art_styles, :center, :common_styles, :dimensions
+    STYLES = { fill: Shoes::COLORS[:black] }.freeze
 
     def create_dimensions(left, top)
       left ||= @style[:left] || 0

--- a/shoes-core/lib/shoes/shape.rb
+++ b/shoes-core/lib/shoes/shape.rb
@@ -51,11 +51,23 @@ class Shoes
     end
 
     def redraw_left
-      @left_bound
+      return 0 unless @left_bound
+      @left_bound - strokewidth.to_i
     end
 
     def redraw_top
-      @top_bound
+      return 0 unless @top_bound
+      @top_bound - strokewidth.to_i
+    end
+
+    def redraw_width
+      return 0 unless element_width
+      element_width + 2 * strokewidth.to_i
+    end
+
+    def redraw_height
+      return 0 unless element_height
+      element_height + 2 * strokewidth.to_i
     end
 
     # Moves the shape

--- a/shoes-core/lib/shoes/shape.rb
+++ b/shoes-core/lib/shoes/shape.rb
@@ -50,6 +50,14 @@ class Shoes
       false
     end
 
+    def redraw_left
+      @left_bound
+    end
+
+    def redraw_top
+      @top_bound
+    end
+
     # Moves the shape
     #
     # @param [Integer] left The new left value

--- a/shoes-core/lib/shoes/star.rb
+++ b/shoes-core/lib/shoes/star.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class Shoes
   class Star < Common::ArtElement
-    style_with :angle, :art_styles, :center, :common_styles, :dimensions, :inner, :outer, :points
-    STYLES = { angle: 0, fill: Shoes::COLORS[:black] }.freeze
+    style_with :art_styles, :center, :common_styles, :dimensions, :inner, :outer, :points
+    STYLES = { fill: Shoes::COLORS[:black] }.freeze
 
     # Don't use param defaults as DSL explicit passes nil for missing params
     def create_dimensions(left, top, points, outer, inner)

--- a/shoes-core/lib/shoes/star.rb
+++ b/shoes-core/lib/shoes/star.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Shoes
   class Star < Common::ArtElement
-    style_with :angle, :art_styles, :common_styles, :dimensions, :inner, :outer, :points
+    style_with :angle, :art_styles, :center, :common_styles, :dimensions, :inner, :outer, :points
     STYLES = { angle: 0, fill: Shoes::COLORS[:black] }.freeze
 
     # Don't use param defaults as DSL explicit passes nil for missing params
@@ -34,6 +34,16 @@ class Shoes
       dy = height / 2.0
       element_left - dx <= x && x <= element_right - dx &&
         element_top - dy <= y && y <= element_bottom - dy
+    end
+
+    def redraw_left
+      return 0 unless element_left
+      center ? element_left - width * 0.5 : super
+    end
+
+    def redraw_top
+      return 0 unless element_top
+      center ? element_top - width * 0.5 : super
     end
   end
 end

--- a/shoes-core/lib/shoes/star.rb
+++ b/shoes-core/lib/shoes/star.rb
@@ -38,12 +38,28 @@ class Shoes
 
     def redraw_left
       return 0 unless element_left
-      center ? element_left - width * 0.5 : super
+      if center
+        element_left - width * 0.5 - style[:strokewidth].to_i
+      else
+        super
+      end
     end
 
     def redraw_top
       return 0 unless element_top
-      center ? element_top - width * 0.5 : super
+      if center
+        element_top - width * 0.5 - style[:strokewidth].to_i
+      else
+        super
+      end
+    end
+
+    def redraw_width
+      element_width + style[:strokewidth].to_i * 2
+    end
+
+    def redraw_height
+      element_height + style[:strokewidth].to_i * 2
     end
   end
 end

--- a/shoes-core/spec/shoes/arrow_spec.rb
+++ b/shoes-core/spec/shoes/arrow_spec.rb
@@ -88,4 +88,29 @@ describe Shoes::Arrow do
       expect { dsl.arrow 40, 50, 100, 666, left: -1 }.to raise_error(ArgumentError)
     end
   end
+
+  describe "redrawing region" do
+    subject(:arrow) { Shoes::Arrow.new(app, parent, 100, 100, 100, strokewidth: 0) }
+
+    before do
+      # faux positioning
+      arrow.absolute_left = 100
+      arrow.absolute_top = 100
+    end
+
+    it "positions around itself" do
+      expect(arrow.redraw_left).to eq(50)
+      expect(arrow.redraw_top).to eq(60)
+      expect(arrow.redraw_width).to eq(100)
+      expect(arrow.redraw_height).to eq(100)
+    end
+
+    it "factors in strokewidth" do
+      arrow.strokewidth = 5
+      expect(arrow.redraw_left).to eq(45)
+      expect(arrow.redraw_top).to eq(55)
+      expect(arrow.redraw_width).to eq(110)
+      expect(arrow.redraw_height).to eq(110)
+    end
+  end
 end

--- a/shoes-core/spec/shoes/line_spec.rb
+++ b/shoes-core/spec/shoes/line_spec.rb
@@ -213,4 +213,31 @@ describe Shoes::Line do
       expect { dsl.line 10, 20, 30, 40, 666, left: -1 }.to raise_error(ArgumentError)
     end
   end
+
+  describe "redrawing region" do
+    subject { Shoes::Line.new(app, parent, 0, 0, 100, 100, strokewidth: 0) }
+
+    it "positions around itself" do
+      expect(subject.redraw_left).to eq(0)
+      expect(subject.redraw_top).to eq(0)
+      expect(subject.redraw_width).to eq(100)
+      expect(subject.redraw_height).to eq(100)
+    end
+
+    it "reverses fine" do
+      subject.move(100, 100, 0, 0)
+      expect(subject.redraw_left).to eq(0)
+      expect(subject.redraw_top).to eq(0)
+      expect(subject.redraw_width).to eq(100)
+      expect(subject.redraw_height).to eq(100)
+    end
+
+    it "factors in strokewidth" do
+      subject.strokewidth = 4
+      expect(subject.redraw_left).to eq(-2)
+      expect(subject.redraw_top).to eq(-2)
+      expect(subject.redraw_width).to eq(104)
+      expect(subject.redraw_height).to eq(104)
+    end
+  end
 end

--- a/shoes-core/spec/shoes/shape_spec.rb
+++ b/shoes-core/spec/shoes/shape_spec.rb
@@ -156,4 +156,29 @@ describe Shoes::Shape do
       expect { dsl.shape 10, 20, 666, left: -1 }.to raise_error(ArgumentError)
     end
   end
+
+  describe "redrawing region" do
+    subject { Shoes::Shape.new app, parent, 100, 100, { strokewidth: 0 }, draw }
+
+    let(:draw) do
+      proc do
+        line_to 200, 200
+      end
+    end
+
+    it "positions around itself" do
+      expect(subject.redraw_left).to eq(0)
+      expect(subject.redraw_top).to eq(0)
+      expect(subject.redraw_width).to eq(200)
+      expect(subject.redraw_height).to eq(200)
+    end
+
+    it "factors in strokewidth" do
+      subject.strokewidth = 5
+      expect(subject.redraw_left).to eq(-5)
+      expect(subject.redraw_top).to eq(-5)
+      expect(subject.redraw_width).to eq(210)
+      expect(subject.redraw_height).to eq(210)
+    end
+  end
 end

--- a/shoes-core/spec/shoes/star_spec.rb
+++ b/shoes-core/spec/shoes/star_spec.rb
@@ -167,4 +167,38 @@ describe Shoes::Star do
       expect { dsl.star 10, 20, 6, 30, 40, 666, left: -1 }.to raise_error(ArgumentError)
     end
   end
+
+  describe "redrawing region" do
+    subject { Shoes::Star.new(app, parent, 100, 100, 5, 50, 30, center: false, strokewidth: 0) }
+
+    before do
+      # faux positioning
+      subject.absolute_left = 100
+      subject.absolute_top = 100
+    end
+
+    it "positions around itself" do
+      expect(subject.redraw_left).to eq(100)
+      expect(subject.redraw_top).to eq(100)
+      expect(subject.redraw_width).to eq(100)
+      expect(subject.redraw_height).to eq(100)
+    end
+
+    it "positions centered around itself" do
+      subject.center = true
+      expect(subject.redraw_left).to eq(50)
+      expect(subject.redraw_top).to eq(50)
+      expect(subject.redraw_width).to eq(100)
+      expect(subject.redraw_height).to eq(100)
+    end
+
+    it "factors in strokewidth when centered" do
+      subject.center = true
+      subject.strokewidth = 4
+      expect(subject.redraw_left).to eq(46)
+      expect(subject.redraw_top).to eq(46)
+      expect(subject.redraw_width).to eq(108)
+      expect(subject.redraw_height).to eq(108)
+    end
+  end
 end

--- a/shoes-swt/lib/shoes/swt/common/fill.rb
+++ b/shoes-swt/lib/shoes/swt/common/fill.rb
@@ -25,7 +25,7 @@ class Shoes
 
         # @return [Integer] the angle to use when filling with a pattern
         def angle
-          @angle || 0
+          dsl.angle || 0
         end
 
         # Just clear it out and let next paint recreate and save our SWT color

--- a/shoes-swt/lib/shoes/swt/gradient.rb
+++ b/shoes-swt/lib/shoes/swt/gradient.rb
@@ -1,4 +1,16 @@
 # frozen_string_literal: true
+#
+# Gradients are a little confusing, but don't let all the math below scare you.
+# Here's the (relatively) simple explanation of what's going on.
+#
+# ::SWT::Pattern, the underlying class we use, defines a gradient by a starting
+# and ending point. We account the angle into it by changing these points.
+#
+# To look right, the start/end points must be outside our shape! If not, then
+# we get a hard line where the color resets without fading, which looks bad.
+# Given that, we must keep those points outside our bounds of the element,
+# which are reported via the redraw_left, redraw_top, etc. methods.
+#
 class Shoes
   module Swt
     class Gradient

--- a/shoes-swt/lib/shoes/swt/gradient.rb
+++ b/shoes-swt/lib/shoes/swt/gradient.rb
@@ -58,7 +58,7 @@ class Shoes
         dsl    = gui.dsl
         width  = dsl.redraw_width * 0.5
         height = dsl.redraw_height * 0.5
-        angle  = normalize_angle(-dsl.angle)
+        angle  = normalize_angle(-(dsl.angle || 0))
         left, top, width, height = determine_args_based_on_angle(angle,
                                                                  dsl.redraw_left,
                                                                  dsl.redraw_top,

--- a/shoes-swt/lib/shoes/swt/gradient.rb
+++ b/shoes-swt/lib/shoes/swt/gradient.rb
@@ -42,12 +42,16 @@ class Shoes
 
       private
 
-      def create_pattern(dsl)
-        width  = dsl.element_width * 0.5
-        height = dsl.element_height * 0.5
+      def create_pattern(gui)
+        dsl    = gui.dsl
+        width  = dsl.redraw_width * 0.5
+        height = dsl.redraw_height * 0.5
         angle  = normalize_angle(-dsl.angle)
-        left, top, width, height = determine_args_based_on_angle(angle, dsl.element_left,
-                                                                 dsl.element_top, width, height)
+        left, top, width, height = determine_args_based_on_angle(angle,
+                                                                 dsl.redraw_left,
+                                                                 dsl.redraw_top,
+                                                                 width,
+                                                                 height)
 
         pattern = ::Swt::Pattern.new Shoes.display, left, top, width, height,
                                      color1.real, color2.real

--- a/shoes-swt/lib/shoes/swt/rect.rb
+++ b/shoes-swt/lib/shoes/swt/rect.rb
@@ -12,8 +12,6 @@ class Shoes
       include Common::Translate
       include ::Shoes::BackendDimensionsDelegations
 
-      def_delegators :dsl, :angle
-
       attr_reader :dsl, :app, :transform, :painter
 
       def initialize(dsl, app)

--- a/shoes-swt/lib/shoes/swt/redrawing_aspect.rb
+++ b/shoes-swt/lib/shoes/swt/redrawing_aspect.rb
@@ -85,8 +85,8 @@ class Shoes
 
       def redraw_element(element, include_children = true)
         target = redraw_target(element)
-        redraw_area target.element_left, target.element_top,
-                    target.element_width, target.element_height,
+        redraw_area target.redraw_left, target.redraw_top,
+                    target.redraw_width, target.redraw_height,
                     include_children
       end
 
@@ -98,7 +98,7 @@ class Shoes
 
       def redraw_target(element)
         # During DSL initialization element.gui is nil, so if a SWT backend
-        # object causes a redraw in its initailize (like Shoes::Swt::Image),
+        # object causes a redraw in its initialize (like Shoes::Swt::Image),
         # we won't have gui set yet. Annoying, but fine.
         if element.gui
           element.gui.redraw_target

--- a/shoes-swt/spec/shoes/swt/gradient_spec.rb
+++ b/shoes-swt/spec/shoes/swt/gradient_spec.rb
@@ -5,9 +5,11 @@ describe Shoes::Swt::Gradient do
   let(:color1) { Shoes::Color.create(Shoes::COLORS[:honeydew]) }
   let(:color2) { Shoes::Color.create(Shoes::COLORS[:salmon]) }
 
-  let(:applied_to) do
-    double("applied to", element_left: 0, element_top: 0, angle: 0,
-                         element_width: 10, element_height: 10)
+  let(:applied_to) { double("applied_to", dsl: element_dsl) }
+  let(:element_dsl) do
+    double("element_dsl", angle: 0,
+                          redraw_left: 0, redraw_top: 0,
+                          redraw_width: 10, redraw_height: 10)
   end
 
   let(:dsl) { Shoes::Gradient.new(color1, color2) }


### PR DESCRIPTION
Coulda probably busted things up, but was on a roll :)

Fixes #1354, #1100, and #1101  🎉 

There were a number of things wrong across the various element:

* Several were missing the DSL-level `angle` style they need to respect gradients
* Bounds on some different element types needed special handling, so provided a new `redraw_*` set of accessors that can be overridden properly
* `RedrawingAspect` also needs that same different redrawing boundaries used, so plumbed those in

Fortunately the base math seems to actually be right, we just weren't setting the "where" for the gradient correctly for a bunch of elements!

TODO:
* [x] Test with stroked gradients (been focused on fill)
* [x] Run samples for things that have gradients in them
* [x] Further specs for new functionality? While we exercise some bits based on the test updates needed, we aren't doing a lot of direct verification of how this stuff works