### PR TITLE
Reduce warnings on circular reference

### DIFF
--- a/shoes-swt/spec/shoes/swt/spec_helper.rb
+++ b/shoes-swt/spec/shoes/swt/spec_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "shoes/swt"
-require "spec_helper"
 
 Shoes.load_backend("swt").initialize_backend
 


### PR DESCRIPTION
When running individual specs in `shoes-swt` was seeing warnings because of circular requires. Turns out we don't seem to need it. If this PR goes 🍏  will just merge away since little impact except to test running.