### PR TITLE
Basic slot scrolling

### DIFF
--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -153,7 +153,7 @@ class Shoes
         return
       end
 
-      value = 0 if value < 0
+      value = 0 if value.negative?
       @scroll_top = [value, scroll_max].min
     end
 

--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -153,6 +153,7 @@ class Shoes
         return
       end
 
+      value = 0 if value < 0
       @scroll_top = [value, scroll_max].min
     end
 

--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -30,11 +30,16 @@ class Shoes
     end
 
     def handle_block(blk)
-      @current_position = Position.new element_left,
-                                       element_top,
-                                       element_top
+      snapshot_current_position
+
       @blk = blk
       eval_block blk
+    end
+
+    def snapshot_current_position
+      offset = scroll ? @scroll_top : 0
+      top = element_top - offset
+      @current_position = Position.new element_left, top, top
     end
 
     def set_default_dimension_values
@@ -166,14 +171,13 @@ class Shoes
     Position = Struct.new(:x, :y, :next_line_start)
 
     def position_contents
-      @current_position = Position.new element_left,
-                                       element_top,
-                                       element_top
+      snapshot_current_position
 
       contents.each do |element|
         next if element.hidden?
         @current_position = positioning(element, @current_position)
       end
+
       @current_position
     end
 

--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -10,6 +10,7 @@ class Shoes
     NEXT_ELEMENT_OFFSET = 1
 
     attr_reader :parent, :dimensions, :gui, :contents, :blk
+    attr_accessor :scroll_top, :scroll_height
 
     style_with :art_styles, :attach, :common_styles, :dimensions, :scroll
     STYLES = { scroll: false, fill: Shoes::COLORS[:black] }.freeze
@@ -140,15 +141,9 @@ class Shoes
       @app.add_mouse_hover_control(self)
     end
 
-    def scroll_height
-      position_contents.y
-    end
-
     def scroll_max
       scroll_height - height
     end
-
-    attr_accessor :scroll_top
 
     def app
       @app.app # return the Shoes::App not the internal app
@@ -311,6 +306,7 @@ class Shoes
 
     def determine_slot_height
       content_height = compute_content_height
+      self.scroll_height = content_height
       self.element_height = content_height if variable_height?
       content_height
     end

--- a/shoes-core/spec/shoes/shared_examples/scroll.rb
+++ b/shoes-core/spec/shoes/shared_examples/scroll.rb
@@ -4,6 +4,30 @@ shared_examples_for "scrollable slot" do
   it "initializes scroll_top to 0" do
     expect(subject.scroll_top).to eq(0)
   end
+
+  describe '#snapshot_current_position' do
+    before do
+      subject.absolute_left = 100
+      subject.absolute_top = 100
+    end
+
+    it "offsets when scrollable" do
+      subject.scroll = true
+      subject.scroll_top = 10
+
+      position = subject.snapshot_current_position
+      expect(position.y).to eq(90)
+      expect(position.next_line_start).to eq(90)
+    end
+
+    it "doesn't offset when not scrollable" do
+      subject.scroll = false
+
+      position = subject.snapshot_current_position
+      expect(position.y).to eq(100)
+      expect(position.next_line_start).to eq(100)
+    end
+  end
 end
 
 shared_examples_for "scrollable slot with overflowing content" do

--- a/shoes-core/spec/shoes/shared_examples/scroll.rb
+++ b/shoes-core/spec/shoes/shared_examples/scroll.rb
@@ -25,6 +25,11 @@ shared_examples_for "scrollable slot" do
         subject.scroll_top = subject.scroll_max + 10
         expect(subject.scroll_top).to eq(subject.scroll_max)
       end
+
+      it "can't scroll negative" do
+        subject.scroll_top = -10
+        expect(subject.scroll_top).to eq(0)
+      end
     end
 
     describe "when not scrolling" do

--- a/shoes-core/spec/shoes/shared_examples/scroll.rb
+++ b/shoes-core/spec/shoes/shared_examples/scroll.rb
@@ -5,6 +5,57 @@ shared_examples_for "scrollable slot" do
     expect(subject.scroll_top).to eq(0)
   end
 
