### PR TITLE
Set control visibility outside of slots + A PLAN!

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -95,6 +95,9 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
   Max: 648
+  Exclude:
+    - 'shoes-core/spec/**/*.rb'
+    - 'shoes-swt/spec/**/*.rb'
 
 # Offense count: 16
 # Configuration parameters: CountComments.

--- a/shoes-core/lib/shoes/common/art_element.rb
+++ b/shoes-core/lib/shoes/common/art_element.rb
@@ -13,6 +13,10 @@ class Shoes
         # We need to include it at inheritance time to get that behavior.
         child.include Common::Hover
       end
+
+      def painted?
+        true
+      end
     end
   end
 end

--- a/shoes-core/lib/shoes/common/background_element.rb
+++ b/shoes-core/lib/shoes/common/background_element.rb
@@ -6,6 +6,10 @@ class Shoes
         @dimensions = ParentDimensions.new @parent, @style
       end
 
+      def painted?
+        true
+      end
+
       # We derive everything from our parent, so we skip slot positioning.
       def needs_positioning?
         false

--- a/shoes-core/lib/shoes/common/ui_element.rb
+++ b/shoes-core/lib/shoes/common/ui_element.rb
@@ -107,6 +107,10 @@ class Shoes
       def redraw_height
         element_height
       end
+
+      def painted?
+        false
+      end
     end
   end
 end

--- a/shoes-core/lib/shoes/common/visibility.rb
+++ b/shoes-core/lib/shoes/common/visibility.rb
@@ -20,6 +20,17 @@ class Shoes
         !hidden?
       end
 
+      def hidden_from_view?
+        hidden? || outside_parent_view?
+      end
+
+      def outside_parent_view?
+        # Painted elements handle slot bounds themselves when painting
+        return false if @parent.nil? || painted?
+
+        !@parent.overlaps?(self.dimensions)
+      end
+
       # Reveals the element, if it is hidden. See also #hide and #toggle.
       def show
         style(hidden: false)

--- a/shoes-core/lib/shoes/common/visibility.rb
+++ b/shoes-core/lib/shoes/common/visibility.rb
@@ -28,7 +28,7 @@ class Shoes
         # Painted elements handle slot bounds themselves when painting
         return false if @parent.nil? || painted?
 
-        !@parent.overlaps?(self.dimensions)
+        !@parent.overlaps?(dimensions)
       end
 
       # Reveals the element, if it is hidden. See also #hide and #toggle.

--- a/shoes-core/lib/shoes/common/visibility.rb
+++ b/shoes-core/lib/shoes/common/visibility.rb
@@ -26,7 +26,7 @@ class Shoes
 
       def outside_parent_view?
         # Painted elements handle slot bounds themselves when painting
-        return false if @parent.nil? || painted?
+        return false if @parent.nil? || @parent.variable_height? || painted?
 
         # We hide when we're at all outside our parent's bounds
         !@parent.contains?(dimensions)

--- a/shoes-core/lib/shoes/common/visibility.rb
+++ b/shoes-core/lib/shoes/common/visibility.rb
@@ -28,7 +28,8 @@ class Shoes
         # Painted elements handle slot bounds themselves when painting
         return false if @parent.nil? || painted?
 
-        !@parent.overlaps?(dimensions)
+        # We hide when we're at all outside our parent's bounds
+        !@parent.contains?(dimensions)
       end
 
       # Reveals the element, if it is hidden. See also #hide and #toggle.

--- a/shoes-core/lib/shoes/dimensions.rb
+++ b/shoes-core/lib/shoes/dimensions.rb
@@ -82,6 +82,16 @@ class Shoes
       x_dimension.in_bounds?(x) && y_dimension.in_bounds?(y)
     end
 
+    def overlaps?(other)
+      return false unless other.element_left && other.element_top &&
+                          other.element_right && other.element_bottom
+
+      in_bounds?(other.element_left, other.element_top) ||
+        in_bounds?(other.element_left, other.element_bottom) ||
+        in_bounds?(other.element_right, other.element_top) ||
+        in_bounds?(other.element_right, other.element_bottom)
+    end
+
     def margin
       [margin_left, margin_top, margin_right, margin_bottom]
     end

--- a/shoes-core/lib/shoes/dimensions.rb
+++ b/shoes-core/lib/shoes/dimensions.rb
@@ -82,14 +82,14 @@ class Shoes
       x_dimension.in_bounds?(x) && y_dimension.in_bounds?(y)
     end
 
