### PR TITLE
Docs for Arc and Working Rake Task

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+./shoes-core/lib/**/*.rb
+-
+LICENSE
+README.md
+shoes-core/README.md
+LICENSE
+CONTRIBUTING.md
+CODE_OF_CONDUCT.MD

--- a/shoes-core/lib/shoes/arc.rb
+++ b/shoes-core/lib/shoes/arc.rb
@@ -9,7 +9,6 @@ class Shoes
   #   arc 200, 200, 100, 100, Shoes::PI, 0
   # @note Angle is the gradient angle used across all art elements. Angle1/2 are the angles of
   #   the arc itself!
-  # @author Jason Clark
   # @param left [Integer] The number of pixels from the left side of the window.
   # @param top [Integer] The number of pixels from the top side of the window
   # @param width [Integer] The width of the arc element.

--- a/shoes-core/lib/shoes/arc.rb
+++ b/shoes-core/lib/shoes/arc.rb
@@ -3,6 +3,13 @@
 class Shoes
   # Arc.  A basic element representing a curve of a circle or an oval.
   #
+  # @example A simple arc which describes the bottom half of a circle and uses the centered style.
+  #   arc 200, 200, 100, 100, 0, Shoes::PI, center: true
+  # @example An arc which describes the top half of a circle.
+  #   arc 200, 200, 100, 100, Shoes::PI, 0
+  # @note Angle is the gradient angle used across all art elements. Angle1/2 are the angles of 
+  #   the arc itself!
+  # @author Jason Clark
   # @param left [Integer] The number of pixels from the left side of the window.
   # @param top [Integer] The number of pixels from the top side of the window
   # @param width [Integer] The width of the arc element.
@@ -11,14 +18,7 @@ class Shoes
   #   starting from the 3 o'clock position.
   # @param angle2 [Float] The second angle of the arc to the center point, in Radians.
   # @param [Hash] Style hash
-  # @example A simple arc which describes the bottom half of a circle.
-  #   arc 200, 200, 100, 100, 0, Shoes::PI, center: true
-  # @example An arc which describes the top half of a circle.
-  #   arc 200, 200, 100, 100, Shoes::PI, 0
-  # @author Jason Clark
   class Arc < Common::ArtElement
-    # angle is the gradient angle used across all art elements
-    # angle1/2 are the angles of the arc itself!
     style_with :angle1, :angle2, :art_styles, :center, :common_styles, :dimensions, :radius, :wedge
     STYLES = { wedge: false, fill: Shoes::COLORS[:black] }.freeze
 

--- a/shoes-core/lib/shoes/arc.rb
+++ b/shoes-core/lib/shoes/arc.rb
@@ -7,7 +7,7 @@ class Shoes
   #   arc 200, 200, 100, 100, 0, Shoes::PI, center: true
   # @example An arc which describes the top half of a circle.
   #   arc 200, 200, 100, 100, Shoes::PI, 0
-  # @note Angle is the gradient angle used across all art elements. Angle1/2 are the angles of 
+  # @note Angle is the gradient angle used across all art elements. Angle1/2 are the angles of
   #   the arc itself!
   # @author Jason Clark
   # @param left [Integer] The number of pixels from the left side of the window.

--- a/shoes-core/lib/shoes/arc.rb
+++ b/shoes-core/lib/shoes/arc.rb
@@ -9,14 +9,7 @@ class Shoes
   #   arc 200, 200, 100, 100, Shoes::PI, 0
   # @note Angle is the gradient angle used across all art elements. Angle1/2 are the angles of
   #   the arc itself!
-  # @param left [Integer] The number of pixels from the left side of the window.
-  # @param top [Integer] The number of pixels from the top side of the window
-  # @param width [Integer] The width of the arc element.
-  # @param height [Integer] The height of the arc element.
-  # @param angle1 [Float] The first angle of the arc to the center point, in Radians,
-  #   starting from the 3 o'clock position.
-  # @param angle2 [Float] The second angle of the arc to the center point, in Radians.
-  # @param [Hash] Style hash
+  # @note The angle passed in is measured in Radians starting at 90 degrees or the 3 o'clock position.
   class Arc < Common::ArtElement
     style_with :angle1, :angle2, :art_styles, :center, :common_styles, :dimensions, :radius, :wedge
     STYLES = { wedge: false, fill: Shoes::COLORS[:black] }.freeze

--- a/shoes-core/lib/shoes/arc.rb
+++ b/shoes-core/lib/shoes/arc.rb
@@ -1,6 +1,21 @@
 # frozen_string_literal: true
 
 class Shoes
