### PR TITLE
Update to use pry-debugger-jruby instead of pry-nav

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :development do
   gem "listen"
 
   gem "pry"
-  gem "pry-nav"
+  gem "pry-debugger-jruby"
 
   gem "rake"
   gem "rspec", "~>3.6.0"


### PR DESCRIPTION
Gets rid of those pesky warnings and is [more actively maintained](https://github.com/nixme/pry-nav/pull/26#issuecomment-355912948)