-    def overlaps?(other)
+    def contains?(other)
       return false unless other.element_left && other.element_top &&
                           other.element_right && other.element_bottom
 
-      in_bounds?(other.element_left, other.element_top) ||
-        in_bounds?(other.element_left, other.element_bottom) ||
-        in_bounds?(other.element_right, other.element_top) ||
-        in_bounds?(other.element_right, other.element_bottom)
+      element_left <= other.element_left &&
+        element_right >= other.element_right &&
+        element_top <= other.element_top &&
+        element_bottom >= other.element_bottom
     end
 
     def margin

--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -130,6 +130,9 @@ class Shoes
 
     def contents_alignment(_ = nil)
       position_contents
+      update_child_visibility
+
+      # Layout code expects height returned!
       determine_slot_height
     end
 
@@ -335,10 +338,14 @@ class Shoes
         super
 
         # Pass it along to all our children that they should update
-        contents.each(&:update_visibility)
+        update_child_visibility
       end
 
       self
+    end
+
+    def update_child_visibility
+      contents.each(&:update_visibility)
     end
   end
 

--- a/shoes-core/spec/shoes/background_spec.rb
+++ b/shoes-core/spec/shoes/background_spec.rb
@@ -26,6 +26,10 @@ describe Shoes::Background do
     expect(background.gui).not_to be_nil
   end
 
+  it "is painted" do
+    expect(subject.painted?).to eq(true)
+  end
+
   it_behaves_like "object with fill", :blue
 
   it_behaves_like "object with style" do

--- a/shoes-core/spec/shoes/common/ui_element_spec.rb
+++ b/shoes-core/spec/shoes/common/ui_element_spec.rb
@@ -29,4 +29,8 @@ describe Shoes::Common::UIElement do
       expect(subject.needs_rotate?).to be_falsey
     end
   end
+
+  it "isn't painted by default" do
+    expect(subject.painted?).to eq(false)
+  end
 end

--- a/shoes-core/spec/shoes/common/visibility_spec.rb
+++ b/shoes-core/spec/shoes/common/visibility_spec.rb
@@ -6,13 +6,20 @@ describe Shoes::Common::Visibility do
     include Shoes::Common::Visibility
     include Shoes::Common::Style
 
-    attr_reader :gui
-    attr_accessor :parent
+    attr_reader :dimensions, :gui
+    attr_accessor :painted, :parent
 
     def initialize(gui, parent)
-      @style = {}
       @gui = gui
+      @painted = false
       @parent = parent
+
+      @dimensions = Shoes::Dimensions.new(nil, 0, 0, 0, 0)
+      @style = {}
+    end
+
+    def painted?
+      @painted
     end
   end
 
@@ -71,5 +78,33 @@ describe Shoes::Common::Visibility do
     allow(parent).to receive(:hidden?).and_return(true)
     subject.parent = nil
     expect(subject).to be_visible
+  end
+
+  describe "view checking" do
+    before do
+      subject.show
+    end
+
+    it "is not hidden from view if no parent" do
+      subject.parent = nil
+      expect(subject.hidden_from_view?).to eq(false)
+    end
+
+    it "is not hidden from view if painted" do
+      subject.painted = true
+      expect(subject.hidden_from_view?).to eq(false)
+    end
+
+    it "is not hidden from view if within parent" do
+      allow(parent).to receive(:contains?).and_return(true)
+      expect(subject.hidden?).to eq(false)
+      expect(subject.hidden_from_view?).to eq(false)
+    end
+
+    it "is hidden from view if outside parent" do
+      allow(parent).to receive(:contains?).and_return(false)
+      expect(subject.hidden?).to eq(false)
+      expect(subject.hidden_from_view?).to eq(true)
+    end
   end
 end

--- a/shoes-core/spec/shoes/common/visibility_spec.rb
+++ b/shoes-core/spec/shoes/common/visibility_spec.rb
@@ -26,7 +26,7 @@ describe Shoes::Common::Visibility do
   subject { VisibilityTester.new(gui, parent) }
 
   let(:gui)    { double("gui", update_visibility: nil) }
-  let(:parent) { double("parent", hidden?: false) }
+  let(:parent) { double("parent", hidden?: false, variable_height?: false) }
 
   it "hides" do
     subject.hide
@@ -87,6 +87,11 @@ describe Shoes::Common::Visibility do
 
     it "is not hidden from view if no parent" do
       subject.parent = nil