+  # Arc.  A basic element representing a curve of a circle or an oval.
+  #
+  # @param left [Integer] The number of pixels from the left side of the window.
+  # @param top [Integer] The number of pixels from the top side of the window
+  # @param width [Integer] The width of the arc element.
+  # @param height [Integer] The height of the arc element.
+  # @param angle1 [Float] The first angle of the arc to the center point, in Radians,
+  #   starting from the 3 o'clock position.
+  # @param angle2 [Float] The second angle of the arc to the center point, in Radians.
+  # @param [Hash] Style hash
+  # @example A simple arc which describes the bottom half of a circle.
+  #   arc 200, 200, 100, 100, 0, Shoes::PI, center: true
+  # @example An arc which describes the top half of a circle.
+  #   arc 200, 200, 100, 100, Shoes::PI, 0
+  # @author Jason Clark
   class Arc < Common::ArtElement
     # angle is the gradient angle used across all art elements
     # angle1/2 are the angles of the arc itself!
@@ -23,12 +38,22 @@ class Shoes
       wedge
     end
 
+    # Access the center point of the arc.
+    #
+    # @return [Shoes::Point] A point at the center of the arc.
+    # @example
+    #   my_point = my_arc.center_point
     def center_point
       center_x = left + (element_width * 0.5).to_i
       center_y = top + (element_height * 0.5).to_i
       Point.new(center_x, center_y)
     end
 
+    # Set the center point of an arc.
+    #
+    # @param point [Shoes::Point] the point to set as the center of the arc.
+    # @example Set an arc's center point at the [x, y] coordinates [100, 300]
+    #   my_arc.center_point = Shoes::Point.new(100, 300)
     def center_point=(point)
       self.left = point.x - (width * 0.5).to_i
       self.top = point.y - (height * 0.5).to_i

--- a/tasks/yard.rb
+++ b/tasks/yard.rb
@@ -3,11 +3,7 @@
 begin
   require 'yard'
 
-  YARD::Rake::YardocTask.new do |t|
-    t.files = ['shoes-core/**/*.rb', 'README.md', 'LICENSE', 'CONTRIBUTING.md',
-               'CODE_OF_CONDUCT.MD']
-    t.options = ['-mmarkdown', '--no-private']
-  end
+  YARD::Rake::YardocTask.new
 rescue LoadError
   desc "Generate YARD Documentation"
   task :yard do

--- a/tasks/yard.rb
+++ b/tasks/yard.rb
@@ -4,6 +4,7 @@ begin
   require 'yard'
 
   YARD::Rake::YardocTask.new do |t|
+    t.files = ['shoes-core/**/*.rb']
     t.options = ['-mmarkdown']
   end
 rescue LoadError

--- a/tasks/yard.rb
+++ b/tasks/yard.rb
@@ -4,8 +4,9 @@ begin
   require 'yard'
 
   YARD::Rake::YardocTask.new do |t|
-    t.files = ['shoes-core/**/*.rb']
-    t.options = ['-mmarkdown']
+    t.files = ['shoes-core/**/*.rb', 'README.md', 'LICENSE', 'CONTRIBUTING.md', 
+      'CODE_OF_CONDUCT.MD']
+    t.options = ['-mmarkdown', '--no-private']
   end
 rescue LoadError
   desc "Generate YARD Documentation"

--- a/tasks/yard.rb
+++ b/tasks/yard.rb
@@ -4,8 +4,8 @@ begin
   require 'yard'
 
   YARD::Rake::YardocTask.new do |t|
-    t.files = ['shoes-core/**/*.rb', 'README.md', 'LICENSE', 'CONTRIBUTING.md', 
-      'CODE_OF_CONDUCT.MD']
+    t.files = ['shoes-core/**/*.rb', 'README.md', 'LICENSE', 'CONTRIBUTING.md',
+               'CODE_OF_CONDUCT.MD']
     t.options = ['-mmarkdown', '--no-private']
   end
 rescue LoadError


### PR DESCRIPTION
Trying to also make progress against #620.

Two things here: 
1. when I ran `rake yard` the yardoc generation didn't generate any files.  Maybe this was because I wasn't running it correctly?  I was able to generate some of the documentation by modifying the rake task as here.  However, we may want to add a .yardopts file so that running yardoc from the root works without requiring a rake task?  This might also be required to get the docs on rubydoc - entirely not sure.  I also added --no-private flag as per the comments in #620.

2. Made a first pass at adding in some docs for the Arc class where I feel sufficiently able to explain what's going on.  I also moved a comment into the notes so that it is featured in the generated docs.

Completely not sure if this is helpful or not but thought I'd start on it and welcome any and all direction change!

best,
n