+  before do
+    subject.scroll_height = 200
+    subject.height = 100
+  end
+
+  describe '#scroll_top' do
+    describe "when scrolling" do
+      before do
+        subject.scroll = true
+      end
+
+      it "allows setting scroll position" do
+        subject.scroll_top = 42
+        expect(subject.scroll_top).to eq(42)
+      end
+
+      it "can't scroll past maximum" do
+        subject.scroll_top = subject.scroll_max + 10
+        expect(subject.scroll_top).to eq(subject.scroll_max)
+      end
+    end
+
+    describe "when not scrolling" do
+      before do
+        subject.scroll = false
+        allow(Shoes.logger).to receive(:warn)
+      end
+
+      it "can't set scroll position" do
+        subject.scroll_top = 42
+        expect(subject.scroll_top).to eq(0)
+      end
+
+      it "logs a warning" do
+        subject.scroll_top = 42
+        expect(Shoes.logger).to have_received(:warn)
+      end
+    end
+  end
+
+  describe '#scroll_max' do
+    it 'allows some scrolling' do
+      expect(subject.scroll_max).to eq(100)
+    end
+
+    it 'caps scrolling' do
+      subject.scroll_height = 80
+      expect(subject.scroll_max).to eq(0)
+    end
+  end
+
   describe '#snapshot_current_position' do
     before do
       subject.absolute_left = 100

--- a/shoes-swt/lib/shoes/swt/arc_painter.rb
+++ b/shoes-swt/lib/shoes/swt/arc_painter.rb
@@ -7,14 +7,14 @@ class Shoes
       def fill(graphics_context)
         if @obj.wedge?
           graphics_context.fill_arc(@obj.translate_left + @obj.element_left,
-                                    @obj.translate_top + @obj.element_top,
+                                    @obj.translate_top + drawing_top,
                                     @obj.element_width,
                                     @obj.element_height,
                                     start_angle, sweep)
         else
           path = ::Swt::Path.new(::Swt.display)
           path.add_arc(@obj.translate_left + @obj.element_left,
-                       @obj.translate_top + @obj.element_top,
+                       @obj.translate_top + drawing_top,
                        @obj.element_width,
                        @obj.element_height,
                        start_angle, sweep)
@@ -26,7 +26,7 @@ class Shoes
         line_width = graphics_context.get_line_width
         if @obj.element_left && @obj.element_top && @obj.element_width && @obj.element_height
           graphics_context.draw_arc(@obj.translate_left + @obj.element_left + line_width / 2,
-                                    @obj.translate_top + @obj.element_top + line_width / 2,
+                                    @obj.translate_top + drawing_top + line_width / 2,
                                     @obj.element_width - line_width,
                                     @obj.element_height - line_width,
                                     start_angle, sweep)

--- a/shoes-swt/lib/shoes/swt/arrow_painter.rb
+++ b/shoes-swt/lib/shoes/swt/arrow_painter.rb
@@ -28,14 +28,14 @@ class Shoes
 
           body_left   = @obj.translate_left + @obj.left - @obj.width * 0.5
           body_right  = @obj.translate_left + @obj.left + @obj.width * 0.1
-          body_top    = @obj.translate_top + @obj.top - @obj.width * 0.2
-          body_bottom = @obj.translate_top + @obj.top + @obj.width * 0.2
+          body_top    = @obj.translate_top + drawing_top - @obj.width * 0.2
+          body_bottom = @obj.translate_top + drawing_top + @obj.width * 0.2
 
-          middle = @obj.translate_top + @obj.top
+          middle = @obj.translate_top + drawing_top
 
           head_right  = @obj.translate_left + @obj.left + @obj.width * 0.5
-          head_top    = @obj.translate_top + @obj.top - @obj.width * 0.4
-          head_bottom = @obj.translate_top + @obj.top + @obj.width * 0.4
+          head_top    = @obj.translate_top + drawing_top - @obj.width * 0.4
+          head_bottom = @obj.translate_top + drawing_top + @obj.width * 0.4
 
           path = ::Swt::Path.new(::Swt.display)
           path.move_to(body_left, middle)
@@ -53,6 +53,10 @@ class Shoes
       end
 
       def dispose
+        clear_path
+      end
+
+      def after_painted
         clear_path
       end
 

--- a/shoes-swt/lib/shoes/swt/common/painter.rb
+++ b/shoes-swt/lib/shoes/swt/common/painter.rb
@@ -17,6 +17,7 @@ class Shoes
         end
 
         def paint_control(event)
+          before_painted
           graphics_context = event.gc
           reset_graphics_context graphics_context
           if @obj.dsl.visible? && @obj.dsl.positioned?