+      expect(subject.hidden_from_view?).to eq(false)
+    end
+
+    it "is not hidden from view if variable height parent" do
+      allow(parent).to receive(:variable_height?).and_return(true)
       expect(subject.hidden_from_view?).to eq(false)
     end
 

--- a/shoes-core/spec/shoes/dimensions_spec.rb
+++ b/shoes-core/spec/shoes/dimensions_spec.rb
@@ -514,6 +514,45 @@ describe Shoes::Dimensions do
     end
   end
 
+  describe '#contains?' do
+    let(:left) { 100 }
+    let(:top) { 100 }
+    let(:width) { 100 }
+    let(:height) { 100 }
+
+    before :each do
+      subject.absolute_left = left
+      subject.absolute_top  = top
+    end
+
+    it 'is fully contained' do
+      other = create_other 150, 150, 50, 50
+      expect(subject.contains?(other)).to eq(true)
+    end
+
+    it 'has top corner out' do
+      other = create_other 75, 75, 50, 50
+      expect(subject.contains?(other)).to eq(false)
+    end
+
+    it 'has bottom corner out' do
+      other = create_other 175, 175, 50, 50
+      expect(subject.contains?(other)).to eq(false)
+    end
+
+    it 'is fully outside' do
+      other = create_other 250, 250, 50, 50
+      expect(subject.contains?(other)).to eq(false)
+    end
+
+    def create_other(top, left, width, height)
+      other = Shoes::Dimensions.new parent, top, left, width, height
+      other.absolute_left = left
+      other.absolute_top = top
+      other
+    end
+  end
+
   describe 'absolute positioning' do
     subject { Shoes::Dimensions.new parent }
     its(:absolutely_positioned?) { should be_falsey }

--- a/shoes-core/spec/shoes/flow_spec.rb
+++ b/shoes-core/spec/shoes/flow_spec.rb
@@ -10,6 +10,7 @@ describe Shoes::Flow do
   it_behaves_like "clickable object"
   it_behaves_like "Slot"
   it_behaves_like "object with hover"
+  it_behaves_like "contents alignment updates visibility"
 
   describe "initialize" do
     let(:input_opts) { {width: 131, height: 137} }

--- a/shoes-core/spec/shoes/helpers/fake_absolute_element.rb
+++ b/shoes-core/spec/shoes/helpers/fake_absolute_element.rb
@@ -1,32 +1,12 @@
 # frozen_string_literal: true
 class Shoes
-  class FakeAbsoluteElement
-    include Common::Attachable
-    include Common::Inspect
-    include Common::Positioning
-    include Common::Remove
-    include Common::Visibility
-
+  class FakeAbsoluteElement < FakeElement
     include Shoes::DimensionsDelegations
+
+    attr_accessor :dimensions
 
     def initialize
       @dimensions = AbsoluteDimensions.new 0, 0, 100, 100
     end
-
-    def add_child(_element)
-      true
-    end
-
-    def adjust_current_position(*_)
-    end
-
-    # Fake this out instead of using Common::Style to avoid things like touching
-    # app level styles, etc. that we don't need for testing purposes
-    def style
-      @style ||= {}
-      @style
-    end
-
-    attr_accessor :dimensions, :parent, :gui
   end
 end

--- a/shoes-core/spec/shoes/helpers/fake_element.rb
+++ b/shoes-core/spec/shoes/helpers/fake_element.rb
@@ -14,6 +14,9 @@ class Shoes
     def adjust_current_position(*_)
     end
 
+    def update_visibility
+    end
+
     # Fake this out instead of using Common::Style to avoid things like touching
     # app level styles, etc. that we don't need for testing purposes
     def style(styles = {})

--- a/shoes-core/spec/shoes/shared_examples/art_element.rb
+++ b/shoes-core/spec/shoes/shared_examples/art_element.rb
@@ -15,4 +15,8 @@ shared_examples "an art element" do
   # requires we define subject subject_without_style and subject_with_style
   # inside the example block!
   it_behaves_like "object with style"
+
+  it "is painted" do
+    expect(subject.painted?).to eq(true)
+  end
 end

--- a/shoes-core/spec/shoes/shared_examples/slot.rb
+++ b/shoes-core/spec/shoes/shared_examples/slot.rb
@@ -471,3 +471,18 @@ shared_examples_for 'margin and positioning' do
     end
   end
 end
+
+shared_examples_for 'contents alignment updates visibility' do
+  before do
+    allow(element).to receive(:update_visibility)
+  end
+
+  include_context 'one slot child'
+  include_context 'contents_alignment'
+
+  it 'sends updates along' do
+    subject.contents.each do |child|
+      expect(child).to have_received(:update_visibility)
+    end
+  end
+end

