### PR TITLE
Resolve Ruby warnings

### DIFF
--- a/shoes-core/lib/shoes/configuration.rb
+++ b/shoes-core/lib/shoes/configuration.rb
@@ -36,9 +36,9 @@ class Shoes
       # @example
       #   Shoes::Configuration.backend = :swt
       def backend=(name)
-        return if @backend_name == name
+        return if defined?(@backend_name) && @backend_name == name
 
-        unless @backend.nil?
+        if defined?(@backend) && !@backend.nil?
           raise "Can't switch backend to Shoes::#{name.capitalize}, Shoes::#{backend_name.capitalize} backend already loaded."
         end
         @backend_name ||= name


### PR DESCRIPTION
Fixes #456 

Resolves the following warnings as output in the [CI build](https://travis-ci.org/shoes/shoes4/jobs/387036460#L1001-L1002).
```
/home/travis/build/shoes/shoes4/shoes-core/lib/shoes/configuration.rb:40: warning: instance variable @backend_name not initialized
/home/travis/build/shoes/shoes4/shoes-core/lib/shoes/configuration.rb:42: warning: instance variable @backend not initialized
```