### PR TITLE
Make edit box a little smaller

### DIFF
--- a/samples/good_displace.rb
+++ b/samples/good_displace.rb
@@ -26,7 +26,7 @@ class Layout
   end
 
   def edit_box
-    @app.edit_box "Edit me", left: left(:edit_box), top: top, width: width
+    @app.edit_box "Edit me", left: left(:edit_box), top: top, height: 50, width: width
   end
 
   def offset(element)


### PR DESCRIPTION
Fixes #1514

Just made the edit box small enough to fit, where it defaults to a couple pixels too large for our 100 height slot.