### PR TITLE
Move RenamedDelegate to proper locations and document it

### DIFF
--- a/shoes-core/lib/shoes/renamed_delegate.rb
+++ b/shoes-core/lib/shoes/renamed_delegate.rb
@@ -1,16 +1,26 @@
 # frozen_string_literal: true
 
-module RenamedDelegate
-  include Forwardable
+class Shoes
+  module RenamedDelegate
+    include Forwardable
 
-  def renamed_delegate_to(getter, methods, renamings)
-    methods.each do |method|
-      method_name = method.to_s
-      renamed_method_name = renamings.inject(method_name) do |name, (word, sub)|
-        name.gsub word, sub
-      end
-      if renamed_method_name != method_name
-        def_delegator getter, method_name, renamed_method_name
+    # Module for delegating method calls while transforming the method names.
+    # Used with classes like `Shoes::Dimensions` to delegate X and Y
+    # coordinates to the underlying `Shoes::Dimension` classes with more
+    # appropriate names.
+    #
+    # @param [Symbol] getter accessor called to find target for delegation
+    # @param [Array<Symbol>] methods target method names to be renamed
+    # @param [Hash<String, String>] renamings string keys from the hash are replaced in delegated methods with hash values
+    def renamed_delegate_to(getter, methods, renamings)
+      methods.each do |method|
+        method_name = method.to_s
+        renamed_method_name = renamings.inject(method_name) do |name, (word, sub)|
+          name.gsub word, sub
+        end
+        if renamed_method_name != method_name
+          def_delegator getter, method_name, renamed_method_name
+        end
       end
     end
   end

--- a/shoes-core/spec/shoes/renamed_delegate_spec.rb
+++ b/shoes-core/spec/shoes/renamed_delegate_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe RenamedDelegate do
+describe Shoes::RenamedDelegate do
   class ToDelegate
     def method_key
     end
@@ -24,7 +24,7 @@ describe RenamedDelegate do
   end
 
   class TestClass
-    extend RenamedDelegate
+    extend Shoes::RenamedDelegate
 
     attr_reader :delegate
 


### PR DESCRIPTION
As part of the big #620 documentation push, noticed this class was declared outside the `Shoes` module so moving it to its own place. Wrote brief description for it.