### PR TITLE
Allow logging from non-main threads

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,10 @@ Performance/UnfreezeString:
   Exclude:
     - 'tasks/changelog.rb'
 
+# We don't care about the performance of 10.times.map vs Array.new(10) {|i|...}
+Performance/TimesMap:
+  Enabled: false
+
 # We don't care if we do kind_of? or is_a?
 Style/ClassCheck:
   Enabled: false

--- a/shoes-core/lib/shoes/console.rb
+++ b/shoes-core/lib/shoes/console.rb
@@ -62,15 +62,14 @@ class Shoes
     end
 
     def drain_queued_messages
-      begin
-        10.times do
-          # Non-blocking = true, so will raise ThreadError once we're done
-          type, message = @queued_messages.pop(true)
-          add_message(type, message)
-        end
-      rescue ThreadError
-        # Queue's drained, carry on!
+      10.times do
+        # Non-blocking = true, so will raise ThreadError once we're done
+        type, message = @queued_messages.pop(true)
+        add_message(type, message)
       end
+    rescue ThreadError # rubocop:disable Lint/HandleExceptions
+      # Queue's drained, carry on!
+      # Disabled cop because this is Queue#pop's non-blocking API
     end
 
     def debug(message)

--- a/shoes-core/lib/shoes/console.rb
+++ b/shoes-core/lib/shoes/console.rb
@@ -5,6 +5,8 @@ class Shoes
     attr_reader :messages, :message_stacks
 
     def initialize
+      @queued_messages = Queue.new
+
       @messages = []
       @message_stacks = []
     end
@@ -48,27 +50,43 @@ class Shoes
             end
           end
         end
+
+        every 0.1 do
+          # Periodically update UI with new log lines
+          @console.drain_queued_messages
+        end
       end
 
-      @messages.each_with_index do |(type, message), index|
-        add_message_stack(type, message, index)
+      # Synchronously drain queue first showing console
+      drain_queued_messages
+    end
+
+    def drain_queued_messages
+      begin
+        loop do
+          # Non-blocking = true, so will raise ThreadError once we're done
+          type, message = @queued_messages.pop(true)
+          add_message(type, message)
+        end
+      rescue ThreadError
+        # Queue's drained, carry on!
       end
     end
 
     def debug(message)
-      add_message(:debug, message)
+      @queued_messages << [:debug, message]
     end
 
     def info(message)
-      add_message(:info, message)
+      @queued_messages << [:info, message]
     end
 
     def warn(message)
-      add_message(:warn, message)
+      @queued_messages << [:warn, message]
     end
 
     def error(message)
-      add_message(:error, message)
+      @queued_messages << [:error, message]
     end
 
     def add_message(type, message)

--- a/shoes-core/lib/shoes/console.rb
+++ b/shoes-core/lib/shoes/console.rb
@@ -63,7 +63,7 @@ class Shoes
 
     def drain_queued_messages
       begin
-        loop do
+        10.times do
           # Non-blocking = true, so will raise ThreadError once we're done
           type, message = @queued_messages.pop(true)
           add_message(type, message)

--- a/shoes-core/spec/shoes/console_spec.rb
+++ b/shoes-core/spec/shoes/console_spec.rb
@@ -87,13 +87,11 @@ describe Shoes::Console do
 
   describe "don't swamp with too many logs" do
     it "buffers a few at a time" do
-      20.times do |i|
-        console.error("whoa #{i}")
-      end
+      20.times { |i| console.error("whoa #{i}") }
 
       console.drain_queued_messages
 
-      expected = 10.times.map {|i| [:error, "whoa #{i}"]}
+      expected = 10.times.map { |i| [:error, "whoa #{i}"] }
       expect(console.messages).to eq(expected)
     end
   end

--- a/shoes-core/spec/shoes/console_spec.rb
+++ b/shoes-core/spec/shoes/console_spec.rb
@@ -85,6 +85,19 @@ describe Shoes::Console do
     end
   end
 
+  describe "don't swamp with too many logs" do
+    it "buffers a few at a time" do
+      20.times do |i|
+        console.error("whoa #{i}")
+      end
+
+      console.drain_queued_messages
+
+      expected = 10.times.map {|i| [:error, "whoa #{i}"]}
+      expect(console.messages).to eq(expected)
+    end
+  end
+
   describe '#add_message' do
     before(:each) do
       allow(console).to receive(:add_message_stack) { |type, message, index| {type: type, message: message, index: index} }

--- a/shoes-core/spec/shoes/console_spec.rb
+++ b/shoes-core/spec/shoes/console_spec.rb
@@ -50,33 +50,37 @@ describe Shoes::Console do
   end
 
   describe 'message type methods' do
-    before(:each) { allow(console).to receive(:add_message) { |type, message| {type: type, message: message} } }
+    let(:sample_message) { "sample message" }
 
     describe '#debug' do
       it 'must pass the given message as a debug message to #add_message' do
-        sample_message = 'test debugging message'
-        expect(console.debug(sample_message)).to eq(type: :debug, message: sample_message)
+        console.debug(sample_message)
+        console.drain_queued_messages
+        expect(console.messages).to eq([[:debug, sample_message]])
       end
     end
 
     describe '#info' do
       it 'must pass the given message as a info message to #add_message' do
-        sample_message = 'test info message'
-        expect(console.info(sample_message)).to eq(type: :info, message: sample_message)
+        console.info(sample_message)
+        console.drain_queued_messages
+        expect(console.messages).to eq([[:info, sample_message]])
       end
     end
 
     describe '#warn' do
       it 'must pass the given message as a warn message to #add_message' do
-        sample_message = 'test warning message'
-        expect(console.warn(sample_message)).to eq(type: :warn, message: sample_message)
+        console.warn(sample_message)
+        console.drain_queued_messages
+        expect(console.messages).to eq([[:warn, sample_message]])
       end
     end
 
     describe '#error' do
       it 'must pass the given message as a error message to #add_message' do
-        sample_message = 'test error message'
-        expect(console.error(sample_message)).to eq(type: :error, message: sample_message)
+        console.error(sample_message)
+        console.drain_queued_messages
+        expect(console.messages).to eq([[:error, sample_message]])
       end
     end
   end


### PR DESCRIPTION
Fixes #1544

The console is present in the logger collection, and if the UI has been opened was trying to directly add the `stack`s and `para`s when we appended a log line. This unfortunately hits SWTs restrictions about touching UI element from background threads.

The fix is simple enough--we queue up the messages in the console, then periodically drain them. Initial open drains any messages that have stacked up before we've shown so we get the display immediately.

This also gave a nice point to buffer the application of messages to the screen. Today if you logged say 1000 messages and then open the console, it'd hang. Now we add them 10 at a time so you get an initial screen, then a growing list instead! ⛱ 