### PR TITLE
Fix link default styling

### DIFF
--- a/shoes-core/lib/shoes/common/style.rb
+++ b/shoes-core/lib/shoes/common/style.rb
@@ -35,11 +35,10 @@ class Shoes
       end
 
       def style_init(arg_styles, new_styles = {})
-        default_element_styles = {}
-        default_element_styles = self.class::STYLES if defined?(self.class::STYLES)
         create_style_hash
-        @style.merge!(default_element_styles)
-        merge_app_styles
+        @style.merge!(DEFAULT_STYLES)
+        @style.merge!(self.class::STYLES) if defined?(self.class::STYLES)
+        @style.merge!(applicable_app_styles)
         @style.merge!(@app.element_styles[self.class]) if @app.element_styles[self.class]
         @style.merge!(new_styles)
         @style.merge!(arg_styles)
@@ -55,9 +54,12 @@ class Shoes
         end
       end
 
-      def merge_app_styles
-        @app.style.each do |key, val|
-          @style[key] = val if supported_styles.include? key
+      def applicable_app_styles
+        @app.style.inject({}) do |memo, (key, value)|
+          if supported_styles.include?(key)
+            memo[key] = value
+          end
+          memo
         end
       end
 

--- a/shoes-core/lib/shoes/common/style.rb
+++ b/shoes-core/lib/shoes/common/style.rb
@@ -40,6 +40,11 @@ class Shoes
         @style.merge!(self.class::STYLES) if defined?(self.class::STYLES)
         @style.merge!(applicable_app_styles)
         @style.merge!(@app.element_styles[self.class]) if @app.element_styles[self.class]
+
+        @app.remove_styles.each do |to_remove|
+          @style.delete(to_remove)
+        end
+
         @style.merge!(new_styles)
         @style.merge!(arg_styles)
         @style = StyleNormalizer.new.normalize(@style)

--- a/shoes-core/lib/shoes/common/style.rb
+++ b/shoes-core/lib/shoes/common/style.rb
@@ -55,11 +55,11 @@ class Shoes
       end
 
       def applicable_app_styles
-        @app.style.inject({}) do |memo, (key, value)|
-          if supported_styles.include?(key)
+        @app.style.each_with_object({}) do |(key, value), memo|
+          changed_from_default = DEFAULT_STYLES[key] != value
+          if supported_styles.include?(key) && changed_from_default
             memo[key] = value
           end
-          memo
         end
       end
 

--- a/shoes-core/lib/shoes/dsl/style.rb
+++ b/shoes-core/lib/shoes/dsl/style.rb
@@ -36,6 +36,7 @@ class Shoes
 
       PATTERN_APP_STYLES.each do |style|
         define_method style do |val|
+          @__app__.remove_styles.delete(style)
           @__app__.style[style] = pattern(val)
         end
       end

--- a/shoes-core/lib/shoes/dsl/style.rb
+++ b/shoes-core/lib/shoes/dsl/style.rb
@@ -51,10 +51,12 @@ class Shoes
       end
 
       def nostroke
+        @__app__.remove_styles << :stroke
         @__app__.style[:stroke] = nil
       end
 
       def nofill
+        @__app__.remove_styles << :fill
         @__app__.style[:fill] = nil
       end
 

--- a/shoes-core/lib/shoes/internal_app.rb
+++ b/shoes-core/lib/shoes/internal_app.rb
@@ -52,8 +52,8 @@ class Shoes
       backend_const.initialize_backend
     end
 
-    attr_reader :gui, :top_slot, :app, :dimensions,
-                :mouse_motion, :owner, :element_styles, :resize_callbacks
+    attr_reader :gui, :top_slot, :app, :dimensions, :owner, :mouse_motion,
+                :element_styles, :remove_styles, :resize_callbacks
 
     attr_writer :width, :height
 
@@ -195,6 +195,7 @@ class Shoes
     def set_initial_attributes
       @style                = default_styles
       @element_styles       = {}
