### PR TITLE
also delegate builtin methods for widgets + URLs

### DIFF
--- a/shoes-core/lib/shoes/app.rb
+++ b/shoes-core/lib/shoes/app.rb
@@ -112,6 +112,7 @@ class Shoes
     # class definitions are evaluated top to bottom, want to have all of them
     # so define at bottom
     DELEGATE_METHODS = ((Shoes::App.public_instance_methods(false) +
+                         Shoes::BuiltinMethods.public_instance_methods +
                          Shoes::DSL.public_instance_methods)).freeze
 
     def self.subscribe_to_dsl_methods(klazz)

--- a/shoes-core/spec/shoes/app_spec.rb
+++ b/shoes-core/spec/shoes/app_spec.rb
@@ -418,9 +418,14 @@ describe Shoes::App do
         expect(subscribed_instance).to respond_to :para, :image
       end
 
-      it 'delegates does methods to the passed in app' do
+      it 'delegates those methods to the passed in app' do
         expect(subject).to receive(:para)
         subscribed_instance.para
+      end
+
+      it 'delegates builtin (dialog) methods' do
+        expect(subject).to receive(:alert)
+        subscribed_instance.alert "Wowzies"
       end
 
       SUBSCRIBED_CLASSES.each do |klazz|


### PR DESCRIPTION
Wowzies, that seems like a pretty big oversight on our part.
Glad we found it finally... maybe we should wip up some sample?

Minimal reproduction script:

```ruby
class AppComponent < Shoes
  url '/', :index
  def index
    alert("doesn't work")
  end
end
Shoes.app width: 800, height: 600, title: 'testing page'
```

side note: It's amazing after a lot of work on big applications and bigger features on benchee how productive one can feel with a system knowledge, not so a big system (but well designed and well tested if I might say so!) and get a critical bugfix in in <20 minutes.