--- a/shoes-core/spec/shoes/stack_spec.rb
+++ b/shoes-core/spec/shoes/stack_spec.rb
@@ -9,6 +9,7 @@ describe Shoes::Stack do
 
   it_behaves_like "Slot"
   it_behaves_like "object with hover"
+  it_behaves_like "contents alignment updates visibility"
 
   describe 'Context' do
     class ContextObject

--- a/shoes-swt/lib/shoes/swt/common/visibility.rb
+++ b/shoes-swt/lib/shoes/swt/common/visibility.rb
@@ -5,7 +5,11 @@ class Shoes
       module Visibility
         def update_visibility
           if defined?(@real) && @real.respond_to?(:set_visible)
-            @real.set_visible(@dsl.visible?)
+            # hidden_from_view? handles all visiblity conditions, including
+            # being outside a slot. SWT as backend doesn't get that for free
+            # because we can't use Composites as they lack transparency...
+            visible = !@dsl.hidden_from_view?
+            @real.set_visible(visible)
           end
         end
       end

--- a/shoes-swt/spec/shoes/swt/check_spec.rb
+++ b/shoes-swt/spec/shoes/swt/check_spec.rb
@@ -10,6 +10,7 @@ describe Shoes::Swt::Check do
     double('dsl', app: shoes_app,
                   gui: real,
                   visible?: true,
+                  hidden_from_view?: false,
                   left: 42,
                   top: 66,
                   element_left: 42,

--- a/shoes-swt/spec/shoes/swt/common/visibility_spec.rb
+++ b/shoes-swt/spec/shoes/swt/common/visibility_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Shoes::Swt::Common::Visibility do
+  let(:clazz) do
+    Class.new do
+      include Shoes::Swt::Common::Visibility
+
+      attr_reader :real, :dsl
+
+      def initialize(dsl, real = nil)
+        @dsl = dsl
+        @real = real
+      end
+    end
+  end
+
+  let(:dsl)  { double("dsl") }
+  let(:real) { double("real", set_visible: nil) }
+
+  subject { clazz.new(dsl, real) }
+
+  it "hides when DSL is hidden from view" do
+    allow(dsl).to receive(:hidden_from_view?).and_return(true)
+    expect(real).to receive(:set_visible).with(false)
+    subject.update_visibility
+  end
+
+  it "shows when DSL is not hidden from view" do
+    allow(dsl).to receive(:hidden_from_view?).and_return(false)
+    expect(real).to receive(:set_visible).with(true)
+    subject.update_visibility
+  end
+
+  it "is fine without real supporting visibility" do
+    allow(real).to receive(:respond_to?).with(:set_visible)
+    expect { subject.update_visibility }.to_not raise_error
+  end
+
+  describe "without real" do
+    let(:real) { nil }
+
+    it "is harmless" do
+      expect { subject.update_visibility }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1036 by hiding elements which aren't painted (things like buttons and textboxes) when they're outside of slot boundaries. Painted elements all abide by the slot boundaries already.

This is a meaningful change on its own (even with the rough edges, which are as good as I suspect we can get on SWT), but it leads into to a broader discussion around scrolling (#853)

In particular, as I [discovered back in 2015](https://github.com/shoes/shoes4/issues/1036#issuecomment-162791833) (and then forgot) and others struggled with all the way back in 2012 (#79), SWT's `Composite` classes (which are the reasonable container objects for the backend) don't support transparency. That means they're unusable because we have to show the element layering for anything to work properly.

This leads me to conclude that the only way to get any sort of scrolling support outside the app frame (since the `Shell` can scroll fine for us) is to handle it ourselves. This hopefully won't be as bad as it sounds... the plan looks like this:

1) Get everything so it properly respects visibility when outside the slot frame
1) Make slots understand their scroll position and move contents around accordingly (much like `translate` already does)
1) See if we can get scrollbars actually displaying for our slots via `org.eclipse.swt.widgets.ScrollBar`
1) Implement necessary handlers/methods for accessing scroll information on slots
1) Yank the existing implementation which works against the app `Shell`. It has inconsistencies with how slot scrolling worked before, and once the other work is done we should be able to just scroll on the top slot.

This PR should stand on its own fairly well. ~~Deserves more specs and manual testing, which I'll get to, but~~ how's that plan sounds @PragTob? My only other thought is to patch up app-level scrolling and punt the whole business, but seems like a meaningful loss to basic functionality.