+      @remove_styles        = []
       @mouse_motion         = []
       @mouse_button         = 0
       @mouse_pos            = [0, 0]

--- a/shoes-core/spec/shoes/common/style_spec.rb
+++ b/shoes-core/spec/shoes/common/style_spec.rb
@@ -203,5 +203,13 @@ describe Shoes::Common::Style do
       user_facing_app.nofill
       expect(subject.style[:fill]).to be_nil
     end
+
+    it 'clears removal if fill is set again' do
+      user_facing_app.nofill
+      expect(StyleTester.new(app).style[:fill]).to be_nil
+
+      user_facing_app.fill(Shoes::COLORS[:red])
+      expect(StyleTester.new(app).style[:fill]).to eq(Shoes::COLORS[:red])
+    end
   end
 end

--- a/shoes-core/spec/shoes/common/style_spec.rb
+++ b/shoes-core/spec/shoes/common/style_spec.rb
@@ -44,7 +44,8 @@ describe Shoes::Common::Style do
   let(:initial_style) do
     {
       key: 'value', left: 15, click: nil, strokewidth: 1, fill: blue, margin: [0, 0, 0, 0],
-      margin_left: 0, margin_top: 0, margin_right: 0, margin_bottom: 0
+      margin_left: 0, margin_top: 0, margin_right: 0, margin_bottom: 0,
+      rotate: 0, stroke: Shoes::COLORS[:black]
     }
   end
 

--- a/shoes-core/spec/shoes/common/style_spec.rb
+++ b/shoes-core/spec/shoes/common/style_spec.rb
@@ -197,4 +197,11 @@ describe Shoes::Common::Style do
     its(:hover_blk) { should eq(hover_blk) }
     its(:leave_blk) { should eq(leave_blk) }
   end
+
+  describe 'removing styles' do
+    it 'drops defaults' do
+      user_facing_app.nofill
+      expect(subject.style[:fill]).to be_nil
+    end
+  end
 end

--- a/shoes-core/spec/shoes/link_spec.rb
+++ b/shoes-core/spec/shoes/link_spec.rb
@@ -3,17 +3,9 @@
 require 'spec_helper'
 
 describe Shoes::Link do
-  let(:gui) { double("gui").as_null_object }
-  let(:user_facing_app) { double("user facing app") }
-  let(:element_styles) { {} }
-
-  let(:app) do
-    double("app", gui: gui, style: {}, element_styles: element_styles,
-                  warn: true, add_mouse_hover_control: nil)
-  end
+  include_context "dsl app"
 
   let(:parent) { double("parent") }
-  let(:internal_app) { double("internal app", app: app, gui: gui, style: {}, element_styles: {}) }
   let(:texts) { ["text", "goes", "first"] }
   let(:text_block) { double 'text block', visible?: true, hidden?: false }
 
@@ -22,12 +14,6 @@ describe Shoes::Link do
     link.parent = parent
     link.text_block = text_block
     link
-  end
-
-  before do
-    allow(user_facing_app).to receive(:style) do |clazz, styles|
-      element_styles[clazz] = styles
-    end
   end
 
   it_behaves_like "object with hover"
@@ -69,7 +55,7 @@ describe Shoes::Link do
 
     context "with a block" do
       let(:callable) { double("callable") }
-      subject { Shoes::Link.new(internal_app, texts, {}, proc { callable.call }) }
+      subject { Shoes::Link.new(app, texts, {}, proc { callable.call }) }
 
       it "sets up for the click" do
         expect(callable).to receive(:call)
@@ -78,17 +64,17 @@ describe Shoes::Link do
     end
 
     context "with click option as text" do
-      subject { Shoes::Link.new(internal_app, texts, click: "/url") }
+      subject { Shoes::Link.new(app, texts, click: "/url") }
 
       it "should visit the url" do
-        expect(app).to receive(:visit).with("/url")
+        expect(app.app).to receive(:visit).with("/url")
         subject.blk.call
       end
     end
 
     context "with click option as Proc" do
       let(:callable) { double("callable", call: nil) }
