### PR TITLE
swt test warning fixes

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --color
 --format progress
 --order random
+--warnings

--- a/shoes-core/spec/spec_helper.rb
+++ b/shoes-core/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 ENV['SHOES_ENV'] = 'test'
 
-SHOESSPEC_ROOT = File.expand_path('..', __FILE__)
+SHOESSPEC_ROOT ||= File.expand_path('..', __FILE__)
 $LOAD_PATH << File.join(SHOESSPEC_ROOT)
 $LOAD_PATH << File.join(SHOESSPEC_ROOT, "../lib")
 

--- a/shoes-swt/lib/shoes/swt.rb
+++ b/shoes-swt/lib/shoes/swt.rb
@@ -46,7 +46,7 @@ class Shoes
     end
 
     def self.initialize_backend
-      return if @initialized
+      return if defined?(@initialized) && @initialized
       @initialized = true
 
       ::Shoes.configuration.backend = :swt

--- a/shoes-swt/lib/shoes/swt/app.rb
+++ b/shoes-swt/lib/shoes/swt/app.rb
@@ -197,7 +197,7 @@ EOS
       # Because SWT shutdown is hard to reverse, we only let you do it once
       # and warn you if you try to run again afterward.
       def self.main_app_closed?
-        @main_app_closed
+        @main_app_closed ||= false
       end
 
       def self.mark_main_app_closed

--- a/shoes-swt/lib/shoes/swt/common/image_handling.rb
+++ b/shoes-swt/lib/shoes/swt/common/image_handling.rb
@@ -13,22 +13,27 @@ class Shoes
           tmpname = File.join(Dir.tmpdir, "__shoes4_#{Time.now.to_i}_#{File.basename(name)}")
           FileUtils.cp(name, tmpname)
 
-          @cleanup_files ||= []
-          @cleanup_files << tmpname
+          cleanup_files << tmpname
           tmpname
         end
 
         def cleanup_temporary_files
-          return unless @cleanup_files
+          return unless cleanup_files.any?
 
-          @cleanup_files.each do |file|
+          cleanup_files.each do |file|
             begin
               FileUtils.rm(file)
             rescue => e
               Shoes.logger.debug("Error during image temp file cleanup.\n#{e.class}: #{e.message}")
             end
           end
-          @cleanup_files.clear
+          cleanup_files.clear
+        end
+
+        private
+
+        def cleanup_files
+          @cleanup_files ||= []
         end
       end
     end

--- a/shoes-swt/lib/shoes/swt/common/remove.rb
+++ b/shoes-swt/lib/shoes/swt/common/remove.rb
@@ -4,15 +4,15 @@ class Shoes
     module Common
       module Remove
         def remove
-          app.remove_paint_listener @painter
+          app.remove_paint_listener(painter)
           remove_click_listeners
-          @real.dispose unless @real.nil? || @real.disposed?
+          real&.dispose unless real&.disposed?
           dispose_held_resources
           dispose
         end
 
         def dispose_held_resources
-          @color_factory&.dispose
+          color_factory&.dispose
         end
 
         # Classes should override to dispose of any Swt resources they create
@@ -20,6 +20,18 @@ class Shoes
         end
 
         private
+
+        def color_factory
+          @color_factory ||= nil
+        end
+
+        def painter
+          @painter ||= nil
+        end
+
+        def real
+          @real ||= nil
+        end
 
         def remove_click_listeners
           app.click_listener.remove_listeners_for(dsl)

--- a/shoes-swt/lib/shoes/swt/common/visibility.rb
+++ b/shoes-swt/lib/shoes/swt/common/visibility.rb
@@ -4,7 +4,7 @@ class Shoes
     module Common
       module Visibility
         def update_visibility
-          if @real && @real.respond_to?(:set_visible)
+          if defined?(@real) && @real.respond_to?(:set_visible)
             @real.set_visible(@dsl.visible?)
           end
         end

--- a/shoes-swt/lib/shoes/swt/gradient.rb
+++ b/shoes-swt/lib/shoes/swt/gradient.rb
@@ -19,6 +19,8 @@ class Shoes
       def initialize(dsl)
         @dsl = dsl
         @patterns = []
+        @color1 = nil
+        @color2 = nil
       end
 
       def dispose

--- a/shoes-swt/lib/shoes/swt/image.rb
+++ b/shoes-swt/lib/shoes/swt/image.rb
@@ -19,6 +19,7 @@ class Shoes
       def initialize(dsl, app)
         @dsl = dsl
         @app = app
+        @tmpname_or_data = nil
         update_image
         add_paint_listener
       end

--- a/shoes-swt/lib/shoes/swt/radio.rb
+++ b/shoes-swt/lib/shoes/swt/radio.rb
@@ -19,9 +19,9 @@ class Shoes
 
       def group=(value)
         group_lookup = RadioGroup.group_lookup
-        group_lookup[@group].remove(self) unless @group.nil?
+        group_lookup[group].remove(self) unless group.nil?
         @group = value || RadioGroup::DEFAULT_RADIO_GROUP
-        group_lookup[@group].add self
+        group_lookup[group].add self
       end
     end
   end

--- a/shoes-swt/lib/shoes/swt/shape.rb
+++ b/shoes-swt/lib/shoes/swt/shape.rb
@@ -20,6 +20,7 @@ class Shoes
         @app = app
         @element = ::Swt::Path.new(::Swt.display)
         @painter = ShapePainter.new(self)
+        @transform = nil
         @app.add_paint_listener @painter
       end
 

--- a/shoes-swt/lib/shoes/swt/text_block/text_font_factory.rb
+++ b/shoes-swt/lib/shoes/swt/text_block/text_font_factory.rb
@@ -4,6 +4,7 @@ class Shoes
     class TextFontFactory
       def initialize
         @fonts = []
+        @display = nil
       end
 
       def create_font(font_style)

--- a/shoes-swt/spec/spec_helper.rb
+++ b/shoes-swt/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 ENV['SHOES_ENV'] = 'test'
 
-SHOESSPEC_ROOT = File.expand_path('..', __FILE__)
+SHOESSPEC_ROOT ||= File.expand_path('..', __FILE__)
 $LOAD_PATH << File.join(SHOESSPEC_ROOT)
 $LOAD_PATH << File.join(SHOESSPEC_ROOT, '../lib')
 $LOAD_PATH << File.join(SHOESSPEC_ROOT, '../../shoes-core/spec')


### PR DESCRIPTION
Cleans up swt test warnings, as discussed in https://github.com/shoes/shoes4/pull/1496

Run via `bundle exec rake rspec` and `bundle exec rubocop`.

Also adds the `warnings` flag to `.rspec` so warnings are always shown going forward