### PR TITLE
Give more room in redrawing stars

### DIFF
--- a/shoes-core/lib/shoes/star.rb
+++ b/shoes-core/lib/shoes/star.rb
@@ -37,26 +37,31 @@ class Shoes
         element_top - dy <= y && y <= element_bottom - dy
     end
 
+    # Redrawing needs a bit of extra room. We offset by this factor, then
+    # extend our size by twice that to evenly surround the whole thing.
+    REDRAW_OFFSET_FACTOR = 4
+    REDRAW_SIZING_FACTOR = REDRAW_OFFSET_FACTOR * 2
+
     def redraw_left
       return 0 unless element_left
       calculated_left = element_left
       calculated_left -= width * 0.5 if center
-      calculated_left - strokewidth.ceil * 4
+      calculated_left - strokewidth.ceil * REDRAW_OFFSET_FACTOR
     end
 
     def redraw_top
       return 0 unless element_top
       calculated_top = element_top
       calculated_top -= width * 0.5 if center
-      calculated_top - strokewidth.ceil * 4
+      calculated_top - strokewidth.ceil * REDRAW_OFFSET_FACTOR
     end
 
     def redraw_width
-      element_width + strokewidth.ceil * 8
+      element_width + strokewidth.ceil * REDRAW_SIZING_FACTOR
     end
 
     def redraw_height
-      element_height + strokewidth.ceil * 8
+      element_height + strokewidth.ceil * REDRAW_SIZING_FACTOR
     end
 
     def center_point

--- a/shoes-core/lib/shoes/star.rb
+++ b/shoes-core/lib/shoes/star.rb
@@ -39,28 +39,24 @@ class Shoes
 
     def redraw_left
       return 0 unless element_left
-      if center
-        element_left - width * 0.5 - style[:strokewidth].to_i
-      else
-        super
-      end
+      calculated_left = super
+      calculated_left = element_left - width * 0.5 if center
+      calculated_left - style[:strokewidth].to_i * 2
     end
 
     def redraw_top
       return 0 unless element_top
-      if center
-        element_top - width * 0.5 - style[:strokewidth].to_i
-      else
-        super
-      end
+      calculated_top = super
+      calculated_top = element_top - width * 0.5 if center
+      calculated_top - style[:strokewidth].to_i * 2
     end
 
     def redraw_width
-      element_width + style[:strokewidth].to_i * 2
+      element_width + style[:strokewidth].to_i * 4
     end
 
     def redraw_height
-      element_height + style[:strokewidth].to_i * 2
+      element_height + style[:strokewidth].to_i * 4
     end
 
     def center_point

--- a/shoes-core/lib/shoes/star.rb
+++ b/shoes-core/lib/shoes/star.rb
@@ -41,22 +41,22 @@ class Shoes
       return 0 unless element_left
       calculated_left = super
       calculated_left = element_left - width * 0.5 if center
-      calculated_left - style[:strokewidth].to_i * 2
+      calculated_left - strokewidth * 2
     end
 
     def redraw_top
       return 0 unless element_top
       calculated_top = super
       calculated_top = element_top - width * 0.5 if center
-      calculated_top - style[:strokewidth].to_i * 2
+      calculated_top - strokewidth * 2
     end
 
     def redraw_width
-      element_width + style[:strokewidth].to_i * 4
+      element_width + strokewidth * 4
     end
 
     def redraw_height
-      element_height + style[:strokewidth].to_i * 4
+      element_height + strokewidth * 4
     end
 
     def center_point

--- a/shoes-core/lib/shoes/star.rb
+++ b/shoes-core/lib/shoes/star.rb
@@ -39,24 +39,24 @@ class Shoes
 
     def redraw_left
       return 0 unless element_left
-      calculated_left = super
-      calculated_left = element_left - width * 0.5 if center
-      calculated_left - strokewidth * 2
+      calculated_left = element_left
+      calculated_left -= width * 0.5 if center
+      calculated_left - strokewidth.ceil * 4
     end
 
     def redraw_top
       return 0 unless element_top
-      calculated_top = super
-      calculated_top = element_top - width * 0.5 if center
-      calculated_top - strokewidth * 2
+      calculated_top = element_top
+      calculated_top -= width * 0.5 if center
+      calculated_top - strokewidth.ceil * 4
     end
 
     def redraw_width
-      element_width + strokewidth * 4
+      element_width + strokewidth.ceil * 8
     end
 
     def redraw_height
-      element_height + strokewidth * 4
+      element_height + strokewidth.ceil * 8
     end
 
     def center_point

--- a/shoes-core/spec/shoes/star_spec.rb
+++ b/shoes-core/spec/shoes/star_spec.rb
@@ -179,35 +179,35 @@ describe Shoes::Star do
     end
 
     it "positions around itself" do
-      expect(subject.redraw_left).to eq(98)
-      expect(subject.redraw_top).to eq(98)
-      expect(subject.redraw_width).to eq(104)
-      expect(subject.redraw_height).to eq(104)
+      expect(subject.redraw_left).to eq(96)
+      expect(subject.redraw_top).to eq(96)
+      expect(subject.redraw_width).to eq(108)
+      expect(subject.redraw_height).to eq(108)
     end
 
     it "positions centered around itself" do
       subject.center = true
-      expect(subject.redraw_left).to eq(48)
-      expect(subject.redraw_top).to eq(48)
-      expect(subject.redraw_width).to eq(104)
-      expect(subject.redraw_height).to eq(104)
+      expect(subject.redraw_left).to eq(46)
+      expect(subject.redraw_top).to eq(46)
+      expect(subject.redraw_width).to eq(108)
+      expect(subject.redraw_height).to eq(108)
     end
 
     it "factors in strokewidth" do
       subject.strokewidth = 4