-      subject { Shoes::Link.new(internal_app, texts, click: proc { callable.call }) }
+      subject { Shoes::Link.new(app, texts, click: proc { callable.call }) }
 
       it "calls the block" do
         expect(callable).to receive(:call)
@@ -99,7 +85,7 @@ describe Shoes::Link do
     context "calling click explicitly" do
       let(:original_block)    { double("original") }
       let(:replacement_block) { double("replacement") }
-      subject { Shoes::Link.new(internal_app, texts) { original_block.call } }
+      subject { Shoes::Link.new(app, texts) { original_block.call } }
 
       it "replaces original block" do
         expect(original_block).to_not receive(:call)

--- a/shoes-swt/spec/shoes/swt/shared_examples/swt_app_context.rb
+++ b/shoes-swt/spec/shoes/swt/shared_examples/swt_app_context.rb
@@ -27,7 +27,9 @@ shared_context "swt app" do
     swt_double
   end
 
-  let(:shoes_app) { double('shoes app', gui: swt_app, rotate: 0, style: Shoes::Common::Style::DEFAULT_STYLES.dup, element_styles: {}) }
+  let(:shoes_app) { double('shoes app', gui: swt_app, rotate: 0,
+                           style: Shoes::Common::Style::DEFAULT_STYLES.dup,
+                           element_styles: {}, remove_styles: []) }
 
   let(:parent) do
     double('parent', app: swt_app, add_child: true, real: true, hidden?: false,

--- a/shoes-swt/spec/shoes/swt/shared_examples/swt_app_context.rb
+++ b/shoes-swt/spec/shoes/swt/shared_examples/swt_app_context.rb
@@ -27,9 +27,11 @@ shared_context "swt app" do
     swt_double
   end
 
-  let(:shoes_app) { double('shoes app', gui: swt_app, rotate: 0,
-                           style: Shoes::Common::Style::DEFAULT_STYLES.dup,
-                           element_styles: {}, remove_styles: []) }
+  let(:shoes_app) do
+    double('shoes app', gui: swt_app, rotate: 0,
+                        style: Shoes::Common::Style::DEFAULT_STYLES.dup,
+                        element_styles: {}, remove_styles: [])
+  end
 
   let(:parent) do
     double('parent', app: swt_app, add_child: true, real: true, hidden?: false,

--- a/shoes-swt/spec/shoes/swt/text_block/text_segment_collection_spec.rb
+++ b/shoes-swt/spec/shoes/swt/text_block/text_segment_collection_spec.rb
@@ -68,9 +68,8 @@ describe Shoes::Swt::TextBlock::TextSegmentCollection do
         styles = [[0..1, [dsl_link]]]
         subject.style_segment_ranges(styles)
 
-        dsl_style = dsl_link.style
-        default_style = default_text_styles.merge(dsl_style)
-        expected_style = default_style.merge(underline: true, stroke: ::Shoes::COLORS[:black], fill: nil)
+        default_style = default_text_styles.merge(dsl_link.style)
+        expected_style = default_style.merge(underline: true, stroke: ::Shoes::COLORS[:blue], fill: nil)
         expect(first_segment).to have_received(:set_style).with(expected_style, 0..1)
       end
 


### PR DESCRIPTION
Fixes  #1537

Links weren't defaulting to blue, despite having the color specified in their defaults for `stroke`. The problem was the app-level styling. Order of application for styles was:

* Element class defaults
* App-instance styling
* etc.

But the app instance styles picked up values from the app defaults, and so any key in the element defaults that was also defined in app defaults got tromped!

This establishes the new, and I believe correct, order:

* App defaults (directly, rather than expecting instance to set it)
* Element class defaults
* App instance styles, but only that don't match app defaults!
* etc.

Oh, and the links show blue by default now :)

Deserves some deeper sample testing since this is pretty fundamental, but don't have time for it this evening... will do before merge.