@@ -112,6 +113,9 @@ class Shoes
         def drawing_bottom
           dsl = @obj.dsl
           dsl.element_bottom - dsl.parent.scroll_top
+        end
+
+        def before_painted
         end
 
         def after_painted

--- a/shoes-swt/lib/shoes/swt/common/painter.rb
+++ b/shoes-swt/lib/shoes/swt/common/painter.rb
@@ -30,6 +30,8 @@ class Shoes
           #
           puts "SWALLOWED PAINT EXCEPTION ON #{@obj} - go take care of it: " + e.to_s
           puts 'Unfortunately we have to swallow it because it causes odd failures :('
+        ensure
+          after_painted
         end
 
         def paint_object(graphics_context)
@@ -105,6 +107,9 @@ class Shoes
         def drawing_top
           dsl = @obj.dsl
           dsl.element_top - dsl.parent.scroll_top
+        end
+
+        def after_painted
         end
       end
     end

--- a/shoes-swt/lib/shoes/swt/common/painter.rb
+++ b/shoes-swt/lib/shoes/swt/common/painter.rb
@@ -109,6 +109,11 @@ class Shoes
           dsl.element_top - dsl.parent.scroll_top
         end
 
+        def drawing_bottom
+          dsl = @obj.dsl
+          dsl.element_bottom - dsl.parent.scroll_top
+        end
+
         def after_painted
         end
       end

--- a/shoes-swt/lib/shoes/swt/common/painter.rb
+++ b/shoes-swt/lib/shoes/swt/common/painter.rb
@@ -42,7 +42,7 @@ class Shoes
             if obj.needs_rotate?
               set_rotate graphics_context, obj.rotate,
                          obj.element_left + obj.element_width / 2.0,
-                         obj.element_top + obj.element_height / 2.0 do
+                         drawing_top + obj.element_height / 2.0 do
                 fill_and_draw(graphics_context)
               end
             else
@@ -100,6 +100,11 @@ class Shoes
           transform.rotate angle
           transform.translate(-left, -top)
           graphics_context.set_transform transform
+        end
+
+        def drawing_top
+          dsl = @obj.dsl
+          dsl.element_top - dsl.parent.scroll_top
         end
       end
     end

--- a/shoes-swt/lib/shoes/swt/line_painter.rb
+++ b/shoes-swt/lib/shoes/swt/line_painter.rb
@@ -4,9 +4,9 @@ class Shoes
     class LinePainter < Common::Painter
       def draw(gc)
         gc.draw_line(@obj.translate_left + @obj.element_left,
-                     @obj.translate_top + @obj.element_top,
+                     @obj.translate_top + drawing_top,
                      @obj.translate_left + @obj.element_right + 1,
-                     @obj.translate_top + @obj.element_bottom + 1)
+                     @obj.translate_top + drawing_bottom + 1)
       end
 
       # Don't do fill setup

--- a/shoes-swt/lib/shoes/swt/oval_painter.rb
+++ b/shoes-swt/lib/shoes/swt/oval_painter.rb
@@ -4,14 +4,14 @@ class Shoes
     class OvalPainter < Common::Painter
       def clipping
         clipping = ::Swt::Path.new(Shoes.display)
