### PR TITLE
Handle center_points for stars with centered styling.

### DIFF
--- a/samples/simple_star.rb
+++ b/samples/simple_star.rb
@@ -16,9 +16,23 @@ Shoes.app width: 600, height: 600 do
   radius = 3
   oval (center_point.x - radius), (center_point.y - radius), radius: radius
 
-  # do you want a star to follow you around?
-  @churyumov_gerasimenko = star 200, 100
+  # do you want a well centered star to follow you around?
+  @churyumov_gerasimenko = star 200, 100, center: true
   motion do |x, y|
     @churyumov_gerasimenko.center_point = Shoes::Point.new(x, y)
+  end
+
+  # an info block to show the coordinates of a click and the center_point
+  # of @churyumov_gerasimenko.
+  stroke(black)
+
+  stack do
+    @info = para ""
+    @info2 = para ""
+  end
+
+  click do |*args|
+    @info.text = args.inspect
+    @info2.text = @churyumov_gerasimenko.center_point.inspect
   end
 end

--- a/shoes-core/lib/shoes/star.rb
+++ b/shoes-core/lib/shoes/star.rb
@@ -65,14 +65,23 @@ class Shoes
     end
 
     def center_point
-      center_x = left + (element_width * 0.5).to_i
-      center_y = top + (element_height * 0.5).to_i
-      Point.new(center_x, center_y)
+      if style[:center]
+        Point.new(left, top)
+      else
+        center_x = left + (element_width * 0.5).to_i
+        center_y = top + (element_height * 0.5).to_i
+        Point.new(center_x, center_y)
+      end
     end
 
     def center_point=(point)
-      self.left = point.x - (width * 0.5).to_i
-      self.top = point.y - (height * 0.5).to_i
+      if style[:center]
+        self.left = point.x
+        self.top = point.y
+      else
+        self.left = point.x - (width * 0.5).to_i
+        self.top = point.y - (height * 0.5).to_i
+      end
     end
   end
 end

--- a/shoes-core/spec/shoes/star_spec.rb
+++ b/shoes-core/spec/shoes/star_spec.rb
@@ -212,10 +212,14 @@ describe Shoes::Star do
   end
 
   describe "center_point" do
-    subject { Shoes::Star.new(app, parent, 125, 175, 5, 50, 30, center: false, strokewidth: 0) }
-
     it "should return the center point of the star" do
-      expect(subject.center_point).to eq(Shoes::Point.new(175, 225))
+      a_star = Shoes::Star.new(app, parent, 125, 175, 5, 50, 30, center: false, strokewidth: 0)
+      expect(a_star.center_point).to eq(Shoes::Point.new(175, 225))
+    end
+
+    it "should correctly return the center point of a centered star" do
+      centered_star = Shoes::Star.new(app, parent, 100, 50, 5, 50, 30, center: true, strokewidth: 0)
+      expect(centered_star.center_point).to eq(Shoes::Point.new(100, 50))
     end
 
     it "should handle stars initialized with nil dimensions" do
@@ -225,11 +229,16 @@ describe Shoes::Star do
   end
 
   describe "center_point=" do
-    subject { Shoes::Star.new(app, parent, 125, 175, 5, 50, 30, center: false, strokewidth: 10) }
-
     it "should set a new center_point" do
-      subject.center_point = Shoes::Point.new(80, 90)
-      expect(subject.center_point).to eq(Shoes::Point.new(80, 90))
+      a_star = Shoes::Star.new(app, parent, 125, 175, 5, 50, 30, center: false, strokewidth: 10)
+      a_star.center_point = Shoes::Point.new(80, 90)
+      expect(a_star.center_point).to eq(Shoes::Point.new(80, 90))
+    end
+
+    it "should correctly handle a centered star" do
+      centered_star = Shoes::Star.new(app, parent, 125, 175, 5, 50, 30, center: true)
+      centered_star.center_point = Shoes::Point.new(80, 90)
+      expect(centered_star.center_point).to eq(Shoes::Point.new(80, 90))
     end
   end
 end


### PR DESCRIPTION
First I updated the center_point= method to match how it is done with Arcs.  Stars, however, also required changing the reader of the center_point based on styling.

I also updated the simple_star.rb example to include a star that was centered so we can see the correct behavior as well as updated the tests.

I'm not sure why reading the center point is different for stars and arcs with the styling, but it definitely appears to be!

fixes #1531.
