### PR TITLE
Text replace perf fix

### DIFF
--- a/samples/simple_scroll.rb
+++ b/samples/simple_scroll.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Shoes.app height: 150 do
   @stack = stack height: 150, scroll: true do
     para strong("Press arrow keys to scroll too!\n")

--- a/shoes-core/lib/shoes/slot.rb
+++ b/shoes-core/lib/shoes/slot.rb
@@ -159,6 +159,7 @@ class Shoes
     end
 
     def scroll_max
+      contents_alignment
       return 0 unless scroll_height && height
 
       [scroll_height - height, 0].max

--- a/shoes-core/spec/shoes/shared_examples/scroll.rb
+++ b/shoes-core/spec/shoes/shared_examples/scroll.rb
@@ -8,6 +8,8 @@ shared_examples_for "scrollable slot" do
 
   before do
     subject.scroll_height = 200
+    allow(subject).to receive(:compute_content_height).and_return(200)
+
     subject.height = 100
   end
 
@@ -58,11 +60,15 @@ shared_examples_for "scrollable slot" do
 
     it 'caps scrolling' do
       subject.scroll_height = 80
+      allow(subject).to receive(:compute_content_height).and_return(80)
+
       expect(subject.scroll_max).to eq(0)
     end
 
     it 'zeroes out if missing scroll_height' do
       subject.scroll_height = nil
+      allow(subject).to receive(:compute_content_height).and_return(nil)
+
       expect(subject.scroll_max).to eq(0)
     end
   end

--- a/shoes-swt/lib/shoes/swt/image_painter.rb
+++ b/shoes-swt/lib/shoes/swt/image_painter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Shoes
   module Swt
     class ImagePainter


### PR DESCRIPTION
Fixes #1508

To get scrolling to find the proper values in `samples/expert_irb.rb`, commit a9d1487cebef22d1f650b262be264b1acef64a85 started triggering a full redraw on `Shoes::TextBlock#replace`. This turns out to be a bad idea for things like manual pages that have lots of text--it causes a hang during the initial render as we constantly recalculate.

A recalculation is needed by `samples/expert_irb.rb`, but we now take the more conservative approach of making sure that we're up to date on `contents_alignment` when a slot gets asked about `scroll_max`. Since that method is only called by user code, not the framework, we can take the perf hit for making sure sizing's right before returning the `scroll_max` value.

Will be keeping a close eye out when testing for next release on perf issues like this to see if anything else shows up, but probably won't do a big test run on this particular PR.