### PR TITLE
Star Center Point

### DIFF
--- a/samples/simple_star.rb
+++ b/samples/simple_star.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# a simple shoes app to show how to use the star.center_point method
+Shoes.app do
+  fill rgb(0, 0.6, 0.9, 0.1)
+  stroke rgb(0, 0.6, 0.9)
+  strokewidth 0.25
+
+  blurgh = star 200, 200
+
+  center_point = blurgh.center_point
+
+  line center_point.x, 0, center_point.x, 500
+  line 0, center_point.y, 500, center_point.y
+
+  radius = 3
+  oval (center_point.x - radius), (center_point.y - radius), radius: radius
+end

--- a/samples/simple_star.rb
+++ b/samples/simple_star.rb
@@ -1,18 +1,24 @@
 # frozen_string_literal: true
 
 # a simple shoes app to show how to use the star.center_point method
-Shoes.app do
-  fill rgb(0, 0.6, 0.9, 0.1)
+Shoes.app width: 600, height: 600 do
+  fill rgb(158, 223, 229, 0.1)
   stroke rgb(0, 0.6, 0.9)
   strokewidth 0.25
+  @pleione = star 200, 100
 
-  blurgh = star 200, 200
-
-  center_point = blurgh.center_point
-
+  # draw two lines that intersect the center of the star
+  center_point = @pleione.center_point
   line center_point.x, 0, center_point.x, 500
   line 0, center_point.y, 500, center_point.y
 
+  # draw a small circle at the center of the star
   radius = 3
   oval (center_point.x - radius), (center_point.y - radius), radius: radius
+
+  # do you want a star to follow you around?
+  @churyumov_gerasimenko = star 200, 100
+  motion do |x, y|
+    @churyumov_gerasimenko.center_point = Shoes::Point.new(x, y)
+  end
 end

--- a/shoes-core/lib/shoes/star.rb
+++ b/shoes-core/lib/shoes/star.rb
@@ -68,6 +68,5 @@ class Shoes
       center_y = top + (height / 2).to_i
       Point.new(center_x, center_y)
     end
-
   end
 end

--- a/shoes-core/lib/shoes/star.rb
+++ b/shoes-core/lib/shoes/star.rb
@@ -62,5 +62,12 @@ class Shoes
     def redraw_height
       element_height + style[:strokewidth].to_i * 2
     end
+
+    def center_point
+      center_x = left + (width / 2).to_i
+      center_y = top + (height / 2).to_i
+      Point.new(center_x, center_y)
+    end
+
   end
 end

--- a/shoes-core/lib/shoes/star.rb
+++ b/shoes-core/lib/shoes/star.rb
@@ -64,9 +64,14 @@ class Shoes
     end
 
     def center_point
-      center_x = left + (width / 2).to_i
-      center_y = top + (height / 2).to_i
+      center_x = left + (element_width * 0.5).to_i
+      center_y = top + (element_height * 0.5).to_i
       Point.new(center_x, center_y)
+    end
+
+    def center_point=(point)
+      self.left = point.x - (width * 0.5).to_i
+      self.top = point.y - (height * 0.5).to_i
     end
   end
 end

--- a/shoes-core/spec/shoes/star_spec.rb
+++ b/shoes-core/spec/shoes/star_spec.rb
@@ -207,13 +207,11 @@ describe Shoes::Star do
     subject { Shoes::Star.new(app, parent, 100, 100, 5, 50, 30, center: false, strokewidth: 0) }
 
     it "should return the center point of the star" do
-      expect(subject.center_point.to_a).to eq([150,150])
+      expect(subject.center_point.to_a).to eq([150, 150])
     end
 
     it "should return the coordinates as a Point" do
       expect(subject.center_point.class).to eq(Shoes::Point)
     end
-
   end
-
 end

--- a/shoes-core/spec/shoes/star_spec.rb
+++ b/shoes-core/spec/shoes/star_spec.rb
@@ -209,5 +209,10 @@ describe Shoes::Star do
     it "should return the center point of the star" do
       expect(subject.center_point).to eq(Shoes::Point.new(175, 225))
     end
+
+    it "should handle stars initialized with nil dimensions" do
+      nil_star = Shoes::Star.new(app, parent, 100, nil, 0, nil, nil, center: false, strokewidth: 0)
+      expect(nil_star.center_point).to eq(Shoes::Point.new(200, 100))
+    end
   end
 end

--- a/shoes-core/spec/shoes/star_spec.rb
+++ b/shoes-core/spec/shoes/star_spec.rb
@@ -215,4 +215,13 @@ describe Shoes::Star do
       expect(nil_star.center_point).to eq(Shoes::Point.new(200, 100))
     end
   end
+
+  describe "center_point=" do
+    subject { Shoes::Star.new(app, parent, 125, 175, 5, 50, 30, center: false, strokewidth: 10) }
+
+    it "should set a new center_point" do
+      subject.center_point = Shoes::Point.new(80, 90)
+      expect(subject.center_point).to eq(Shoes::Point.new(80, 90))
+    end
+  end
 end

--- a/shoes-core/spec/shoes/star_spec.rb
+++ b/shoes-core/spec/shoes/star_spec.rb
@@ -204,14 +204,10 @@ describe Shoes::Star do
   end
 
   describe "center_point" do
-    subject { Shoes::Star.new(app, parent, 100, 100, 5, 50, 30, center: false, strokewidth: 0) }
+    subject { Shoes::Star.new(app, parent, 125, 175, 5, 50, 30, center: false, strokewidth: 0) }
 
     it "should return the center point of the star" do
-      expect(subject.center_point.to_a).to eq([150, 150])
-    end
-
-    it "should return the coordinates as a Point" do
-      expect(subject.center_point.class).to eq(Shoes::Point)
+      expect(subject.center_point).to eq(Shoes::Point.new(175, 225))
     end
   end
 end

--- a/shoes-core/spec/shoes/star_spec.rb
+++ b/shoes-core/spec/shoes/star_spec.rb
@@ -202,4 +202,18 @@ describe Shoes::Star do
       expect(subject.redraw_height).to eq(108)
     end
   end
+
+  describe "center_point" do
+    subject { Shoes::Star.new(app, parent, 100, 100, 5, 50, 30, center: false, strokewidth: 0) }
+
+    it "should return the center point of the star" do
+      expect(subject.center_point.to_a).to eq([150,150])
+    end
+
+    it "should return the coordinates as a Point" do
+      expect(subject.center_point.class).to eq(Shoes::Point)
+    end
+
+  end
+
 end


### PR DESCRIPTION
A first pass at issue #996 - Give Star and arc a center point accessor.

Thought I'd start with a simple method to get the center point.  Then could work on setting the center_point and updating the corresponding Top and Left coordinates.  Then could recreate with arcs under separate PR.

## Open Questions
1. Not even sure this is the right way to add the functionality or if Shoes was looking for a style to use in the same way as `style_with`?
2. Should it return a Point? <- Seems like no, given 3.
3. I added the sample app mostly for my own benefit - can easily delete!
4. When setting a point, do you want to pass in a Point or just use simple x and y's? <- seems like this would be more in line with how coordinates are used in Shoes.
5. Wasn't fully sure about the difference between element_width and width...

Thanks!