-      expect(subject.redraw_left).to eq(92)
-      expect(subject.redraw_top).to eq(92)
-      expect(subject.redraw_width).to eq(116)
-      expect(subject.redraw_height).to eq(116)
+      expect(subject.redraw_left).to eq(84)
+      expect(subject.redraw_top).to eq(84)
+      expect(subject.redraw_width).to eq(132)
+      expect(subject.redraw_height).to eq(132)
     end
 
     it "factors in strokewidth when centered" do
       subject.center = true
       subject.strokewidth = 4
-      expect(subject.redraw_left).to eq(42)
-      expect(subject.redraw_top).to eq(42)
-      expect(subject.redraw_width).to eq(116)
-      expect(subject.redraw_height).to eq(116)
+      expect(subject.redraw_left).to eq(34)
+      expect(subject.redraw_top).to eq(34)
+      expect(subject.redraw_width).to eq(132)
+      expect(subject.redraw_height).to eq(132)
     end
   end
 

--- a/shoes-core/spec/shoes/star_spec.rb
+++ b/shoes-core/spec/shoes/star_spec.rb
@@ -193,13 +193,21 @@ describe Shoes::Star do
       expect(subject.redraw_height).to eq(100)
     end
 
+    it "factors in strokewidth" do
+      subject.strokewidth = 4
+      expect(subject.redraw_left).to eq(92)
+      expect(subject.redraw_top).to eq(92)
+      expect(subject.redraw_width).to eq(116)
+      expect(subject.redraw_height).to eq(116)
+    end
+
     it "factors in strokewidth when centered" do
       subject.center = true
       subject.strokewidth = 4
-      expect(subject.redraw_left).to eq(46)
-      expect(subject.redraw_top).to eq(46)
-      expect(subject.redraw_width).to eq(108)
-      expect(subject.redraw_height).to eq(108)
+      expect(subject.redraw_left).to eq(42)
+      expect(subject.redraw_top).to eq(42)
+      expect(subject.redraw_width).to eq(116)
+      expect(subject.redraw_height).to eq(116)
     end
   end
 

--- a/shoes-core/spec/shoes/star_spec.rb
+++ b/shoes-core/spec/shoes/star_spec.rb
@@ -170,7 +170,7 @@ describe Shoes::Star do
   end
 
   describe "redrawing region" do
-    subject { Shoes::Star.new(app, parent, 100, 100, 5, 50, 30, center: false) }
+    subject { Shoes::Star.new(app, parent, 100, 100, 5, 50, 30, center: false, strokewidth: 1) }
 
     before do
       # faux positioning

--- a/shoes-core/spec/shoes/star_spec.rb
+++ b/shoes-core/spec/shoes/star_spec.rb
@@ -170,7 +170,7 @@ describe Shoes::Star do
   end
 
   describe "redrawing region" do
-    subject { Shoes::Star.new(app, parent, 100, 100, 5, 50, 30, center: false, strokewidth: 0) }
+    subject { Shoes::Star.new(app, parent, 100, 100, 5, 50, 30, center: false) }
 
     before do
       # faux positioning
@@ -179,18 +179,18 @@ describe Shoes::Star do
     end
 
     it "positions around itself" do
-      expect(subject.redraw_left).to eq(100)
-      expect(subject.redraw_top).to eq(100)
-      expect(subject.redraw_width).to eq(100)
-      expect(subject.redraw_height).to eq(100)
+      expect(subject.redraw_left).to eq(98)
+      expect(subject.redraw_top).to eq(98)
+      expect(subject.redraw_width).to eq(104)
+      expect(subject.redraw_height).to eq(104)
     end
 
     it "positions centered around itself" do
       subject.center = true
-      expect(subject.redraw_left).to eq(50)
-      expect(subject.redraw_top).to eq(50)
-      expect(subject.redraw_width).to eq(100)
-      expect(subject.redraw_height).to eq(100)
+      expect(subject.redraw_left).to eq(48)
+      expect(subject.redraw_top).to eq(48)
+      expect(subject.redraw_width).to eq(104)
+      expect(subject.redraw_height).to eq(104)
     end
 
     it "factors in strokewidth" do

--- a/shoes-swt/spec/shoes/swt/shared_examples/swt_app_context.rb
+++ b/shoes-swt/spec/shoes/swt/shared_examples/swt_app_context.rb
@@ -27,7 +27,7 @@ shared_context "swt app" do
     swt_double
   end
 
-  let(:shoes_app) { double('shoes app', gui: swt_app, rotate: 0, style: {}, element_styles: {}) }
+  let(:shoes_app) { double('shoes app', gui: swt_app, rotate: 0, style: Shoes::Common::Style::DEFAULT_STYLES.dup, element_styles: {}) }
 
   let(:parent) do
     double('parent', app: swt_app, add_child: true, real: true, hidden?: false,

--- a/shoes-swt/spec/shoes/swt/text_block/text_segment_collection_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block/text_segment_collection_spec.rb
@@ -70,7 +70,7 @@ describe Shoes::Swt::TextBlock::TextSegmentCollection do
 
         dsl_style = dsl_link.style
         default_style = default_text_styles.merge(dsl_style)
-        expected_style = default_style.merge(underline: true, stroke: ::Shoes::COLORS[:blue], fill: nil)
+        expected_style = default_style.merge(underline: true, stroke: ::Shoes::COLORS[:black], fill: nil)
         expect(first_segment).to have_received(:set_style).with(expected_style, 0..1)
       end
 


### PR DESCRIPTION
Fixes #1526

Ended up that after some testing it wasn't just a single pixel--it was related to the strokewidth for the drawing which wasn't being accounted for perfectly.

This may be slightly more generous than it needs to be, but generally redrawing a few more pixels around the edges is better than artifacts!