### PR TITLE
More docs!

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,9 +1,13 @@
 --no-private
 ./shoes-core/lib/**/*.rb
+./shoes-package/lib/**/*.rb
+./shoes-swt/lib/**/*.rb
 -
 LICENSE
 README.md
 shoes-core/README.md
+shoes-package/README.md
+shoes-swt/README.md
 LICENSE
 CONTRIBUTING.md
 CODE_OF_CONDUCT.MD

--- a/shoes-core/lib/shoes/dimensions.rb
+++ b/shoes-core/lib/shoes/dimensions.rb
@@ -12,10 +12,10 @@ class Shoes
   # fully positioned/doesn't flow anymore when set
   #
   # *absolute_** (+absolute_left+, +absolute_top+, +absolute_right+,
-  # +absolute_bottom+): The absolute position of an element in the app, set
-  # by positioning code (in +slot.rb+). Might not be the beginning of the
-  # element as it also takes margins into account, so it could be the beginning
-  # of the margin. Is also used in the positioning code.
+  # +absolute_bottom+): The absolute position an element begins positioning
+  # from in the app (in +slot.rb+). Margins are not included in absolute
+  # position values--that's the main difference between +absolute+ and
+  # +element+ values.
   #
   # *element_** (+element_left+, +element_top+, +element_right+,
   # +element_bottom+): Derived from +absolute_+* but shows the real position

--- a/shoes-package/README.md
+++ b/shoes-package/README.md
@@ -1,0 +1,5 @@
+# shoes-package
+
+This is the default packaging library to go along with `shoes-swt`. It provides
+a warbler-based implementation of packaging a Shoes app into an easily sharable
+artifact.

--- a/shoes-swt/lib/shoes/swt/animation.rb
+++ b/shoes-swt/lib/shoes/swt/animation.rb
@@ -9,7 +9,6 @@ class Shoes
       #
       # @param [Shoes::Animation] dsl The Shoes DSL Animation this represents
       # @param [Shoes::Swt::App] app The Swt representation of the current app
-      # @param [Proc] blk The block of code to execute for each animation frame
       def initialize(dsl, app)
         @dsl = dsl
         @app = app

--- a/shoes-swt/lib/shoes/swt/button.rb
+++ b/shoes-swt/lib/shoes/swt/button.rb
@@ -6,8 +6,7 @@ class Shoes
       # Create a button
       #
       # @param [Shoes::Button] dsl The Shoes DSL button this represents
-      # @param [::Swt::Widgets::Composite] parent The parent element of this button
-      # @param [Proc] blk The block of code to call when this button is activated
+      # @param [Shoes::Swt::App] app The app element of this button
       def initialize(dsl, app)
         super(dsl, app, ::Swt::SWT::PUSH) do |button|
           button.set_text @dsl.text

--- a/shoes-swt/lib/shoes/swt/check.rb
+++ b/shoes-swt/lib/shoes/swt/check.rb
@@ -6,8 +6,7 @@ class Shoes
       # Create a check box
       #
       # @param [Shoes::Button] dsl The Shoes DSL check box this represents
-      # @param [::Swt::Widgets::Composite] parent The parent element of this button
-      # @param [Proc] blk The block of code to call when this button is activated
+      # @param [Shoes::Swt::App] parent The parent element of this button
       def initialize(dsl, parent)
         super(dsl, parent, ::Swt::SWT::CHECK)
       end

--- a/shoes-swt/lib/shoes/swt/color.rb
+++ b/shoes-swt/lib/shoes/swt/color.rb
@@ -27,14 +27,14 @@ class Shoes
       end
 
       # @param [Swt::Graphics::GC] gc the graphics context on which to apply fill
-      # @dsl unused by this method, passed to satisfy the Pattern interface
+      # _dsl unused by this method, passed to satisfy the Pattern interface
       def apply_as_fill(gc, _dsl = nil)
         gc.set_background real
         gc.set_alpha alpha
       end
 
       # @param [Swt::Graphics::GC] gc the graphics context on which to apply stroke
-      # @dsl unused by this method, passed to satisfy the Pattern interface
+      # _dsl unused by this method, passed to satisfy the Pattern interface
       def apply_as_stroke(gc, _dsl = nil)
         gc.set_foreground real
         gc.set_alpha alpha

--- a/shoes-swt/lib/shoes/swt/oval.rb
+++ b/shoes-swt/lib/shoes/swt/oval.rb
@@ -16,7 +16,6 @@ class Shoes
 
       # @param [Shoes::Oval] dsl the dsl object to provide gui for
       # @param [Shoes::Swt::App] app the app
-      # @param [Hash] opts options
       def initialize(dsl, app)
         @dsl = dsl
         @app = app

--- a/shoes-swt/lib/shoes/swt/radio.rb
+++ b/shoes-swt/lib/shoes/swt/radio.rb
@@ -11,8 +11,7 @@ class Shoes
       # Create a radio button
       #
       # @param [Shoes::Radio] dsl The Shoes DSL radio this represents
-      # @param [::Swt::Widgets::Composite] app The app element of this button
-      # @param [Proc] blk The block of code to call when this button is activated
+      # @param [Shoes::Swt::App] app The app element of this button
       def initialize(dsl, app)
         super(dsl, app, ::Swt::SWT::RADIO)
         self.group = dsl.group

--- a/shoes-swt/lib/shoes/swt/shape.rb
+++ b/shoes-swt/lib/shoes/swt/shape.rb
@@ -13,9 +13,7 @@ class Shoes
       # Creates a new Shoes::Swt::Shape
       #
       # @param [Shoes::Shape] dsl The dsl object to provide gui for
-      # @param [Hash] opts Initialization options
-      #   If this shape is part of another shape (i.e. it is not responsible
-      #   for drawing itself), `opts` should be omitted
+      # @param [Shoes::Swt::App] app The app element of this shape
       def initialize(dsl, app)
         @dsl = dsl
         @app = app


### PR DESCRIPTION
More for #620 

This started generating docs for `shoes-swt` and `shoes-package` which we were leaving out. Deals with warnings as a result of those additions.

Also documents the `Shoes::Dimensions` and `Shoes::Dimension` class. Chose not to plumb in every single individual method since the pre-amble description really captures it all more clearly than the method-by-method callouts would without huge amounts of duplication.