-        clipping.add_arc(@obj.element_left, @obj.element_top,
+        clipping.add_arc(@obj.element_left, drawing_top,
                          @obj.element_width, @obj.element_height, 0, 360)
         clipping
       end
 
       def fill(graphics_context)
         graphics_context.fill_oval(@obj.translate_left + @obj.element_left,
-                                   @obj.translate_top + @obj.element_top,
+                                   @obj.translate_top + drawing_top,
                                    @obj.element_width,
                                    @obj.element_height)
       end
@@ -19,7 +19,7 @@ class Shoes
       def draw(graphics_context)
         sw = graphics_context.get_line_width
         graphics_context.draw_oval(@obj.translate_left + @obj.element_left + sw / 2,
-                                   @obj.translate_top + @obj.element_top + sw / 2,
+                                   @obj.translate_top + drawing_top + sw / 2,
                                    @obj.element_width - sw,
                                    @obj.element_height - sw)
       end

--- a/shoes-swt/lib/shoes/swt/rect_painter.rb
+++ b/shoes-swt/lib/shoes/swt/rect_painter.rb
@@ -4,7 +4,7 @@ class Shoes
     class RectPainter < Common::Painter
       def fill(gc)
         gc.fill_round_rectangle(@obj.translate_left + @obj.element_left + inset,
-                                @obj.translate_top + @obj.element_top + inset,
+                                @obj.translate_top + drawing_top + inset,
                                 @obj.element_width - inset * 2,
                                 @obj.element_height - inset * 2,
                                 @obj.corners * 2,
@@ -14,7 +14,7 @@ class Shoes
       def draw(gc)
         stroke_width = gc.get_line_width
         gc.draw_round_rectangle(@obj.translate_left + @obj.element_left + stroke_width / 2,
-                                @obj.translate_top + @obj.element_top + stroke_width / 2,
+                                @obj.translate_top + drawing_top + stroke_width / 2,
                                 @obj.element_width - stroke_width,
                                 @obj.element_height - stroke_width,
                                 @obj.corners * 2, @obj.corners * 2)

--- a/shoes-swt/lib/shoes/swt/shape.rb
+++ b/shoes-swt/lib/shoes/swt/shape.rb
@@ -22,6 +22,7 @@ class Shoes
         @painter = ShapePainter.new(self)
         @transform = nil
         @app.add_paint_listener @painter
+        @scroll_top_applied = nil
       end
 
       def dispose
@@ -30,6 +31,7 @@ class Shoes
       end
 
       attr_reader :dsl, :app, :element, :painter
+      attr_accessor :scroll_top_applied
 
       def redraw_target
         @dsl

--- a/shoes-swt/lib/shoes/swt/shape_painter.rb
+++ b/shoes-swt/lib/shoes/swt/shape_painter.rb
@@ -2,6 +2,17 @@
 class Shoes
   module Swt
     class ShapePainter < Common::Painter
+      def before_painted
+        if @obj.scroll_top_applied != @obj.dsl.parent.scroll_top
+          # Put back what we've already done
+          @obj.transform.translate(0, @obj.scroll_top_applied) if @obj.scroll_top_applied
+
+          # Move it!
+          @obj.transform.translate(0, -@obj.dsl.parent.scroll_top)
+          @obj.scroll_top_applied = @obj.dsl.parent.scroll_top
+        end
+      end
+
       def fill(gc)
         gc.fill_path(@obj.element)
       end

--- a/shoes-swt/lib/shoes/swt/star_painter.rb
+++ b/shoes-swt/lib/shoes/swt/star_painter.rb
@@ -15,7 +15,7 @@ class Shoes
         inner = obj.inner
         points = obj.points
         left = obj.translate_left + obj.element_left
-        top = obj.translate_top + obj.element_top
+        top = obj.translate_top + drawing_top
         @polygon = []
         add_edge(left, top + outer)
         (1..points * 2).each do |i|

--- a/shoes-swt/spec/shoes/swt/arc_painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/arc_painter_spec.rb
@@ -13,7 +13,7 @@ describe Shoes::Swt::ArcPainter do
   let(:fill_color) { Shoes::Color.new(40, 50, 60, 70) }
   let(:stroke_color) { Shoes::Color.new(80, 90, 100, 110) }
   let(:dsl) do
-    double("dsl object", app: shoes_app,
+    double("dsl object", app: shoes_app, parent: parent,
                          element_width: width, element_height: height,
                          element_left: left, element_top: top,
                          translate_left: 0, translate_top: 0,

--- a/shoes-swt/spec/shoes/swt/arrow_painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/arrow_painter_spec.rb
@@ -2,6 +2,7 @@
 require 'spec_helper'
 
 describe Shoes::Swt::ArrowPainter do
+  include_context "swt app"
   include_context "painter context"
 
   let(:corners) { 0 }
@@ -9,10 +10,12 @@ describe Shoes::Swt::ArrowPainter do
   let(:container) { double('container', disposed?: false) }
 
   let(:dsl) do
-    double("dsl object", hidden: false, rotate: 0,
+    double("dsl object", parent: parent, hidden: false, rotate: 0,
                          translate_left: 0, translate_top: 0,
                          left: left, top: top,
                          width: width, height: height,
+                         element_left: left, element_top: top,
+                         element_width: width, element_height: height,
                          style: {}, strokewidth: 1).as_null_object
   end
 
@@ -33,6 +36,11 @@ describe Shoes::Swt::ArrowPainter do
 
   it "fills on path" do
     expect(gc).to receive(:fill_path).with(subject.path)
+    subject.paint_control(event)
+  end
+
+  it "disposes of path after painting" do
+    expect(subject.path).to receive(:dispose)
     subject.paint_control(event)
   end
 

--- a/shoes-swt/spec/shoes/swt/background_spec.rb
+++ b/shoes-swt/spec/shoes/swt/background_spec.rb
@@ -12,6 +12,7 @@ describe Shoes::Swt::Background do
   let(:fill) { Shoes::COLORS[:salmon] }
   let(:dsl) do
     double("dsl object", app: shoes_app,
+                         parent: parent,
                          element_left: left, element_top: top,
                          element_width: width, element_height: height,
                          translate_left: 0, translate_top: 0,

--- a/shoes-swt/spec/shoes/swt/common/painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/common/painter_spec.rb
@@ -9,11 +9,12 @@ describe Shoes::Swt::Common::Painter do
 
   let(:parent) do
     double 'parent', absolute_left: 0, absolute_top: 0, width: 200, height: 100,
-                     fixed_height?: true
+                     scroll_top: 0, fixed_height?: true
   end
 
   let(:dsl) do
-    double 'dsl', parent: parent, visible?: true, positioned?: true, style: {}
+    double 'dsl', parent: parent, visible?: true, positioned?: true, style: {},
+                  element_left: 0, element_top: 0, element_width: 0, element_height: 0
   end
 
   let(:event) { double 'paint event', gc: graphics_context }
@@ -63,10 +64,6 @@ describe Shoes::Swt::Common::Painter do
     it 'rotates' do
       allow(dsl).to receive(:needs_rotate?) { true }
       allow(dsl).to receive(:rotate) { 10 }
-      allow(dsl).to receive(:element_left)   { 0 }
-      allow(dsl).to receive(:element_width)  { 0 }
-      allow(dsl).to receive(:element_top)    { 0 }
-      allow(dsl).to receive(:element_height) { 0 }
 
       expect_transform_for_rotate(dsl.rotate)
 
@@ -90,6 +87,17 @@ describe Shoes::Swt::Common::Painter do
       subject.set_rotate graphics_context, rotate_by, 0, 0 do
         # no-op
       end
+    end
+  end
+
+  describe "drawing_top" do
+    it "matches element_top if not scrolled" do
+      expect(subject.drawing_top).to eq(dsl.element_top)
+    end
+
+    it "is offset when parent is scrolled" do
+      allow(parent).to receive(:scroll_top).and_return(10)
+      expect(subject.drawing_top).to eq(dsl.element_top - 10)
     end
   end
 

--- a/shoes-swt/spec/shoes/swt/common/painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/common/painter_spec.rb
@@ -14,7 +14,8 @@ describe Shoes::Swt::Common::Painter do
 
   let(:dsl) do
     double 'dsl', parent: parent, visible?: true, positioned?: true, style: {},
-                  element_left: 0, element_top: 0, element_width: 0, element_height: 0
+                  element_left: 0, element_top: 0, element_bottom: 0,
+                  element_width: 0, element_height: 0
   end
 
   let(:event) { double 'paint event', gc: graphics_context }
@@ -98,6 +99,17 @@ describe Shoes::Swt::Common::Painter do
     it "is offset when parent is scrolled" do
       allow(parent).to receive(:scroll_top).and_return(10)
       expect(subject.drawing_top).to eq(dsl.element_top - 10)
+    end
+  end
+
+  describe "drawing_bottom" do
+    it "matches element_bottom if not scrolled" do
+      expect(subject.drawing_bottom).to eq(dsl.element_bottom)
+    end
+
+    it "is offset when parent is scrolled" do
+      allow(parent).to receive(:scroll_top).and_return(10)
+      expect(subject.drawing_bottom).to eq(dsl.element_bottom - 10)
     end
   end
 

--- a/shoes-swt/spec/shoes/swt/line_painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/line_painter_spec.rb
@@ -24,4 +24,10 @@ describe Shoes::Swt::LinePainter do
     expect(gc).to receive(:draw_line).with(10, 100, 300, 10)
     subject.paint_control(event)
   end
+
+  specify "draws line scrolled" do
+    allow(parent).to receive(:scroll_top).and_return(10)
+    expect(gc).to receive(:draw_line).with(10, 90, 300, 0)
+    subject.paint_control(event)
+  end
 end

--- a/shoes-swt/spec/shoes/swt/oval_painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/oval_painter_spec.rb
@@ -38,4 +38,10 @@ describe Shoes::Swt::OvalPainter do
     expect(gc).to receive(:draw_oval).with(left + sw / 2, top + sw / 2, width - sw, height - sw)
     subject.paint_control(event)
   end
+
+  it "positions correctly when scrolled" do
+    allow(parent).to receive(:scroll_top).and_return(10)
+    expect(gc).to receive(:draw_oval).with(left + sw / 2, top - 10 + sw / 2, width - sw, height - sw)
+    subject.paint_control(event)
+  end
 end

--- a/shoes-swt/spec/shoes/swt/rect_painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/rect_painter_spec.rb
@@ -49,4 +49,12 @@ describe Shoes::Swt::RectPainter do
       subject.paint_control(event)
     end
   end
+
+  describe "scrolling" do
+    it "draws rect offset" do
+      allow(parent).to receive(:scroll_top).and_return(10)
+      expect(gc).to receive(:draw_round_rectangle).with(left + sw / 2, top - 10 + sw / 2, width - sw, height - sw, corners * 2, corners * 2)
+      subject.paint_control(event)
+    end
+  end
 end

--- a/shoes-swt/spec/shoes/swt/rect_painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/rect_painter_spec.rb
@@ -2,6 +2,7 @@
 require 'spec_helper'
 
 describe Shoes::Swt::RectPainter do
+  include_context "swt app"
   include_context "painter context"
 
   let(:corners) { 0 }
@@ -9,7 +10,7 @@ describe Shoes::Swt::RectPainter do
   let(:container) { double('container', disposed?: false) }
 
   let(:dsl) do
-    double("dsl object", hidden: false, rotate: 0,
+    double("dsl object", parent: parent, hidden: false, rotate: 0,
                          translate_left: 0, translate_top: 0,
                          element_left: left, element_top: top,
                          element_width: width, element_height: height,

--- a/shoes-swt/spec/shoes/swt/shape_painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/shape_painter_spec.rb
@@ -6,7 +6,8 @@ describe Shoes::Swt::ShapePainter do
   include_context "painter context"
 
   let(:dsl) do
-    double("Shoes::Shape", hidden: false, needs_rotate?: false, style: {}).as_null_object
+    double("Shoes::Shape", parent: parent, hidden: false,
+                           needs_rotate?: false, style: {}).as_null_object
   end
 
   let(:shape) { Shoes::Swt::Shape.new(dsl, swt_app) }
@@ -24,5 +25,14 @@ describe Shoes::Swt::ShapePainter do
   it "draws path" do
     expect(gc).to receive(:draw_path)
     subject.paint_control(event)
+  end
+
+  it "remembers scrolling position applied" do
+    expect(shape.scroll_top_applied).to eq(nil)
+
+    allow(parent).to receive(:scroll_top).and_return(10)
+    subject.paint_control(event)
+
+    expect(shape.scroll_top_applied).to eq(10)
   end
 end

--- a/shoes-swt/spec/shoes/swt/shared_examples/swt_app_context.rb
+++ b/shoes-swt/spec/shoes/swt/shared_examples/swt_app_context.rb
@@ -30,6 +30,7 @@ shared_context "swt app" do
 
   let(:parent) do
     double('parent', app: swt_app, add_child: true, real: true, hidden?: false,
+                     scroll_top: 0,
                      absolute_left: 0, absolute_top: 0,
                      width: 200, height: 100, fixed_height?: true)
   end

--- a/shoes-swt/spec/shoes/swt/star_painter_spec.rb
+++ b/shoes-swt/spec/shoes/swt/star_painter_spec.rb
@@ -13,7 +13,8 @@ describe Shoes::Swt::StarPainter do
   let(:corners) { 0 }
 
   let(:dsl) do
-    double("dsl object", hidden: false, points: points, outer: outer,
+    double("dsl object", parent: parent, hidden: false,
+                         points: points, outer: outer,
                          inner: inner, element_width: outer * 2.0,
                          element_height: outer * 2.0, element_left: left,
                          element_top: top).as_null_object


### PR DESCRIPTION
Teaser!
![scroll](https://user-images.githubusercontent.com/130504/32036584-9ae41a20-b9d5-11e7-866a-187a65420272.gif)

(Clicking buttons is incrementing the `scroll_top` on the slots. No mouse interaction yet--this PR will just get the method handling right.)

## TODO
* [x] Use `drawing_top` across all painted element types
* [x] Test all non-painted elements in a scrolling slot 
* [ ] Test samples
