### PR TITLE
Redraw more thoroughly on text changes

### DIFF
--- a/shoes-swt/lib/shoes/swt/redrawing_aspect.rb
+++ b/shoes-swt/lib/shoes/swt/redrawing_aspect.rb
@@ -22,6 +22,7 @@ class Shoes
           MouseMoveListener                => [:eval_move_block],
           TextBlock::CursorPainter         => [:move_textcursor],
           Timer                            => [:eval_block],
+          ::Shoes::TextBlock               => [:replace],
           ::Shoes::Common::Changeable      => [:call_change_listeners]
         }.freeze
 
@@ -32,8 +33,7 @@ class Shoes
                            ::Shoes::Common::Style  => [:update_style],
                            ::Shoes::Common::Remove => [:remove],
                            ::Shoes::Slot           => [:mouse_hovered,
-                                                       :mouse_left],
-                           ::Shoes::TextBlock      => [:replace] }.freeze
+                                                       :mouse_left]}.freeze
 
       CHANGED_POSITION = { ::Shoes::DimensionsDelegations => [:adjust_current_position],
                            ::Shoes::Common::Positioning   => [:_position, :displace],


### PR DESCRIPTION
Fixes #519

Because we set the `scroll_max` after recalculating slot positioning, we need a bit more aggressive redrawing when a text block's text changes.

Along with the basic slot scrolling work from #1499, this gets the sample to follow text at the bottom of the window when you're typing new commands that extend past the scroll.